### PR TITLE
Add favourite button to detail body

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2252,10 +2252,10 @@ function makePosts(){
               ${p.dates.map(d=> `<span class="date">${d}</span>`).join('')}
             </div>
             <div class="desc">${p.desc}</div>
+            <button class="pill" data-act="fav">☆ Favourite</button>
           </div>
           <div class="tools">
             <button class="pill" data-act="center">Center on Map</button>
-            <button class="pill" data-act="fav">☆ Favourite</button>
             <button class="close" data-act="close">Close</button>
           </div>
         </div>`;


### PR DESCRIPTION
## Summary
- Add a "☆ Favourite" button inside the detail view body so users can mark events as favourites directly from the main content area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2753df4b88331b4eef2748fddb8c3