### PR TITLE
Use FunMap logo in header

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18d.html
+++ b/ChatGPT-to-Codex-2025-08-18d.html
@@ -1405,7 +1405,7 @@ footer .foot-row .foot-item img {
 <body class="mode-map">
   <header class="header" role="banner">
     <div class="logo" aria-label="Site logo">
-      <img src="assets/logo.svg" alt="FunMap.com logo" />
+      <img src="assets/funmap-logo-2011-09-30g.png" alt="FunMap.com logo" />
     </div>
     <div class="top-actions">
       <nav aria-label="Primary">


### PR DESCRIPTION
## Summary
- display the provided FunMap PNG logo in the header instead of the old SVG

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33bc887248331aebf3650175bbfe4