### PR TITLE
Add sticky headers to admin and member modals

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -199,6 +199,19 @@ body{
   display:flex;
   gap:10px;
 }
+.modal-header{
+  position:sticky;
+  top:0;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  background:inherit;
+  padding-bottom:10px;
+  z-index:1;
+}
+.modal-header .modal-actions{
+  margin-top:0;
+}
 .palette{
   display:flex;
   gap:10px;
@@ -1633,8 +1646,14 @@ footer .foot-row .foot-item img {
 
   <div id="memberModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="modal-content">
-      <h2>Create Post</h2>
       <form id="memberForm">
+        <div class="modal-header">
+          <h2>Create Post</h2>
+          <div class="modal-actions">
+            <button type="submit">Save</button>
+            <button type="button" class="close-modal">Close</button>
+          </div>
+        </div>
         <div class="modal-field">
           <label for="mTitle">Title</label>
           <input type="text" id="mTitle" required />
@@ -1651,18 +1670,20 @@ footer .foot-row .foot-item img {
           <label for="mLocation">Location</label>
           <input type="text" id="mLocation" />
         </div>
-        <div class="modal-actions">
-          <button type="submit">Save</button>
-          <button type="button" class="close-modal">Close</button>
-        </div>
       </form>
     </div>
   </div>
 
   <div id="adminModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="modal-content">
-      <h2>Admin Settings</h2>
       <form id="adminForm">
+        <div class="modal-header">
+          <h2>Admin Settings</h2>
+          <div class="modal-actions">
+            <button type="submit">Save</button>
+            <button type="button" class="close-modal">Close</button>
+          </div>
+        </div>
         <h3>Theme Customization</h3>
         <div id="styleControls"></div>
         <div class="modal-field">
@@ -1681,10 +1702,6 @@ footer .foot-row .foot-item img {
           <div class="field-item" draggable="true" data-type="location">Location</div>
         </div>
         <div id="formBuilder" class="builder-zone" aria-label="Form fields drop zone"></div>
-        <div class="modal-actions">
-          <button type="submit">Save</button>
-          <button type="button" class="close-modal">Close</button>
-        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- keep Save and Close buttons visible by moving them into a sticky `modal-header`
- restructure admin and member forms so actions are always accessible at the top

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a349af19b88331b9e4fd5ae4dc437a