### PR TITLE
Remove panel background styling

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -298,7 +298,6 @@ body{
   padding: 10px;
   box-shadow: var(--shadow);
   border: 1px solid rgba(0,0,0,.1);
-  background: var(--list-background);
   overflow: auto;
   flex: 1;
   min-height: 0;
@@ -1102,12 +1101,11 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   z-index: 0;
 }
 
-.results-col .panel .res-list, .map-wrap{
+.map-wrap{
   background: var(--main-background);
 }
 
 .results-col .panel .res-list{
-  background: var(--list-background);
   border-radius: inherit;
 }
 
@@ -1524,11 +1522,13 @@ footer .foot-row .foot-item img {
     border: 1px solid #ffcc80;
     color: #333;
   }
-  .panel,
   .card,
   .detail-inline,
   .map-wrap {
     background: var(--list-background);
+    border-color: #ffcc80;
+  }
+  .panel {
     border-color: #ffcc80;
   }
 </style>


### PR DESCRIPTION
## Summary
- Remove default background from panel styles to prevent background showing behind panels
- Adjust result list and theme styles to keep borders without background fill

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a366d8b4288331a4c3b2ea1e57cbe6