### PR TITLE
Fix admin modal blocked by mapbox controls

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -591,6 +591,7 @@ body{
 
 .map-wrap{
   background: var(--main-background);
+  position: relative;
 }
 
 #map{


### PR DESCRIPTION
## Summary
- Scope absolute-positioned Mapbox map to its container so it no longer covers the header.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3747d493883318f8572005ef6670f