### PR TITLE
Improve modal design and remove opacity sliders

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -136,27 +136,27 @@ body{
 
 .modal{
   position:fixed;
-  top:0;
-  left:0;
-  width:100%;
-  height:100%;
-  background:transparent;
+  inset:0;
   display:none;
+  align-items:center;
+  justify-content:center;
+  background:rgba(0,0,0,0.5);
   z-index:2000;
-  pointer-events:none;
+  padding:20px;
 }
-.modal.show{display:block;}
+.modal.show{display:flex;}
 .modal-content{
-  position:absolute;
   background:#fff;
   padding:0 20px 20px;
   border-radius:8px;
-  width:90%;
+  width:100%;
   max-width:600px;
-  max-height:90%;
+  max-height:100%;
   overflow:auto;
-  resize:both;
   pointer-events:auto;
+}
+@media (max-width:600px){
+  .modal-content{max-width:100%;}
 }
 .admin-fieldset{margin:10px 0;border:1px solid #ccc;border-radius:8px;padding:10px;}
 #adminModal #styleControls{display:flex;flex-wrap:wrap;gap:10px;align-items:flex-start;}
@@ -169,32 +169,25 @@ body{
   background:linear-gradient(180deg,#fff,#f7f7f7);
   border:2px solid #ffecb3;
   box-shadow:0 4px 16px rgba(0,0,0,0.2);
-  width:90%;
   max-width:1200px;
   max-height:90%;
 }
 #memberModal .modal-content{
-  width:90%;
   max-width:1200px;
   max-height:90%;
 }
 @media (max-width:600px){
   #adminModal .modal-content,
   #memberModal .modal-content{
-    width:95%;
-    max-width:95%;
+    max-width:100%;
     max-height:95%;
   }
 }
 #adminModal legend{font-weight:600;padding:0 6px;}
 #adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
 #adminModal .control-row label{min-width:40px;font-size:12px;}
-#adminModal .color-group{width:120px;display:flex;flex-direction:column;position:relative;}
+#adminModal .color-group{width:120px;display:flex;flex-direction:column;}
 #adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;}
-#adminModal .opacity-pop{display:none;position:absolute;left:0;right:0;top:100%;margin-top:4px;padding:4px;border:1px solid #ccc;border-radius:0 0 4px 4px;background:#fff;align-items:center;gap:6px;z-index:10;}
-#adminModal .color-group.show-opacity .opacity-pop{display:flex;}
-#adminModal .opacity-pop input[type=range]{flex:1;}
-#adminModal .opacity-pop span{width:30px;text-align:right;font-size:12px;}
 #adminModal .tab-bar{display:flex;gap:6px;}
 #adminModal .tab-bar button{flex:1;padding:6px 10px;border:1px solid #ccc;border-radius:6px;background:#eee;cursor:pointer;}
 #adminModal .tab-bar button[aria-selected="true"]{background:#ddd;font-weight:600;}
@@ -1541,7 +1534,6 @@ footer .foot-row .foot-item img {
 </style>
 
 <style>
-  #filterModal .modal-content,
   #filterModal .filters-col,
   #filterModal .left-tools,
   #filterModal .sq,
@@ -1562,7 +1554,7 @@ footer .foot-row .foot-item img {
     display: revert;
   }
   #filterModal .modal-content {
-    position: absolute;
+    max-width:600px;
   }
 </style>
 
@@ -2669,14 +2661,6 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
   const filterModal = document.getElementById('filterModal');
 
   function openModal(m){
-    const content = m.querySelector('.modal-content');
-    if(content){
-      content.style.width = '';
-      content.style.height = '';
-      content.style.left = '50%';
-      content.style.top = '50%';
-      content.style.transform = 'translate(-50%, -50%)';
-    }
     m.classList.add('show');
     m.removeAttribute('aria-hidden');
   }
@@ -2687,43 +2671,6 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
   filterBtn && filterBtn.addEventListener('click', ()=> openModal(filterModal));
   document.querySelectorAll('.modal .close-modal').forEach(btn=>{
     btn.addEventListener('click', ()=> closeModal(btn.closest('.modal')));
-  });
-
-  document.querySelectorAll('.modal').forEach(modal=>{
-    const content = modal.querySelector('.modal-content');
-    const header = modal.querySelector('.modal-header');
-    if(!content || !header) return;
-    let dragging = false;
-    let offsetX = 0, offsetY = 0;
-      header.addEventListener('mousedown', e=>{
-        dragging = true;
-        const rect = content.getBoundingClientRect();
-        offsetX = e.clientX - rect.left;
-        offsetY = e.clientY - rect.top;
-        content.style.left = `${rect.left}px`;
-        content.style.top = `${rect.top}px`;
-        content.style.transform = 'none';
-        document.addEventListener('mousemove', onMouseMove);
-        document.addEventListener('mouseup', onMouseUp);
-        e.preventDefault();
-      });
-      function onMouseMove(e){
-        if(!dragging) return;
-        let newLeft = e.clientX - offsetX;
-        let newTop = e.clientY - offsetY;
-        const rect = content.getBoundingClientRect();
-        const maxLeft = window.innerWidth - rect.width;
-        const maxTop = window.innerHeight - header.offsetHeight;
-        newLeft = Math.min(Math.max(newLeft, 0), Math.max(maxLeft, 0));
-        newTop = Math.min(Math.max(newTop, 0), Math.max(maxTop, 0));
-        content.style.left = `${newLeft}px`;
-        content.style.top = `${newTop}px`;
-      }
-      function onMouseUp(){
-        dragging = false;
-        document.removeEventListener('mousemove', onMouseMove);
-        document.removeEventListener('mouseup', onMouseUp);
-      }
   });
 
   const adminTabs = document.querySelectorAll('#adminModal .tab-bar button');
@@ -2754,17 +2701,12 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
     return '#' + [r,g,b].map(x=>x.toString(16).padStart(2,'0')).join('');
   }
 
-  function hexToRgb(hex){
-    const int = parseInt(hex.slice(1),16);
-    return [(int>>16)&255,(int>>8)&255,int&255];
-  }
 
   function syncAdminControls(){
     colorAreas.forEach(area=>{
       ['bg','text','btn'].forEach(type=>{
         const cInput = document.getElementById(`${area.key}-${type}-c`);
-        const oInput = document.getElementById(`${area.key}-${type}-o`);
-        if(!(cInput && oInput)) return;
+        if(!cInput) return;
         const selectors = area.selectors[type] || [];
         let col = null;
         selectors.some(sel=>{
@@ -2776,16 +2718,12 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
           return col;
         });
         if(!col) return;
-        const match = col.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
+        const match = col.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)\)/);
         if(!match) return;
         const r = parseInt(match[1],10);
         const g = parseInt(match[2],10);
         const bVal = parseInt(match[3],10);
-        const a = match[4] !== undefined ? parseFloat(match[4]) : 1;
         cInput.value = rgbToHex(r,g,bVal);
-        oInput.value = a;
-        const span = oInput.nextElementSibling;
-        if(span) span.textContent = a;
       });
     });
   }
@@ -2806,10 +2744,6 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
             <label>${type} color</label>
             <div class="color-group">
               <input id="${area.key}-${type}-c" type="color" />
-              <div class="opacity-pop">
-                <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
-                <span class="opacity-val">1</span>
-              </div>
             </div>
           `;
           fs.appendChild(row);
@@ -2818,31 +2752,12 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
     });
   }
 
-  function initColorGroupEvents(){
-    document.querySelectorAll('#adminModal .color-group').forEach(g=>{
-      const colorInput = g.querySelector('input[type=color]');
-      const range = g.querySelector('.opacity-pop input[type=range]');
-      const val = g.querySelector('.opacity-pop span');
-      if(range && val){
-        function update(){ val.textContent = range.value; }
-        range.addEventListener('input', update);
-        update();
-      }
-      if(colorInput){
-        colorInput.addEventListener('focus', ()=> g.classList.add('show-opacity'));
-        colorInput.addEventListener('blur', ()=> g.classList.remove('show-opacity'));
-      }
-    });
-  }
-
   function applyAdmin(){
     colorAreas.forEach(area=>{
       ['bg','text','btn'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
-        const o = document.getElementById(`${area.key}-${type}-o`);
-        if(!(c && o)) return;
-        const [r,g,b] = hexToRgb(c.value);
-        const color = `rgba(${r},${g},${b},${o.value})`;
+        if(!c) return;
+        const color = c.value;
         const targets = area.selectors[type] || [];
         targets.forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
@@ -2860,9 +2775,8 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
     colorAreas.forEach(area=>{
       ['bg','text','btn'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
-        const o = document.getElementById(`${area.key}-${type}-o`);
-        if(c && o){
-          data[`${area.key}-${type}`] = {color:c.value, opacity:o.value};
+        if(c){
+          data[`${area.key}-${type}`] = {color:c.value};
         }
       });
     });
@@ -2876,16 +2790,16 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
   function initBuiltInPresets(){
     const dark = {};
     colorAreas.forEach(area=>{
-      dark[`${area.key}-bg`] = {color:'#222222', opacity:'1'};
-      dark[`${area.key}-text`] = {color:'#eeeeee', opacity:'1'};
-      dark[`${area.key}-btn`] = {color:'#444444', opacity:'1'};
+      dark[`${area.key}-bg`] = {color:'#222222'};
+      dark[`${area.key}-text`] = {color:'#eeeeee'};
+      dark[`${area.key}-btn`] = {color:'#444444'};
     });
     builtInPresets.push({name:'Dark', data: dark});
     const ocean = {};
     colorAreas.forEach(area=>{
-      ocean[`${area.key}-bg`] = {color:'#e0f7fa', opacity:'1'};
-      ocean[`${area.key}-text`] = {color:'#006064', opacity:'1'};
-      ocean[`${area.key}-btn`] = {color:'#00838f', opacity:'1'};
+      ocean[`${area.key}-bg`] = {color:'#e0f7fa'};
+      ocean[`${area.key}-text`] = {color:'#006064'};
+      ocean[`${area.key}-btn`] = {color:'#00838f'};
     });
     builtInPresets.push({name:'Ocean', data: ocean});
   }
@@ -2912,12 +2826,8 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
       Object.entries(data).forEach(([key,val])=>{
         const [areaKey,type] = key.split('-');
         const c = document.getElementById(`${areaKey}-${type}-c`);
-        const o = document.getElementById(`${areaKey}-${type}-o`);
-        if(c && o){
+        if(c){
           c.value = val.color;
-          o.value = val.opacity;
-          const span = o.nextElementSibling;
-          if(span) span.textContent = val.opacity;
         }
       });
       applyAdmin();
@@ -2931,7 +2841,6 @@ function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https:
   }
 
   buildStyleControls();
-  initColorGroupEvents();
   syncAdminControls();
   defaultTheme = collectThemeValues();
   initBuiltInPresets();


### PR DESCRIPTION
## Summary
- Make all modals responsive and centered with a dark backdrop
- Remove opacity sliders and related logic from the admin settings modal
- Simplify preset handling and modal script without drag positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a381ba40448331bbec1b2384f9dbc5