### PR TITLE
Align admin color controls and clear filter modal background

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -20,7 +20,6 @@
   */
 
   --main-background: rgba(255,255,255,0.8);
-  --filter-background: linear-gradient(180deg,#ffffff,#f7f7f7);
   --list-background: rgba(255,255,255,0.8);
 }
 
@@ -178,11 +177,12 @@ body{
   max-width:1200px;
   max-height:90%;
 }
-#filterModal .modal-content{
-  width:90%;
-  max-width:340px;
-  max-height:90%;
-}
+  #filterModal .modal-content{
+    background:none;
+    width:90%;
+    max-width:340px;
+    max-height:90%;
+  }
 @media (max-width:600px){
   #adminModal .modal-content,
   #memberModal .modal-content,
@@ -195,7 +195,7 @@ body{
 #adminModal legend{font-weight:600;padding:0 6px;}
 #adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
 #adminModal .control-row label{min-width:40px;font-size:12px;}
-#adminModal .color-group{width:120px;display:flex;flex-direction:column;position:relative;}
+  #adminModal .color-group{width:120px;display:flex;align-items:center;position:relative;}
 #adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;}
 #adminModal .tab-bar{display:flex;gap:6px;}
 #adminModal .tab-bar button{flex:1;padding:6px 10px;border:1px solid #ccc;border-radius:6px;background:#eee;cursor:pointer;}
@@ -1496,7 +1496,6 @@ footer .foot-row .foot-item img {
     --panel-grad: linear-gradient(180deg, #ffecb3, #ffe0b2);
     --bg-grad: linear-gradient(0deg, #fff8e1, #ffe0b2);
     --main-background: rgba(255, 255, 255, 0.8);
-    --filter-background: linear-gradient(180deg, #fff3e0, #ffe0b2);
     --list-background: rgba(255, 248, 225, 0.8);
   }
   body {


### PR DESCRIPTION
## Summary
- Align admin modal `color-group` containers for consistent color control layout
- Remove background styles from the filters modal for a transparent appearance
- Drop unused filter background variable

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a387e361808331b68705b24cc9ac89