### PR TITLE
Only prompt to save admin settings when changes exist

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2687,7 +2687,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   const filterModal = document.getElementById('filterModal');
 
   memberBtn && memberBtn.addEventListener('click', ()=> toggleModal(memberModal));
-  adminBtn && adminBtn.addEventListener('click', ()=>{ syncAdminControls(); toggleModal(adminModal); });
+  adminBtn && adminBtn.addEventListener('click', ()=>{
+    syncAdminControls();
+    adminModal.dataset.originalValues = JSON.stringify(collectThemeValues());
+    adminModal.removeAttribute('data-needs-save');
+    toggleModal(adminModal);
+  });
   filterBtn && filterBtn.addEventListener('click', ()=> toggleModal(filterModal));
   document.querySelectorAll('.modal .close-modal').forEach(btn=>{
     btn.addEventListener('click', ()=> requestCloseModal(btn.closest('.modal')));
@@ -2904,11 +2909,20 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   loadPresets();
   const adminForm = document.getElementById('adminForm');
   if(adminForm){
-    adminForm.addEventListener('input', e=>{ applyAdmin(); adminModal.setAttribute('data-needs-save','true'); });
-    adminForm.addEventListener('change', e=>{ applyAdmin(); adminModal.setAttribute('data-needs-save','true'); });
+    const updateSaveState = ()=>{
+      const current = JSON.stringify(collectThemeValues());
+      if(current !== adminModal.dataset.originalValues){
+        adminModal.setAttribute('data-needs-save','true');
+      } else {
+        adminModal.removeAttribute('data-needs-save');
+      }
+    };
+    adminForm.addEventListener('input', e=>{ applyAdmin(); updateSaveState(); });
+    adminForm.addEventListener('change', e=>{ applyAdmin(); updateSaveState(); });
     adminForm.addEventListener('submit', e=>{
       e.preventDefault();
       applyAdmin();
+      adminModal.dataset.originalValues = JSON.stringify(collectThemeValues());
       adminModal.removeAttribute('data-needs-save');
       closeModal(adminModal);
     });


### PR DESCRIPTION
## Summary
- Store admin modal's initial values and reset save-needed flag when opened
- Track form changes against initial values to only prompt when unsaved changes exist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a473656b2c8331b9bdef237c365278