### PR TITLE
Align filter color inputs

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -204,7 +204,7 @@ body{
 #adminModal legend{font-weight:600;padding:0 6px;}
 #adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
 #adminModal .control-row label{min-width:40px;font-size:12px;}
-  #adminModal .color-group{width:120px;display:flex;align-items:center;position:relative;}
+  #adminModal .color-group{width:120px;display:flex;align-items:center;position:relative;margin-left:auto;}
 #adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;}
 #adminModal .tab-bar{display:flex;gap:6px;}
 #adminModal .tab-bar button{flex:1;padding:6px 10px;border:1px solid #ccc;border-radius:6px;background:#eee;cursor:pointer;}


### PR DESCRIPTION
## Summary
- ensure filter panel color picker inputs align by adding right-margin auto to color-group

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4926684d88331887cfd53b3d2ad9d