### PR TITLE
Allow filter modal resizing to match other modals

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -189,7 +189,7 @@ body{
     border:2px solid #ffecb3;
     box-shadow:0 4px 16px rgba(0,0,0,0.2);
     width:90%;
-    max-width:340px;
+    max-width:1200px;
     max-height:90%;
   }
   @media (max-width:600px){


### PR DESCRIPTION
## Summary
- permit the filter modal to resize up to 1200px, aligning it with admin and member modals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a493ad566c8331a3e44fcfa93e5e0f