### PR TITLE
Add opacity sliders for background color pickers

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -204,8 +204,9 @@ body{
 #adminModal legend{font-weight:600;padding:0 6px;}
 #adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
 #adminModal .control-row label{min-width:40px;font-size:12px;}
-  #adminModal .color-group{width:120px;display:flex;align-items:center;position:relative;margin-left:auto;}
+  #adminModal .color-group{width:120px;display:flex;flex-direction:column;align-items:stretch;position:relative;margin-left:auto;}
 #adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;}
+#adminModal .color-group input[type=range]{width:100%;}
 #adminModal .tab-bar{display:flex;gap:6px;}
 #adminModal .tab-bar button{flex:1;padding:6px 10px;border:1px solid #ccc;border-radius:6px;background:#eee;cursor:pointer;}
 #adminModal .tab-bar button[aria-selected="true"]{background:#ddd;font-weight:600;}
@@ -2744,11 +2745,19 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     return '#' + [r,g,b].map(x=>x.toString(16).padStart(2,'0')).join('');
   }
 
+  function hexToRgba(hex, alpha){
+    const r = parseInt(hex.slice(1,3),16);
+    const g = parseInt(hex.slice(3,5),16);
+    const b = parseInt(hex.slice(5,7),16);
+    return `rgba(${r},${g},${b},${alpha})`;
+  }
+
 
   function syncAdminControls(){
     colorAreas.forEach(area=>{
       ['bg','text','btn'].forEach(type=>{
         const cInput = document.getElementById(`${area.key}-${type}-c`);
+        const oInput = document.getElementById(`${area.key}-${type}-o`);
         if(!cInput) return;
         const selectors = area.selectors[type] || [];
         let col = null;
@@ -2766,7 +2775,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const r = parseInt(match[1],10);
         const g = parseInt(match[2],10);
         const bVal = parseInt(match[3],10);
+        const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
         cInput.value = rgbToHex(r,g,bVal);
+        if(type==='bg' && oInput) oInput.value = alpha;
       });
     });
   }
@@ -2783,12 +2794,22 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         ['bg','text','btn'].forEach(type=>{
           const row = document.createElement('div');
           row.className = 'control-row';
-          row.innerHTML = `
-            <label>${type} color</label>
-            <div class="color-group">
-              <input id="${area.key}-${type}-c" type="color" />
-            </div>
-          `;
+          if(type === 'bg'){
+            row.innerHTML = `
+              <label>${type} color</label>
+              <div class="color-group">
+                <input id="${area.key}-${type}-c" type="color" />
+                <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
+              </div>
+            `;
+          } else {
+            row.innerHTML = `
+              <label>${type} color</label>
+              <div class="color-group">
+                <input id="${area.key}-${type}-c" type="color" />
+              </div>
+            `;
+          }
           fs.appendChild(row);
         });
       wrap.appendChild(fs);
@@ -2800,10 +2821,13 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       const [areaKey, type] = targetInput.id.split('-');
       const area = colorAreas.find(a=>a.key===areaKey);
       if(area){
-        const color = targetInput.value;
+        const colorInput = document.getElementById(`${areaKey}-${type}-c`);
+        const opacityInput = document.getElementById(`${areaKey}-${type}-o`);
+        const color = colorInput ? colorInput.value : '#ffffff';
+        const opacity = opacityInput ? opacityInput.value : 1;
         (area.selectors[type]||[]).forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
-            if(type==='bg') el.style.backgroundColor = color;
+            if(type==='bg') el.style.backgroundColor = hexToRgba(color, opacity);
             else if(type==='text') el.style.color = color;
             else if(type==='btn'){ el.style.backgroundColor = color; el.style.borderColor = color; }
           });
@@ -2814,12 +2838,14 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     colorAreas.forEach(area=>{
       ['bg','text','btn'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
+        const o = document.getElementById(`${area.key}-${type}-o`);
         if(!c) return;
         const color = c.value;
+        const opacity = o ? o.value : 1;
         const targets = area.selectors[type] || [];
         targets.forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
-            if(type==='bg') el.style.backgroundColor = color;
+            if(type==='bg') el.style.backgroundColor = hexToRgba(color, opacity);
             else if(type==='text') el.style.color = color;
             else if(type==='btn'){ el.style.backgroundColor = color; el.style.borderColor = color; }
           });
@@ -2833,8 +2859,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     colorAreas.forEach(area=>{
       ['bg','text','btn'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
+        const o = document.getElementById(`${area.key}-${type}-o`);
         if(c){
-          data[`${area.key}-${type}`] = {color:c.value, opacity:'1'};
+          data[`${area.key}-${type}`] = {color:c.value, opacity: o ? o.value : '1'};
         }
       });
     });
@@ -2884,9 +2911,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       Object.entries(data).forEach(([key,val])=>{
         const [areaKey,type] = key.split('-');
         const c = document.getElementById(`${areaKey}-${type}-c`);
-        if(c){
-          c.value = val.color;
-        }
+        const o = document.getElementById(`${areaKey}-${type}-o`);
+        if(c){ c.value = val.color; }
+        if(type==='bg' && o && val.opacity!==undefined){ o.value = val.opacity; }
       });
       applyAdmin();
     }


### PR DESCRIPTION
## Summary
- Allow background color pickers to set transparency via a new opacity range input and updated panel styles.
- Extend admin scripting and theme presets to handle alpha values when applying, syncing and saving colors.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49a8b896c8331b5692901b7748db7