### PR TITLE
style: remove extra backgrounds from posts and calendar

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -616,6 +616,7 @@ body{
   overflow: auto;
   min-height: 0;
   padding-right: 6px;
+  background: transparent;
 }
 
 .mode-posts .posts-mode{
@@ -644,6 +645,7 @@ body{
   justify-content: center;
   color: var(--muted);
   min-height: 0;
+  background: transparent;
 }
 
 .detail-inline{
@@ -1136,6 +1138,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   border: none;
   backdrop-filter: blur(4px);
   color: #fff;
+  background: transparent;
 }
 
 .mode-posts #postsWide .res-list{


### PR DESCRIPTION
## Summary
- Ensure posts section has no default background so admin modal controls appearance
- Make posts-wide list and calendar areas transparent by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49e9928488331a44b747a23add51c