### PR TITLE
Ensure map visible beneath calendar

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -626,7 +626,7 @@ body{
   display: block;
 }
 
-.mode-calendar .map-wrap,.mode-calendar .posts-mode{
+.mode-calendar .posts-mode{
   display: none;
 }
 
@@ -1253,7 +1253,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     
     .mode-map .posts-mode{display:none}
     .mode-map .map-wrap{display:block}
-    .mode-calendar .map-wrap,.mode-calendar .posts-mode{display:none}
+    .mode-calendar .posts-mode{display:none}
     .calendar{display:none;height:100%;align-items:center;justify-content:center;color:var(--muted);min-height:0}
     .mode-calendar .calendar{display:flex}
 


### PR DESCRIPTION
## Summary
- Keep map displayed when viewing the calendar by removing CSS that hid the map

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a4a4f216488331bb2f650a252cb95c