### PR TITLE
Add card color picker with opacity control

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2737,11 +2737,11 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button']}},
     {key:'body', label:'Body', selectors:{bg:['body'], text:['body'], btn:['body button']}},
     {key:'filter', label:'Filter Panel', selectors:{bg:['.filters-col'], text:['.filters-col'], btn:['.filters-col button','.filters-col .sq','.filters-col .tiny','.filters-col .btn']}},
-    {key:'list', label:'List Panel', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col button']}},
+    {key:'list', label:'List Panel', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col button'], card:['.results-col .card']}},
     {key:'main', label:'Main Panel', selectors:{bg:['.main'], text:['.main'], btn:['.main button']}},
-    {key:'posts', label:'Posts Area', selectors:{bg:['.posts-mode'], text:['.posts-mode'], btn:['.posts-mode button']}},
+    {key:'posts', label:'Posts Area', selectors:{bg:['.posts-mode'], text:['.posts-mode'], btn:['.posts-mode button'], card:['.posts-mode .card']}},
     {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], btn:['.calendar button']}},
-    {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button']}}
+    {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], card:['footer .foot-row .foot-item']}}
   ];
 
   function rgbToHex(r,g,b){
@@ -2758,7 +2758,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
 
   function syncAdminControls(){
     colorAreas.forEach(area=>{
-      ['bg','text','btn'].forEach(type=>{
+      ['bg','text','btn','card'].forEach(type=>{
         const cInput = document.getElementById(`${area.key}-${type}-c`);
         const oInput = document.getElementById(`${area.key}-${type}-o`);
         if(!cInput) return;
@@ -2768,7 +2768,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           const el = document.querySelector(sel);
           if(!el) return false;
           const cs = getComputedStyle(el);
-          if(type === 'bg' || type === 'btn') col = cs.backgroundColor;
+          if(type === 'bg' || type === 'btn' || type === 'card') col = cs.backgroundColor;
           else if(type === 'text') col = cs.color;
           return col;
         });
@@ -2780,7 +2780,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const bVal = parseInt(match[3],10);
         const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
         cInput.value = rgbToHex(r,g,bVal);
-        if(type==='bg' && oInput) oInput.value = alpha;
+        if((type==='bg' || type==='card') && oInput) oInput.value = alpha;
       });
     });
   }
@@ -2794,27 +2794,29 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       const lg = document.createElement('legend');
       lg.textContent = area.label;
       fs.appendChild(lg);
-        ['bg','text','btn'].forEach(type=>{
-          const row = document.createElement('div');
-          row.className = 'control-row';
-          if(type === 'bg'){
-            row.innerHTML = `
+      const types = ['bg','text','btn'];
+      if(area.selectors.card) types.push('card');
+      types.forEach(type=>{
+        const row = document.createElement('div');
+        row.className = 'control-row';
+        if(type === 'bg' || type === 'card'){
+          row.innerHTML = `
               <label>${type} color</label>
               <div class="color-group">
                 <input id="${area.key}-${type}-c" type="color" />
                 <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
               </div>
             `;
-          } else {
-            row.innerHTML = `
+        } else {
+          row.innerHTML = `
               <label>${type} color</label>
               <div class="color-group">
                 <input id="${area.key}-${type}-c" type="color" />
               </div>
             `;
-          }
-          fs.appendChild(row);
-        });
+        }
+        fs.appendChild(row);
+      });
       wrap.appendChild(fs);
     });
   }
@@ -2830,7 +2832,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const opacity = opacityInput ? opacityInput.value : 1;
         (area.selectors[type]||[]).forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
-            if(type==='bg') el.style.backgroundColor = hexToRgba(color, opacity);
+            if(type==='bg' || type==='card') el.style.backgroundColor = hexToRgba(color, opacity);
             else if(type==='text') el.style.color = color;
             else if(type==='btn'){ el.style.backgroundColor = color; el.style.borderColor = color; }
           });
@@ -2840,7 +2842,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       return;
     }
     colorAreas.forEach(area=>{
-      ['bg','text','btn'].forEach(type=>{
+      ['bg','text','btn','card'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         if(!c) return;
@@ -2849,7 +2851,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const targets = area.selectors[type] || [];
         targets.forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
-            if(type==='bg') el.style.backgroundColor = hexToRgba(color, opacity);
+            if(type==='bg' || type==='card') el.style.backgroundColor = hexToRgba(color, opacity);
             else if(type==='text') el.style.color = color;
             else if(type==='btn'){ el.style.backgroundColor = color; el.style.borderColor = color; }
           });
@@ -2862,7 +2864,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function collectThemeValues(){
     const data = {};
     colorAreas.forEach(area=>{
-      ['bg','text','btn'].forEach(type=>{
+      ['bg','text','btn','card'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         if(c){
@@ -2883,6 +2885,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       dark[`${area.key}-bg`] = {color:'#222222', opacity:'1'};
       dark[`${area.key}-text`] = {color:'#eeeeee', opacity:'1'};
       dark[`${area.key}-btn`] = {color:'#444444', opacity:'1'};
+      if(area.selectors.card) dark[`${area.key}-card`] = {color:'#222222', opacity:'1'};
     });
     builtInPresets.push({name:'Dark', data: dark});
     const ocean = {};
@@ -2890,6 +2893,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       ocean[`${area.key}-bg`] = {color:'#e0f7fa', opacity:'1'};
       ocean[`${area.key}-text`] = {color:'#006064', opacity:'1'};
       ocean[`${area.key}-btn`] = {color:'#00838f', opacity:'1'};
+      if(area.selectors.card) ocean[`${area.key}-card`] = {color:'#e0f7fa', opacity:'1'};
     });
     builtInPresets.push({name:'Ocean', data: ocean});
   }
@@ -2918,7 +2922,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const c = document.getElementById(`${areaKey}-${type}-c`);
         const o = document.getElementById(`${areaKey}-${type}-o`);
         if(c){ c.value = val.color; }
-        if(type==='bg' && o && val.opacity!==undefined){ o.value = val.opacity; }
+        if((type==='bg' || type==='card') && o && val.opacity!==undefined){ o.value = val.opacity; }
       });
       applyAdmin();
     }


### PR DESCRIPTION
## Summary
- allow customizing card background color with opacity in list panel, posts area, and footer
- extend admin modal theme controls and presets to handle card color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab121a5883318ecbaaf69e036633