### PR TITLE
Ensure card opacity defaults to 1

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1282,7 +1282,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     footer .foot-row .fav svg{width:16px;height:16px;}
   
 /* === 0512 Clean fix: prevent text/image overlap in closed cards without !important === */
-.card{display:flex;gap:12px;align-items:flex-start}
+.card{display:flex;gap:12px;align-items:flex-start;opacity:1}
 .card .thumb{flex:0 0 90px;width:90px;height:70px;display:block;object-fit:cover;border-radius:12px}
 .posts-mode .card .thumb{flex-basis:70px;width:70px;height:70px}
 .card .meta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:6px}


### PR DESCRIPTION
## Summary
- Set `.card` elements to opacity 1 so cards render fully opaque by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ad45ffa0833182e995933ea68f67