### PR TITLE
Remove redundant footer background styles

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -728,7 +728,6 @@ body{
 footer{
   height: var(--footer-h);
   border-top: 1px solid rgba(255,255,255,.08);
-  background: linear-gradient(180deg,#0c1b2d,#0a1523);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -1270,7 +1269,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     .date{background:#10253c;border:1px solid rgba(255,255,255,.08);border-radius:999px;padding:6px 10px;font-size:12px}
     .desc{color:var(--ink-d);margin-top:8px}
 
-    footer{height:var(--footer-h);border-top:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,#0c1b2d,#0a1523);display:flex;align-items:center;gap:10px;padding:10px 14px}
+    footer{height:var(--footer-h);border-top:1px solid rgba(255,255,255,.08);display:flex;align-items:center;gap:10px;padding:10px 14px}
     .foot-title{font-size:12px;color:var(--muted);margin-right:6px;white-space:nowrap}
     .foot-row{overflow-x:auto;overflow-y:hidden;white-space:nowrap;display:flex;gap:8px;width:100%}
     .foot-row::-webkit-scrollbar{height:10px}


### PR DESCRIPTION
## Summary
- Remove default gradient background from the footer
- Keep footer background styling solely driven by admin modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ae73b63883319a80cf5ccce04845