### PR TITLE
Remove hardcoded opacity from styles

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -18,8 +18,8 @@
   --footer-h: 70px;
   */
 
-  --main-background: rgba(255,255,255,0.8);
-  --list-background: rgba(255,255,255,0.8);
+  --main-background: #ffffff;
+  --list-background: #ffffff;
 }
 
 *{
@@ -98,7 +98,6 @@ body{
 .auth a{
   text-decoration: none;
   color: #fff;
-  opacity: .9;
 }
 
 .auth button{
@@ -125,7 +124,6 @@ body{
 .gear svg{
   width: 18px;
   height: 18px;
-  opacity: .9;
 }
 
 .modal{
@@ -304,7 +302,6 @@ body{
 .sq svg{
   width: 14px;
   height: 14px;
-  opacity: .9;
 }
 
 
@@ -598,7 +595,6 @@ body{
   color: #fff;
   font-weight: 700;
   letter-spacing: .5px;
-  opacity: .15;
   pointer-events: none;
 }
 
@@ -850,7 +846,6 @@ footer{
 
 .hover-card .s{
   font-size: 12px;
-  opacity: .8;
   margin-top: 2px;
   white-space: normal;
   word-break: break-word;
@@ -916,7 +911,6 @@ footer{
 
 .multi-item .s{
   font-size: 12px;
-  opacity: .8;
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -1152,20 +1146,19 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 .main .map-wrap .main-bg-overlay{
   position: absolute;
   inset: 0;
-  background: var(--main-background, rgba(0,0,0,0.8));
+  background: var(--main-background, #000);
   pointer-events: none;
   border-radius: 0;
   z-index: 1;
-  opacity: 0;
+  display: none;
 }
 
-body.mode-posts .main .map-wrap .main-bg-overlay{
-  opacity: 1;
-}
-
+body.mode-posts .main .map-wrap .main-bg-overlay,
 body.mode-calendar .main .map-wrap .main-bg-overlay{
-  opacity: 1;
-}</style>
+  display: block;
+}
+
+</style>
 
 
 <style>
@@ -1195,15 +1188,15 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     .seg button{border:1px solid rgba(255,255,255,.6);border-radius:999px;padding:10px 14px;background:rgba(255,255,255,0.2);color:#fff;font-weight:600;cursor:pointer}
     .seg button[aria-current="page"]{background:rgba(255,255,255,0.35)}
     .auth{display:flex;align-items:center;gap:10px}
-    .auth a{text-decoration:none;color:#fff;opacity:.9}
+    .auth a{text-decoration:none;color:#fff}
     .gear{width:36px;height:36px;border-radius:10px;background:rgba(255,255,255,0.2);display:grid;place-items:center}
-    .gear svg{width:18px;height:18px;opacity:.9}
+    .gear svg{width:18px;height:18px}
 
     .main{height:calc(100% - var(--header-h) - var(--footer-h));display:grid;grid-template-columns:var(--results-w) 1fr;gap:var(--gap);padding:14px}
     .filters-col{display:flex;flex-direction:column;min-height:0}
     .left-tools{display:flex;gap:8px;margin-bottom:8px;padding-left:2px}
     .sq{width:30px;height:30px;border-radius:8px;background:#0c2238;display:grid;place-items:center}
-    .sq svg{width:14px;height:14px;opacity:.9}
+    .sq svg{width:14px;height:14px}
     .field{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin:8px 0}
     .field .input{position:relative}
     .input input,.input select{width:100%;height:40px;border-radius:12px;border:1px solid rgba(255,255,255,.1);background:#0b1a29;color:var(--ink);padding:0 38px 0 12px;outline:0}
@@ -1245,7 +1238,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
 
     .map-wrap{position:relative;background:#091a2c;border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,.08)}
     #map{position:absolute;inset:0}
-    .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
+    .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;pointer-events:none}
 
     .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding-right:6px}
     .mode-posts .posts-mode{display:block}
@@ -1281,7 +1274,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     footer .foot-row .fav svg{width:16px;height:16px;}
   
 /* === 0512 Clean fix: prevent text/image overlap in closed cards without !important === */
-.card{display:flex;gap:12px;align-items:flex-start;opacity:1}
+    .card{display:flex;gap:12px;align-items:flex-start}
 .card .thumb{flex:0 0 90px;width:90px;height:70px;display:block;object-fit:cover;border-radius:12px}
 .posts-mode .card .thumb{flex-basis:70px;width:70px;height:70px}
 .card .meta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:6px}
@@ -1304,7 +1297,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
 .hover-card{display:flex;gap:10px;align-items:center;max-width:280px}
 .hover-card img{width:64px;height:44px;object-fit:cover;border-radius:8px;flex:0 0 auto;display:block;background:#0b2239}
 .hover-card .t{font-weight:800;font-size:13px;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px}
-.hover-card .s{font-size:12px;opacity:.8}
+    .hover-card .s{font-size:12px}
 
 
 /* === 0515: Robust wrapping/clamping for hover popups === */
@@ -1322,7 +1315,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
   display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:3;overflow:hidden;
 }
 .hover-card .s{
-  font-size:12px;opacity:.8;margin-top:2px;
+  font-size:12px;margin-top:2px;
   white-space:normal;word-break:break-word;overflow-wrap:anywhere;
   display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1;overflow:hidden;
 }
@@ -1370,7 +1363,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
   word-break:break-word;
   overflow-wrap:anywhere;
 }
-.multi-item .s{font-size:12px;opacity:.8;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .multi-item .s{font-size:12px;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .multi-ctrls{display:flex;justify-content:space-between;align-items:center;gap:10px;margin-top:8px}
 .multi-ctrls .hint{font-size:12px;color:var(--ink-d)}
 .multi-ctrls .close{border:0;background:#16283f;color:#fff;border-radius:10px;padding:6px 10px;cursor:pointer}
@@ -1479,8 +1472,8 @@ footer .foot-row .foot-item img {
     --btn-2: #ff9800;
     --panel-grad: linear-gradient(180deg, #ffecb3, #ffe0b2);
     --bg-grad: linear-gradient(0deg, #fff8e1, #ffe0b2);
-    --main-background: rgba(255, 255, 255, 0.8);
-    --list-background: rgba(255, 248, 225, 0.8);
+    --main-background: #ffffff;
+    --list-background: #fff8e1;
   }
   body {
     background: #fff8e1;
@@ -2209,7 +2202,7 @@ function makePosts(){
       map.addLayer({ id:'clusters', type:'circle', source:'posts', filter:['has','point_count'], minzoom:3.5, paint:{
         'circle-color': ['step',['get','point_count'], '#24c6dc', 20, '#514a9d', 50, '#f7797d', 100, '#fbd786'],
         'circle-radius': ['step',['get','point_count'], 16, 20, 22, 50, 28, 100, 34],
-        'circle-opacity': 0.85, 'circle-stroke-color':'#0b1623', 'circle-stroke-width':1 } });
+        'circle-stroke-color':'#0b1623', 'circle-stroke-width':1 } });
       map.addLayer({ id:'cluster-count', type:'symbol', source:'posts', filter:['has','point_count'], minzoom:3.5, layout:{ 'text-field':['get','point_count_abbreviated'], 'text-size':12 }, paint:{'text-color':'#fff'} });
       // === 0528: Right‑click cluster -> open scrollable list (locks map) ===
       // Close list on outside click or ESC
@@ -2298,7 +2291,7 @@ function makePosts(){
 
       // Hover ring layer for individual points
       map.addLayer({ id:'hover-ring', type:'circle', source:'posts', filter:['==',['get','id'],'__none__'], paint:{
-        'circle-color': '#ffffff', 'circle-opacity': 0, 'circle-stroke-color':'#fff', 'circle-stroke-opacity':0.95,
+        'circle-color': '#ffffff', 'circle-stroke-color':'#fff',
         'circle-stroke-width': 2, 'circle-radius': 12
       }});
 
@@ -2867,7 +2860,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         if(c){
-          data[`${area.key}-${type}`] = {color:c.value, opacity: o ? o.value : '1'};
+          const obj = {color: c.value};
+          if(o && o.value !== '1') obj.opacity = o.value;
+          data[`${area.key}-${type}`] = obj;
         }
       });
     });
@@ -2881,18 +2876,18 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function initBuiltInPresets(){
     const dark = {};
     colorAreas.forEach(area=>{
-      dark[`${area.key}-bg`] = {color:'#222222', opacity:'1'};
-      dark[`${area.key}-text`] = {color:'#eeeeee', opacity:'1'};
-      dark[`${area.key}-btn`] = {color:'#444444', opacity:'1'};
-      if(area.selectors.card) dark[`${area.key}-card`] = {color:'#222222', opacity:'1'};
+      dark[`${area.key}-bg`] = {color:'#222222'};
+      dark[`${area.key}-text`] = {color:'#eeeeee'};
+      dark[`${area.key}-btn`] = {color:'#444444'};
+      if(area.selectors.card) dark[`${area.key}-card`] = {color:'#222222'};
     });
     builtInPresets.push({name:'Dark', data: dark});
     const ocean = {};
     colorAreas.forEach(area=>{
-      ocean[`${area.key}-bg`] = {color:'#e0f7fa', opacity:'1'};
-      ocean[`${area.key}-text`] = {color:'#006064', opacity:'1'};
-      ocean[`${area.key}-btn`] = {color:'#00838f', opacity:'1'};
-      if(area.selectors.card) ocean[`${area.key}-card`] = {color:'#e0f7fa', opacity:'1'};
+      ocean[`${area.key}-bg`] = {color:'#e0f7fa'};
+      ocean[`${area.key}-text`] = {color:'#006064'};
+      ocean[`${area.key}-btn`] = {color:'#00838f'};
+      if(area.selectors.card) ocean[`${area.key}-card`] = {color:'#e0f7fa'};
     });
     builtInPresets.push({name:'Ocean', data: ocean});
   }


### PR DESCRIPTION
## Summary
- drop all hard-coded `opacity` declarations from CSS styles
- ensure Mapbox layers and presets no longer set opacity by default
- let theme collection store opacity only when explicitly changed via admin modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b01846448331a1ec60b5ef1aefa7