### PR TITLE
Restore map overlay opacity

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -595,6 +595,7 @@ body{
   color: #fff;
   font-weight: 700;
   letter-spacing: .5px;
+  opacity: .15;
   pointer-events: none;
 }
 
@@ -1146,16 +1147,19 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 .main .map-wrap .main-bg-overlay{
   position: absolute;
   inset: 0;
-  background: var(--main-background, #000);
+  background: var(--main-background, rgba(0,0,0,0.8));
   pointer-events: none;
   border-radius: 0;
   z-index: 1;
-  display: none;
+  opacity: 0;
 }
 
-body.mode-posts .main .map-wrap .main-bg-overlay,
+body.mode-posts .main .map-wrap .main-bg-overlay{
+  opacity: 1;
+}
+
 body.mode-calendar .main .map-wrap .main-bg-overlay{
-  display: block;
+  opacity: 1;
 }
 
 </style>
@@ -1238,7 +1242,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
 
     .map-wrap{position:relative;background:#091a2c;border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,.08)}
     #map{position:absolute;inset:0}
-    .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;pointer-events:none}
+    .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
 
     .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding-right:6px}
     .mode-posts .posts-mode{display:block}


### PR DESCRIPTION
## Summary
- Restore semi-transparent map overlay to show Loading message
- Revert main background overlay to use opacity toggling rather than display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b36976cc833183dc64ea21417930