### PR TITLE
Remove non-map opacity styles

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -98,7 +98,7 @@ body{
 .auth a{
   text-decoration: none;
   color: #fff;
-  opacity: .9;
+  
 }
 
 .auth button{
@@ -125,7 +125,7 @@ body{
 .gear svg{
   width: 18px;
   height: 18px;
-  opacity: .9;
+  
 }
 
 .modal{
@@ -304,7 +304,7 @@ body{
 .sq svg{
   width: 14px;
   height: 14px;
-  opacity: .9;
+  
 }
 
 
@@ -850,7 +850,7 @@ footer{
 
 .hover-card .s{
   font-size: 12px;
-  opacity: .8;
+  
   margin-top: 2px;
   white-space: normal;
   word-break: break-word;
@@ -916,7 +916,7 @@ footer{
 
 .multi-item .s{
   font-size: 12px;
-  opacity: .8;
+  
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -1195,15 +1195,15 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     .seg button{border:1px solid rgba(255,255,255,.6);border-radius:999px;padding:10px 14px;background:rgba(255,255,255,0.2);color:#fff;font-weight:600;cursor:pointer}
     .seg button[aria-current="page"]{background:rgba(255,255,255,0.35)}
     .auth{display:flex;align-items:center;gap:10px}
-    .auth a{text-decoration:none;color:#fff;opacity:.9}
+    .auth a{text-decoration:none;color:#fff;}
     .gear{width:36px;height:36px;border-radius:10px;background:rgba(255,255,255,0.2);display:grid;place-items:center}
-    .gear svg{width:18px;height:18px;opacity:.9}
+    .gear svg{width:18px;height:18px;}
 
     .main{height:calc(100% - var(--header-h) - var(--footer-h));display:grid;grid-template-columns:var(--results-w) 1fr;gap:var(--gap);padding:14px}
     .filters-col{display:flex;flex-direction:column;min-height:0}
     .left-tools{display:flex;gap:8px;margin-bottom:8px;padding-left:2px}
     .sq{width:30px;height:30px;border-radius:8px;background:#0c2238;display:grid;place-items:center}
-    .sq svg{width:14px;height:14px;opacity:.9}
+    .sq svg{width:14px;height:14px;}
     .field{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin:8px 0}
     .field .input{position:relative}
     .input input,.input select{width:100%;height:40px;border-radius:12px;border:1px solid rgba(255,255,255,.1);background:#0b1a29;color:var(--ink);padding:0 38px 0 12px;outline:0}
@@ -1281,7 +1281,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     footer .foot-row .fav svg{width:16px;height:16px;}
   
 /* === 0512 Clean fix: prevent text/image overlap in closed cards without !important === */
-.card{display:flex;gap:12px;align-items:flex-start;opacity:1}
+.card{display:flex;gap:12px;align-items:flex-start;}
 .card .thumb{flex:0 0 90px;width:90px;height:70px;display:block;object-fit:cover;border-radius:12px}
 .posts-mode .card .thumb{flex-basis:70px;width:70px;height:70px}
 .card .meta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:6px}
@@ -1304,7 +1304,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
 .hover-card{display:flex;gap:10px;align-items:center;max-width:280px}
 .hover-card img{width:64px;height:44px;object-fit:cover;border-radius:8px;flex:0 0 auto;display:block;background:#0b2239}
 .hover-card .t{font-weight:800;font-size:13px;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px}
-.hover-card .s{font-size:12px;opacity:.8}
+.hover-card .s{font-size:12px;}
 
 
 /* === 0515: Robust wrapping/clamping for hover popups === */
@@ -1322,7 +1322,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
   display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:3;overflow:hidden;
 }
 .hover-card .s{
-  font-size:12px;opacity:.8;margin-top:2px;
+  font-size:12px;margin-top:2px;
   white-space:normal;word-break:break-word;overflow-wrap:anywhere;
   display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1;overflow:hidden;
 }
@@ -1370,7 +1370,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
   word-break:break-word;
   overflow-wrap:anywhere;
 }
-.multi-item .s{font-size:12px;opacity:.8;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.multi-item .s{font-size:12px;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .multi-ctrls{display:flex;justify-content:space-between;align-items:center;gap:10px;margin-top:8px}
 .multi-ctrls .hint{font-size:12px;color:var(--ink-d)}
 .multi-ctrls .close{border:0;background:#16283f;color:#fff;border-radius:10px;padding:6px 10px;cursor:pointer}


### PR DESCRIPTION
## Summary
- remove default opacity on auth link and settings icon
- drop hardcoded opacity from various UI components
- allow opacity changes only via map or admin controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5db24ec83318a9ef70c44b59a05