### PR TITLE
Make panel and card backgrounds fully opaque

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -19,7 +19,7 @@
   */
 
   --main-background: rgba(255,255,255,0.8);
-  --list-background: rgba(255,255,255,0.8);
+  --list-background: rgba(255,255,255,1);
 }
 
 *{
@@ -282,6 +282,7 @@ body{
   display: flex;
   flex-direction: column;
   min-height: 0;
+  background: var(--list-background);
 }
 
 .left-tools{
@@ -732,6 +733,7 @@ footer{
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
+  background: var(--list-background);
 }
 
 .foot-title{
@@ -1480,7 +1482,7 @@ footer .foot-row .foot-item img {
     --panel-grad: linear-gradient(180deg, #ffecb3, #ffe0b2);
     --bg-grad: linear-gradient(0deg, #fff8e1, #ffe0b2);
     --main-background: rgba(255, 255, 255, 0.8);
-    --list-background: rgba(255, 248, 225, 0.8);
+    --list-background: rgba(255, 248, 225, 1);
   }
   body {
     background: #fff8e1;


### PR DESCRIPTION
## Summary
- Make filter panel and footer backgrounds use the opaque list background color
- Define list background color with full opacity for cards across list and posts areas

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b89865848331910f84c1983749ab