### PR TITLE
Rename filter panel and add hex color pickers

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1554,7 +1554,7 @@ footer .foot-row .foot-item img {
             <div class="muted">Map area filter active in Map mode</div>
           </div>
           <div class="res-actions">
-            <button id="filterBtn" aria-label="Open filters panel">Filters</button>
+            <button id="filterBtn" aria-label="Open filters modal">Filters</button>
             <select id="sortSelect" aria-label="Sort order">
               <option value="favaz">Favourites, A - Z</option>
               <option value="az">Title A - Z</option>
@@ -1660,6 +1660,10 @@ footer .foot-row .foot-item img {
           <label for="mLocation">Location</label>
           <input type="text" id="mLocation" />
         </div>
+        <div class="modal-field">
+          <label for="mColor">Color</label>
+          <input type="color" id="mColor" data-mode="hex" value="#000000" />
+        </div>
       </form>
     </div>
   </div>
@@ -1700,6 +1704,10 @@ footer .foot-row .foot-item img {
           <div class="modal-field">
             <label for="subList">Subcategories</label>
             <textarea id="subList" rows="3" placeholder="One subcategory per line"></textarea>
+          </div>
+          <div class="modal-field">
+            <label for="aColor">Color</label>
+            <input type="color" id="aColor" data-mode="hex" value="#000000" />
           </div>
           <h3>Subcategory Form Builder</h3>
           <div class="palette" id="fieldPalette">
@@ -2737,13 +2745,15 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a']}},
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button']}},
     {key:'body', label:'Body', selectors:{bg:['body'], text:['body'], btn:['body button']}},
-    {key:'filter', label:'Filter Panel', selectors:{bg:['.filters-col'], text:['.filters-col'], btn:['.filters-col button','.filters-col .sq','.filters-col .tiny','.filters-col .btn']}},
+    {key:'filter', label:'Filter Modal', selectors:{bg:['.filters-col'], text:['.filters-col'], btn:['.filters-col button','.filters-col .sq','.filters-col .tiny','.filters-col .btn']}},
     {key:'list', label:'List Panel', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col button'], card:['.results-col .card']}},
     {key:'main', label:'Main Panel', selectors:{bg:['.main'], text:['.main'], btn:['.main button']}},
     {key:'posts', label:'Posts Area', selectors:{bg:['.posts-mode'], text:['.posts-mode'], btn:['.posts-mode button'], card:['.posts-mode .card']}},
     {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], btn:['.calendar button']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], card:['footer .foot-row .foot-item']}}
   ];
+
+  const COLOR_PICKER_MODE = 'hex';
 
   function rgbToHex(r,g,b){
     return '#' + [r,g,b].map(x=>x.toString(16).padStart(2,'0')).join('');
@@ -2804,7 +2814,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           row.innerHTML = `
               <label>${type} color</label>
               <div class="color-group">
-                <input id="${area.key}-${type}-c" type="color" />
+                <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
                 <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
               </div>
             `;
@@ -2812,7 +2822,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           row.innerHTML = `
               <label>${type} color</label>
               <div class="color-group">
-                <input id="${area.key}-${type}-c" type="color" />
+                <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
               </div>
             `;
         }


### PR DESCRIPTION
## Summary
- Default all color pickers to hex mode with a `COLOR_PICKER_MODE` constant
- Rename "Filter Panel" references to "Filter Modal"
- Add color picker inputs to member and admin modals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bb1cb314833192afbb9f2173158e