### PR TITLE
Adjust modal layouts and add copyable color picker info

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -165,22 +165,19 @@ body{
   min-width:180px;
   max-width:260px;
 }
-#adminModal .modal-content{
-  width:90%;
-  max-width:1200px;
+#adminModal .modal-content,
+#memberModal .modal-content{
+  width:600px;
+  max-width:600px;
   max-height:90%;
+  background:#ffffff;
 }
-  #memberModal .modal-content{
-    width:90%;
-    max-width:1200px;
-    max-height:90%;
-  }
-  #filterModal .modal-content{
-    width:90%;
-    max-width:1200px;
-    max-height:90%;
-  }
-  @media (max-width:600px){
+#filterModal .modal-content{
+  width:350px;
+  max-width:350px;
+  max-height:calc(100% - var(--header-h));
+}
+@media (max-width:600px){
   #adminModal .modal-content,
   #memberModal .modal-content,
   #filterModal .modal-content{
@@ -195,6 +192,7 @@ body{
   #adminModal .color-group{width:120px;display:flex;flex-direction:column;align-items:stretch;position:relative;margin-left:auto;}
 #adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;}
 #adminModal .color-group input[type=range]{width:100%;}
+#adminModal .color-group input.color-info{margin-top:4px;padding:4px;font-size:12px;border:1px solid #ccc;border-radius:4px;}
 #adminModal .tab-bar{display:flex;gap:6px;}
 #adminModal .tab-bar button{flex:1;padding:6px 10px;border:1px solid #ccc;border-radius:6px;background:#eee;cursor:pointer;}
 #adminModal .tab-bar button[aria-selected="true"]{background:#ddd;font-weight:600;}
@@ -485,9 +483,15 @@ body{
 .res-head{
   display: flex;
   align-items: center;
-  justify-content: space-between;
   margin: 0 0 8px 0;
   color: var(--ink-d);
+  gap: 8px;
+}
+.res-actions{
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .res-list{
@@ -728,6 +732,10 @@ footer{
   gap: 10px;
   padding: 10px 14px;
   background: var(--list-background);
+}
+
+footer .foot-row .foot-item{
+  background: #FFF8E1;
 }
 
 .foot-title{
@@ -1224,8 +1232,8 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     .reset-box .arr{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;background:#0d2237;border:1px solid rgba(255,255,255,.08)}
 
     .results-col{display:flex;flex-direction:column;min-width:0;min-height:0}
-      .res-head{display:flex;align-items:center;justify-content:space-between;margin:0 0 8px 0;color:var(--ink-d)}
-      .res-actions{display:flex;align-items:center;gap:8px}
+      .res-head{display:flex;align-items:center;margin:0 0 8px 0;color:var(--ink-d);gap:8px}
+      .res-actions{display:flex;align-items:center;gap:8px;margin-left:auto}
       .res-head button{border:1px solid var(--ink-d);border-radius:999px;padding:8px 12px;background:var(--btn);color:var(--ink);font-weight:600;cursor:pointer}
       .res-head select{height:40px;border:1px solid var(--ink-d);border-radius:999px;background:var(--btn);color:var(--ink);padding:0 12px}
       .res-list{overflow:auto;padding-right:6px;flex:1;min-height:0}
@@ -1543,12 +1551,12 @@ footer .foot-row .foot-item img {
   <main class="main">
       <section class="results-col" aria-label="Results">
         <div class="res-head">
+          <button id="filterBtn" aria-label="Open filters modal">Filters</button>
           <div class="res-info">
             <div id="resultCount" aria-live="polite"><strong>0</strong> Results</div>
             <div class="muted">Map area filter active in Map mode</div>
           </div>
           <div class="res-actions">
-            <button id="filterBtn" aria-label="Open filters modal">Filters</button>
             <select id="sortSelect" aria-label="Sort order">
               <option value="favaz">Favourites, A - Z</option>
               <option value="az">Title A - Z</option>
@@ -2625,9 +2633,19 @@ function openModal(m){
   if(content){
     content.style.width = '';
     content.style.height = '';
-    content.style.left = '50%';
-    content.style.top = '50%';
-    content.style.transform = 'translate(-50%, -50%)';
+    if(m.id === 'filterModal'){
+      const headerHeight = document.querySelector('.header').offsetHeight;
+      content.style.left = '0';
+      content.style.top = `${headerHeight}px`;
+      content.style.transform = 'none';
+      content.style.width = '350px';
+      content.style.maxWidth = '350px';
+      content.style.height = `calc(100% - ${headerHeight}px)`;
+    } else {
+      content.style.left = '50%';
+      content.style.top = '50%';
+      content.style.transform = 'translate(-50%, -50%)';
+    }
   }
   m.classList.add('show');
   m.removeAttribute('aria-hidden');
@@ -2763,6 +2781,16 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   }
 
 
+  function updateColorInfo(areaKey, type){
+    const colorInput = document.getElementById(`${areaKey}-${type}-c`);
+    const opacityInput = document.getElementById(`${areaKey}-${type}-o`);
+    const infoInput = document.getElementById(`${areaKey}-${type}-info`);
+    if(!infoInput || !colorInput) return;
+    const color = colorInput.value;
+    const opacity = opacityInput ? opacityInput.value : '1';
+    infoInput.value = hexToRgba(color, opacity);
+  }
+
   function syncAdminControls(){
     colorAreas.forEach(area=>{
       ['bg','text','btn','card'].forEach(type=>{
@@ -2788,6 +2816,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
         cInput.value = rgbToHex(r,g,bVal);
         if((type==='bg' || type==='card') && oInput) oInput.value = alpha;
+        updateColorInfo(area.key, type);
       });
     });
   }
@@ -2812,6 +2841,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
               <div class="color-group">
                 <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
                 <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
+                <input id="${area.key}-${type}-info" class="color-info" type="text" readonly title="Click to copy" />
               </div>
             `;
         } else {
@@ -2819,10 +2849,18 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
               <label>${type} color</label>
               <div class="color-group">
                 <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
+                <input id="${area.key}-${type}-info" class="color-info" type="text" readonly title="Click to copy" />
               </div>
             `;
         }
         fs.appendChild(row);
+        const colorInput = row.querySelector(`#${area.key}-${type}-c`);
+        const opacityInput = row.querySelector(`#${area.key}-${type}-o`);
+        const infoInput = row.querySelector(`#${area.key}-${type}-info`);
+        if(colorInput) colorInput.addEventListener('input', ()=>{ applyAdmin(colorInput); updateColorInfo(area.key, type); });
+        if(opacityInput) opacityInput.addEventListener('input', ()=>{ applyAdmin(opacityInput); updateColorInfo(area.key, type); });
+        if(infoInput) infoInput.addEventListener('click', ()=> navigator.clipboard.writeText(infoInput.value));
+        updateColorInfo(area.key, type);
       });
       wrap.appendChild(fs);
     });
@@ -2845,6 +2883,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           });
         });
       }
+      updateColorInfo(areaKey, type);
       updateOverlayColor();
       return;
     }
@@ -2863,6 +2902,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
             else if(type==='btn'){ el.style.backgroundColor = color; el.style.borderColor = color; }
           });
         });
+        updateColorInfo(area.key, type);
       });
     });
     updateOverlayColor();


### PR DESCRIPTION
## Summary
- Open admin and member modals at 600px wide with solid white backgrounds
- Launch filter modal as a left-side panel at 350px wide and move Filters button to subheader's left
- Add copyable RGBA info boxes to color pickers and set footer cards to #FFF8E1

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c13f2be0833182ff62fda29854de