### PR TITLE
Add map card color picker and style filter modal

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18-0060.html
+++ b/ChatGPT-to-Codex-2025-08-18-0060.html
@@ -176,6 +176,7 @@ body{
   width:350px;
   max-width:600px;
   max-height:90%;
+  background:#fff;
 }
   @media (max-width:600px){
   #adminModal .modal-content,
@@ -2754,11 +2755,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a']}},
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button']}},
     {key:'body', label:'Body', selectors:{bg:['body'], text:['body'], btn:['body button']}},
-    {key:'filter', label:'Filter Modal', selectors:{bg:['.filters-col'], text:['.filters-col'], btn:['.filters-col button','.filters-col .sq','.filters-col .tiny','.filters-col .btn']}},
-    {key:'list', label:'List Panel', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col button'], card:['.results-col .card']}},
     {key:'main', label:'Main Panel', selectors:{bg:['.main'], text:['.main'], btn:['.main button']}},
-    {key:'posts', label:'Posts Area', selectors:{bg:['.posts-mode'], text:['.posts-mode'], btn:['.posts-mode button'], card:['.posts-mode .card']}},
+    {key:'list', label:'List Panel', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col button'], card:['.results-col .card']}},
+    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode'], btn:['.posts-mode button'], card:['.posts-mode .card']}},
     {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], btn:['.calendar button']}},
+    {key:'mapCards', label:'Map Cards', selectors:{bg:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], text:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], btn:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], card:['.mapboxgl-popup.hover-pop .hover-card']}},
+    {key:'filter', label:'Filter Modal', selectors:{bg:['.filters-col'], text:['.filters-col'], btn:['.filters-col button','.filters-col .sq','.filters-col .tiny','.filters-col .btn']}},
     {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], btn:['#adminModal button']}},
     {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], card:['footer .foot-row .foot-item']}}


### PR DESCRIPTION
## Summary
- give filter modal a white background so rounded edges match other dialogs
- reorder admin color controls, rename Posts Area to Posts, and include new Map Cards section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1b185548331aa190fcfb0fc1838