### PR TITLE
feat: add linkable styling controls

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -185,7 +185,8 @@ body{
     max-height:95%;
   }
 }
-#adminModal legend{font-weight:600;padding:0 6px;}
+#adminModal legend{font-weight:600;padding:0 6px;display:flex;align-items:center;gap:6px;}
+#adminModal legend .link-label{font-weight:400;font-size:12px;display:flex;align-items:center;gap:4px;}
 #adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
 #adminModal .control-row label{min-width:40px;font-size:12px;}
   #adminModal .color-group{width:120px;display:flex;flex-direction:column;align-items:stretch;position:relative;margin-left:auto;}
@@ -604,8 +605,9 @@ body{
   height: 100%;
   overflow: auto;
   min-height: 0;
-  padding-right: 6px;
-  background: transparent;
+  padding:12px 6px 0 6px;
+  background: rgba(0,0,0,0.7);
+  color:#000;
 }
 
 .mode-posts .posts-mode{
@@ -1235,7 +1237,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
 
-    .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding-right:6px}
+    .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:12px 6px 0 6px;background:rgba(0,0,0,0.7);color:#000}
     .mode-posts .posts-mode{display:block}
     
     .mode-map .posts-mode{display:none}
@@ -2792,14 +2794,14 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button']}},
     {key:'body', label:'Body', selectors:{bg:['body'], text:['body'], btn:['body button']}},
     {key:'main', label:'Main Panel', selectors:{bg:['.main'], text:['.main'], btn:['.main button']}},
-    {key:'list', label:'List Panel', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
-    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], btn:['.posts-mode button'], card:['.posts-mode .card']}},
-    {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], btn:['.calendar button']}},
-    {key:'mapCards', label:'Map Cards', selectors:{bg:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], text:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], btn:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], card:['.mapboxgl-popup.hover-pop .hover-card']}},
+    {key:'list', label:'Results List', linkable:true, selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
+    {key:'posts', label:'Posts', linkable:true, selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], btn:['.posts-mode button'], card:['.posts-mode .card']}},
+    {key:'calendar', label:'Calendar', linkable:true, selectors:{bg:['.calendar'], text:['.calendar'], btn:['.calendar button'], card:['.calendar .card']}},
+    {key:'footer', label:'Footer', linkable:true, selectors:{bg:['footer'], text:['footer'], btn:['footer button'], card:['footer .foot-row .foot-item']}},
+    {key:'mapCards', label:'Map Cards', linkable:true, selectors:{bg:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], text:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], btn:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], card:['.mapboxgl-popup.hover-pop .hover-card']}},
     {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
     {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], btn:['#adminModal button']}},
-    {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button']}},
-    {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], card:['footer .foot-row .foot-item']}}
+    {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button']}}
   ];
 
   const COLOR_PICKER_MODE = 'hex';
@@ -2853,6 +2855,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       fs.className = 'admin-fieldset';
       const lg = document.createElement('legend');
       lg.textContent = area.label;
+      if(area.linkable){
+        const linkLabel = document.createElement('label');
+        linkLabel.className = 'link-label';
+        linkLabel.innerHTML = `<input type="checkbox" id="link-${area.key}"> Link`;
+        lg.appendChild(linkLabel);
+      }
       fs.appendChild(lg);
       const types = ['bg','text','btn'];
       if(area.selectors.card) types.push('card');
@@ -2883,9 +2891,14 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
 
   function applyAdmin(targetInput){
     if(targetInput && targetInput.id){
+      if(targetInput.id.startsWith('link-')){
+        applyAdmin();
+        return;
+      }
       const [areaKey, type] = targetInput.id.split('-');
       const area = colorAreas.find(a=>a.key===areaKey);
-      if(area){
+      const linkChk = document.getElementById(`link-${areaKey}`);
+      if(area && (!area.linkable || !linkChk || linkChk.checked)){
         const colorInput = document.getElementById(`${areaKey}-${type}-c`);
         const opacityInput = document.getElementById(`${areaKey}-${type}-o`);
         const color = colorInput ? colorInput.value : '#ffffff';
@@ -2902,6 +2915,8 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       return;
     }
     colorAreas.forEach(area=>{
+      const linkChk = document.getElementById(`link-${area.key}`);
+      if(area.linkable && (!linkChk || !linkChk.checked)) return;
       ['bg','text','btn','card'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);


### PR DESCRIPTION
## Summary
- add link toggles for Results List, Posts, Calendar, Footer, and Map Cards in admin modal
- set Posts default styling with black text, semi-opaque background, and balanced padding
- enable Calendar card color picker and reorder admin style controls

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea28eb5083319c91afbaf96b9034