### PR TITLE
fix: refine posts styling and remove flicker

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -605,14 +605,13 @@ body{
   height:100%;
   overflow:auto;
   min-height:0;
-  padding:6px;
-  padding-bottom:50vh;
+  padding:6px 6px 50vh;
   color:#000;
   background:rgba(0,0,0,0.7);
 }
 .posts-mode .res-list{overflow:visible;padding:0}
 .posts-mode,.posts-mode *{color:#000!important}
-.posts-mode .card{background:rgba(0,0,0,0.7)}
+.posts-mode .card{background:#FFF8E1}
 .posts-mode .detail-inline{margin-top:6px}
 
 .mode-posts .posts-mode{
@@ -1242,10 +1241,10 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
 
-    .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:6px;padding-bottom:50vh;color:#000;background:rgba(0,0,0,0.7)}
+    .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:6px 6px 50vh;color:#000;background:rgba(0,0,0,0.7)}
     .posts-mode .res-list{overflow:visible;padding:0}
     .posts-mode,.posts-mode *{color:#000!important}
-    .posts-mode .card{background:rgba(0,0,0,0.7)}
+    .posts-mode .card{background:#FFF8E1}
     .posts-mode .detail-inline{margin-top:6px}
     .mode-posts .posts-mode{display:block}
     
@@ -2575,8 +2574,7 @@ function makePosts(){
       const container = target.closest('.posts-mode');
       if(fromPosts && container){
         const top = target.offsetTop - parseInt(getComputedStyle(container).paddingTop,10);
-        container.scrollTo({top, behavior:'smooth'});
-        await sleep(300);
+        container.scrollTop = top;
       } else {
         target.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
@@ -2942,6 +2940,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         });
       }
       updateOverlayColor();
+      const themeStr = JSON.stringify(collectThemeValues());
+      localStorage.setItem('currentTheme', themeStr);
+      if (typeof adminModal !== 'undefined' && adminModal) {
+        adminModal.dataset.originalValues = themeStr;
+        adminModal.removeAttribute('data-needs-save');
+      }
       return;
     }
     colorAreas.forEach(area=>{
@@ -2962,6 +2966,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       });
     });
     updateOverlayColor();
+    const themeStr = JSON.stringify(collectThemeValues());
+    localStorage.setItem('currentTheme', themeStr);
+    if (typeof adminModal !== 'undefined' && adminModal) {
+      adminModal.dataset.originalValues = themeStr;
+      adminModal.removeAttribute('data-needs-save');
+    }
   }
 
   function collectThemeValues(){
@@ -3037,11 +3047,17 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     loadPresets();
   }
 
+  function loadSavedTheme(){
+    const saved = JSON.parse(localStorage.getItem('currentTheme')||'null');
+    if(saved) applyPresetData(saved);
+  }
+
   buildStyleControls();
   syncAdminControls();
   defaultTheme = collectThemeValues();
   initBuiltInPresets();
   loadPresets();
+  loadSavedTheme();
   const adminForm = document.getElementById('adminForm');
   if(adminForm){
     const updateSaveState = ()=>{


### PR DESCRIPTION
## Summary
- set posts panel defaults to black text on translucent black background with cream cards
- persist admin theme changes automatically across sessions
- remove smooth scroll animation to avoid flicker when opening posts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f4c105f483319e28e76a396e3a5a