### PR TITLE
Ensure open posts reflect admin styling

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2189,7 +2189,7 @@ function makePosts(){
       const detail = buildDetail(p);
       target.replaceWith(detail);
       hookDetailActions(detail, p);
-      applyAdmin();
+      if(window.applyAdmin){ window.applyAdmin(); }
       detail.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
 
       const favBtn = detail.querySelector('[data-act="fav"]');
@@ -2206,7 +2206,7 @@ function makePosts(){
       el.querySelector('[data-act="close"]').addEventListener('click', ()=>{
         const replacedCard = card(p, true);
         el.replaceWith(replacedCard);
-        applyAdmin();
+        if(window.applyAdmin){ window.applyAdmin(); }
       });
       el.querySelector('[data-act="center"]').addEventListener('click', ()=>{ if(map){ map.flyTo({center:[p.lng,p.lat], zoom:10}); } setMode('map'); });
       el.querySelector('[data-act="fav"]').addEventListener('click', (e)=>{
@@ -2572,6 +2572,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     const themeStr = JSON.stringify(collectThemeValues());
     localStorage.setItem('currentTheme', themeStr);
   }
+  window.applyAdmin = applyAdmin;
 
   function collectThemeValues(){
     const data = {};


### PR DESCRIPTION
## Summary
- Expose `applyAdmin` globally so other modules can invoke it
- Reapply admin styles when opening or closing a post

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a54e15d6508331b360e9b9c45f5282