### PR TITLE
style: unify list and post spacing

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -493,7 +493,7 @@ body{
 
 .res-list{
   overflow: auto;
-  padding: 0 6px;
+  padding: 6px;
   flex: 1;
   min-height: 0;
 }
@@ -502,6 +502,11 @@ body{
   display: flex;
   gap: 12px;
   align-items: flex-start;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 18px;
+  padding: 14px;
+  overflow: hidden;
+  margin: 0 0 6px 0;
 }
 
 .thumb{
@@ -606,7 +611,7 @@ body{
   background:rgba(0,0,0,0.7);
   color:#000;
 }
-.posts-mode .res-list{overflow:visible;padding:12px 6px 0;}
+.posts-mode .res-list{overflow:visible;padding:6px;}
 .posts-mode .card,
 .posts-mode .detail-inline{background:#FFF8E1;}
 .posts-mode button{border:1px solid;background:#2a345b;border-color:#2a345b;color:#fff;}
@@ -647,7 +652,7 @@ body{
 .detail-inline{
   border: 1px solid rgba(255,255,255,.08);
   border-radius: 18px;
-  margin: 0 0 12px 0;
+  margin: 0 0 6px 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- Add rounded borders and internal padding to result cards
- Use consistent 6px spacing between result cards and open posts
- Normalize list padding in posts mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a556eb9e6083318ed737f8d8543420