### PR TITLE
style: update header buttons and post offset

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -74,10 +74,10 @@ body{
 
 .seg button,
 .auth button{
-  border: 1px solid rgba(255,255,255,.6);
+  border: 1px solid #6d603C;
   border-radius: 999px;
   padding: 10px 14px;
-  background: rgba(255,255,255,0.2);
+  background: #6d603C;
   color: inherit;
   font-weight: 600;
   cursor: pointer;
@@ -2197,6 +2197,7 @@ function makePosts(){
       hookDetailActions(detail, p);
       if(window.applyAdmin){ window.applyAdmin(); }
       detail.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
+      if(container){ container.scrollTop = Math.max(container.scrollTop - 6, 0); }
 
       const favBtn = detail.querySelector('[data-act="fav"]');
       favBtn.textContent = p.fav ? '★ Favourited' : '☆ Favourite';


### PR DESCRIPTION
## Summary
- style header buttons with default #6d603C color
- keep opened posts 6px below the top of the posts panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a558f2888083318ddcd63806319de4