### PR TITLE
Avoid vh-based padding in posts panel

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -604,7 +604,7 @@ body{
   height:100%;
   overflow:auto;
   min-height:0;
-  padding:0 6px 100vh;
+  padding:0 6px 1000px;
   color:#000;
   background:rgba(0,0,0,0.7);
 }
@@ -1238,7 +1238,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
 
-    .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:0 6px 100vh;color:#000;background:rgba(0,0,0,0.7)}
+    .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:0 6px 1000px;color:#000;background:rgba(0,0,0,0.7)}
     .posts-mode .res-list{overflow:visible;padding:12px 0 0}
     .posts-mode,.posts-mode *{color:#000}
     .posts-mode .card,.posts-mode .detail-inline{background:#FFF8E1}


### PR DESCRIPTION
## Summary
- replace `vh` padding with `px` to avoid viewport-based sizing issues

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57344f32083318420325568a053c0