### PR TITLE
Preserve post panel scroll on open

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2599,10 +2599,10 @@ function makePosts(){
       if(!target){ return; }
 
       const container = target.closest('.posts-mode');
-      if(container){
+      if(container && !fromPosts){
         const top = target.offsetTop - parseInt(getComputedStyle(container).paddingTop,10);
         container.scrollTop = top;
-      } else {
+      } else if(!container){
         target.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
 
@@ -2610,10 +2610,10 @@ function makePosts(){
       target.replaceWith(detail);
       hookDetailActions(detail, p);
 
-      if(container){
+      if(container && !fromPosts){
         const top = detail.offsetTop - parseInt(getComputedStyle(container).paddingTop,10);
         container.scrollTop = top;
-      } else {
+      } else if(!container){
         detail.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
 
@@ -2637,7 +2637,7 @@ function makePosts(){
         p.fav=!p.fav;
         e.currentTarget.textContent = p.fav?'★ Favourited':'☆ Favourite';
         renderLists(filtered);
-        openPost(p.id);
+        openPost(p.id, !!el.closest('.posts-mode'));
       });
     }
 


### PR DESCRIPTION
## Summary
- prevent post panel from scrolling to the top when opening a post from the panel
- ensure re-opening after favouriting keeps the same scroll context

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5797c3d048331a0a23f0c73137997