### PR TITLE
Avoid switching to map mode when clicking inside open post

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2160,10 +2160,10 @@ function makePosts(){
     $('#tab-calendar').addEventListener('click',()=> setMode('calendar'));
 
     $('.posts-mode').addEventListener('click', (e)=>{
-      if(!e.target.closest('.card')) setMode('map');
+      if(!e.target.closest('.card, .detail-inline')) setMode('map');
     });
     $('.calendar').addEventListener('click', (e)=>{
-      if(!e.target.closest('.card')) setMode('map');
+      if(!e.target.closest('.card, .detail-inline')) setMode('map');
     });
 
     // Mapbox


### PR DESCRIPTION
## Summary
- Prevent map mode from activating when clicking inside an open post.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57b0ef86c83318808d9b300454d39