### PR TITLE
Fix bottom post alignment in posts panel

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2600,8 +2600,8 @@ function makePosts(){
 
       const container = target.closest('.posts-mode');
       if(container && !fromPosts){
-        const top = target.offsetTop - parseInt(getComputedStyle(container).paddingTop,10);
-        container.scrollTop = top;
+        const top = target.offsetTop - parseInt(getComputedStyle(container).paddingTop,10) - 6;
+        container.scrollTop = Math.max(top, 0);
       } else if(!container){
         target.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
@@ -2611,8 +2611,8 @@ function makePosts(){
       hookDetailActions(detail, p);
 
       if(container && !fromPosts){
-        const top = detail.offsetTop - parseInt(getComputedStyle(container).paddingTop,10);
-        container.scrollTop = top;
+        const top = detail.offsetTop - parseInt(getComputedStyle(container).paddingTop,10) - 6;
+        container.scrollTop = Math.max(top, 0);
       } else if(!container){
         detail.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }


### PR DESCRIPTION
## Summary
- Align bottom posts so their top never moves above 6px from the panel top when scrolled programmatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57ef26858833193e680320355f053