### PR TITLE
fix: ensure posts stay 12px below panel top

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2633,8 +2633,9 @@ function makePosts(){
     }
 
     function ensureGap(container, el){
-      const gap = el.getBoundingClientRect().top - container.getBoundingClientRect().top;
-      if(gap < 12){ container.scrollTop += gap - 12; }
+      const pad = parseInt(getComputedStyle(container).paddingTop, 10) || 0;
+      const desired = el.offsetTop - pad - 12;
+      if(container.scrollTop > desired){ container.scrollTop = Math.max(desired, 0); }
     }
 
     function hookDetailActions(el, p){


### PR DESCRIPTION
## Summary
- anchor posts 12px below post panel's top by using offset-based scroll correction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5859174288331ba73d9f759dd93c4