### PR TITLE
Clamp scrolling of last post in posts panel

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2435,6 +2435,15 @@ function makePosts(){
 
     const resultsEl = $('#results');
     const postsWideEl = $('#postsWide');
+    const postsModeEl = $('.posts-mode');
+
+    postsModeEl.addEventListener('scroll', () => {
+      const last = postsWideEl.lastElementChild;
+      if(!last) return;
+      const limit = postsModeEl.getBoundingClientRect().top + 12;
+      const lastTop = last.getBoundingClientRect().top;
+      if(lastTop < limit){ postsModeEl.scrollTop -= (limit - lastTop); }
+    });
 
     function renderLists(list){
       const sort = $('#sortSelect').value;


### PR DESCRIPTION
## Summary
- prevent scrolling the final post higher than 12px below the posts panel top by clamping scrollTop during scroll events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a58878ec148331ae42d217e696c68c