### PR TITLE
Allow scrolling for final post overlapping footer

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2440,9 +2440,19 @@ function makePosts(){
     postsModeEl.addEventListener('scroll', () => {
       const last = postsWideEl.lastElementChild;
       if(!last) return;
-      const limit = postsModeEl.getBoundingClientRect().top + 12;
-      const lastTop = last.getBoundingClientRect().top;
-      if(lastTop < limit){ postsModeEl.scrollTop -= (limit - lastTop); }
+      const postsTop = postsModeEl.getBoundingClientRect().top;
+      const limitTop = postsTop + 12;
+      const rect = last.getBoundingClientRect();
+      const lastTop = rect.top;
+      const lastBottom = rect.bottom;
+      const footerH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--footer-h')) || 0;
+      const footerTop = window.innerHeight - footerH;
+      const desiredBottom = footerTop - 12;
+      if(lastBottom > desiredBottom){
+        postsModeEl.scrollTop -= (lastBottom - desiredBottom);
+      } else if(lastTop < limitTop){
+        postsModeEl.scrollTop -= (limitTop - lastTop);
+      }
     });
 
     function renderLists(list){


### PR DESCRIPTION
## Summary
- adjust scroll handler so bottom of last post can reach 12px above the footer

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a58d496b7c8331b16f04d4fdf2730e