### PR TITLE
Allow scrolling in popup post lists

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2272,10 +2272,10 @@ function makePosts(){
         openListPopupAtPoint(e.point, buildClusterListHTML(items));
 
         (function(){
-          function consume(ev){ try{ ev.preventDefault(); }catch{} try{ ev.stopPropagation(); }catch{} }
+          function consume(ev){ try{ ev.stopPropagation(); }catch{} }
           const _root = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
           if(_root){
-            ['pointerdown','mousedown','mouseup','click'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
+            ['pointerdown','mousedown','mouseup','click','wheel'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
           }
         })();
     
@@ -2350,10 +2350,10 @@ function makePosts(){
           openListPopupAtPoint(e.point, buildClusterListHTML(multi));
 
         (function(){
-          function consume(ev){ try{ ev.preventDefault(); }catch{} try{ ev.stopPropagation(); }catch{} }
+          function consume(ev){ try{ ev.stopPropagation(); }catch{} }
           const _root = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
           if(_root){
-            ['pointerdown','mousedown','mouseup','click'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
+            ['pointerdown','mousedown','mouseup','click','wheel'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
           }
         })();
     
@@ -2386,10 +2386,10 @@ function makePosts(){
           registerPopup(hoverPopup);
 
         (function(){
-          function consume(ev){ try{ ev.preventDefault(); }catch{} try{ ev.stopPropagation(); }catch{} }
+          function consume(ev){ try{ ev.stopPropagation(); }catch{} }
           const _root = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
           if(_root){
-            ['pointerdown','mousedown','mouseup','click'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
+            ['pointerdown','mousedown','mouseup','click','wheel'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
           }
         })();
     


### PR DESCRIPTION
## Summary
- stop consuming default events in popup handlers
- add wheel event interception so popup lists can scroll

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a58e5ff3888331b2ce1319681267fb