### PR TITLE
fix: prevent post panel from covering footer

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -754,6 +754,8 @@ footer{
   gap: 10px;
   padding: 10px 14px;
   background: var(--list-background);
+  position: relative;
+  z-index: 10;
 }
 
 .foot-row{
@@ -1286,7 +1288,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     .date{background:#10253c;border:1px solid rgba(255,255,255,.08);border-radius:999px;padding:6px 10px;font-size:12px}
     .desc{margin-top:8px}
 
-    footer{height:var(--footer-h);border-top:1px solid rgba(255,255,255,.08);display:flex;align-items:center;gap:10px;padding:10px 14px}
+    footer{height:var(--footer-h);border-top:1px solid rgba(255,255,255,.08);display:flex;align-items:center;gap:10px;padding:10px 14px;position:relative;z-index:10}
     .foot-row{overflow-x:auto;overflow-y:hidden;white-space:nowrap;display:flex;gap:8px;width:100%}
     .foot-row::-webkit-scrollbar{height:10px}
     .foot-row::-webkit-scrollbar-thumb{background:#0d2a44;border-radius:8px}


### PR DESCRIPTION
## Summary
- keep footer visible above the posts panel by increasing its stacking order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a591e66918833180fd940a92d53543