### PR TITLE
fix: restore list panel for calendar view

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -648,9 +648,8 @@ body{
 .mode-calendar .posts-mode{
   display: none;
 }
-.mode-calendar .results-col{
-  display: none;
-}
+/* allow results list in calendar mode */
+
 
 .calendar{
   display: none;
@@ -1131,7 +1130,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 }
 
 .main .calendar{
-  grid-column: 1/2;
+  grid-column: 2/3;
   grid-row: 1;
   position: relative;
   z-index: 1;
@@ -1268,8 +1267,7 @@ body.mode-calendar .main .map-wrap .main-bg-overlay{
     .mode-map .posts-mode{display:none}
     .mode-map .map-wrap{display:block}
     .mode-posts .map-wrap, .mode-calendar .map-wrap{display:block;grid-column:2/3;grid-row:1;z-index:0}
-    .mode-calendar .posts-mode{display:none}
-    .mode-calendar .results-col{display:none}
+    .mode-calendar .posts-mode{display:none}/* results list visible in calendar mode */
     .calendar{display:none;height:100%;align-items:center;justify-content:center;color:var(--muted);min-height:0}
     .mode-calendar .calendar{display:flex}
 
@@ -2168,6 +2166,7 @@ function makePosts(){
         updatePostPanel();
       }
       applyFilters();
+      adjustListHeight();
     }
     $('#tab-posts').addEventListener('click',()=> setMode('posts'));
     $('#tab-map').addEventListener('click',()=> setMode('map'));


### PR DESCRIPTION
## Summary
- keep results list and subheader visible in calendar mode
- position calendar placeholder over the map area
- recalc list panel height whenever mode changes

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59c963cb08331bd512f6c41309d26