### PR TITLE
Use Mapbox geocoder with in-map geolocate button

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1605,14 +1605,6 @@ footer .foot-row .foot-item img {
       <div class="modal-body">
         <section class="filters-col" aria-label="Filters">
           <div>
-            <h3>Location</h3>
-            <div class="field" role="search">
-              <div class="input"><input id="locationInput" type="text" placeholder="Enter a city or address and press Enter" aria-label="Location" />
-                <div class="x" role="button" aria-label="Clear location">X</div>
-              </div>
-              <div id="btnGeo" class="tiny" role="button" aria-label="Find my location">Locate</div>
-            </div>
-
             <h3>Keywords</h3>
             <div class="field">
               <div class="input"><input id="kwInput" type="text" placeholder="Search keywords" aria-label="Keywords" />
@@ -2127,7 +2119,7 @@ function makePosts(){
       selection.cats.clear(); selection.subs.clear();
       $$('.cat').forEach(el=>el.setAttribute('aria-expanded','false'));
       $$('.chip.on').forEach(ch=>ch.classList.remove('on'));
-      $('#kwInput').value=''; $('#dateInput').value='This month'; $('#locationInput').value='';
+      $('#kwInput').value=''; $('#dateInput').value='This month';
       applyFilters();
     });
 
@@ -2181,11 +2173,17 @@ function makePosts(){
 
     // Mapbox
     function loadMapbox(cb){
-      if(window.mapboxgl) return cb();
+      if(window.mapboxgl && window.MapboxGeocoder) return cb();
       const link = document.createElement('link'); link.rel='stylesheet'; link.href='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css';
       document.head.appendChild(link);
+      const link2 = document.createElement('link'); link2.rel='stylesheet'; link2.href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.css';
+      document.head.appendChild(link2);
       const s = document.createElement('script'); s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
-      s.onload = cb; document.head.appendChild(s);
+      s.onload = ()=>{
+        const g = document.createElement('script'); g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.min.js';
+        g.onload = cb; document.head.appendChild(g);
+      };
+      document.head.appendChild(s);
     }
     loadMapbox(initMap);
 
@@ -2213,35 +2211,13 @@ function makePosts(){
     function startSpin(){ spinning = true; function step(){ if(!spinning || !map) return; map.setBearing(map.getBearing() + 0.03); requestAnimationFrame(step); } requestAnimationFrame(step); }
     function stopSpin(){ spinning = false; }
 
-    $('#btnGeo').addEventListener('click', ()=>{
-      stopSpin();
-      if(navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(pos=>{
-          const {longitude:lng, latitude:lat} = pos.coords;
-          if(map) map.flyTo({center:[lng,lat], zoom:10});
-        });
-      }
-    });
-
-    // Geocode
-    const locInput = $('#locationInput');
-    locInput.placeholder = 'Try: Federation Square, Swanston St & Flinders St, Melbourne VIC 3000, Australia';
-    locInput.addEventListener('keydown', async (e)=>{
-      if(e.key !== 'Enter') return;
-      const q = locInput.value.trim(); if(!q) return;
-      try{
-        locInput.disabled = true;
-        const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${MAPBOX_TOKEN}&limit=1`;
-        const res = await fetch(url);
-        const data = await res.json();
-        const f = data.features && data.features[0];
-        if(f && f.center){
-          stopSpin(); map.flyTo({center:f.center, zoom: Math.max(8, map.getZoom())});
-          await sleep(500); applyFilters(); locInput.style.borderColor = '#1ee6a1';
-        } else { locInput.style.borderColor = '#ff6b6b'; }
-      }catch(err){ console.error(err); locInput.style.borderColor = '#ff6b6b'; }
-      finally{ setTimeout(()=>{locInput.style.borderColor=''; locInput.disabled=false;}, 900); }
-    });
+    // Mapbox search and geolocate controls
+    const geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken, mapboxgl, marker: false });
+    geocoder.on('result', stopSpin);
+    map.addControl(geocoder, 'top-left');
+    const geolocate = new mapboxgl.GeolocateControl({ positionOptions:{ enableHighAccuracy:true }, trackUserLocation:true });
+    geolocate.on('geolocate', stopSpin);
+    map.addControl(geolocate, 'top-left');
 
     // Map layers
     function postsToGeoJSON(list){


### PR DESCRIPTION
## Summary
- remove manual location filter and rely on Mapbox's geocoder UI
- load Mapbox Geocoder resources and add geolocate button inside the map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5af12d8dc8331a5abb257960a0695