### PR TITLE
fix: ensure mapbox theme changes apply

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -3162,12 +3162,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       const styleUrl = e.target.value;
       localStorage.setItem('mapboxStyle', styleUrl);
       if(map){
-        map.setStyle(styleUrl);
         map.once('style.load', () => {
           addPostSource();
           applyFilters();
           updatePostPanel();
         });
+        map.setStyle(styleUrl);
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure mapbox style dropdown re-adds layers after style change

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a5b65ae1908331a4ba7de7d825bf20