### PR TITLE
fix: restore mapbox markers and theme switching

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2204,6 +2204,14 @@ function makePosts(){
     }
     loadMapbox(initMap);
 
+    function handleStyleLoad(){
+      map.setFog({ color: 'rgb(186, 210, 255)', 'high-color': 'rgb(64, 152, 255)', 'space-color':'rgb(4,7,22)', 'horizon-blend': 0.3 });
+      map.setSky({ 'sky-type':'atmosphere', 'sky-atmosphere-sun':[0.0, 90.0], 'sky-atmosphere-sun-intensity': 10 });
+      addPostSource();
+      applyFilters();
+      updatePostPanel();
+    }
+
     function initMap(){
       mapboxgl.accessToken = MAPBOX_TOKEN;
         const style = pendingMapStyle || localStorage.getItem('mapboxStyle') || DEFAULT_MAP_STYLE;
@@ -2217,13 +2225,7 @@ function makePosts(){
           pitch:0,
           attributionControl:true
         });
-        map.on('style.load', () => {
-          map.setFog({ color: 'rgb(186, 210, 255)', 'high-color': 'rgb(64, 152, 255)', 'space-color':'rgb(4,7,22)', 'horizon-blend': 0.3 });
-          map.setSky({ 'sky-type':'atmosphere', 'sky-atmosphere-sun':[0.0, 90.0], 'sky-atmosphere-sun-intensity': 10 });
-          addPostSource();
-          applyFilters();
-          updatePostPanel();
-        });
+        map.once('style.load', handleStyleLoad);
         map.on('load', ()=>{ $('.map-overlay').style.display='none'; startSpin(); });
 
       ['mousedown','wheel','touchstart','dragstart','pitchstart','rotatestart','zoomstart'].forEach(ev=> map.on(ev, stopSpin));
@@ -3164,6 +3166,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         pendingMapStyle = styleUrl;
         return;
       }
+      map.once('style.load', handleStyleLoad);
       map.setStyle(styleUrl);
     }
 


### PR DESCRIPTION
## Summary
- Ensure Mapbox style changes reinitialize layers and posts
- Reload markers after style switch to restore map features

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5be240b208331be1df6412e3e449e