### PR TITLE
Fix theme preset card colors

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2475,6 +2475,8 @@ function makePosts(){
       arr.forEach(p => { resultsEl.appendChild(card(p)); postsWideEl.appendChild(card(p, true)); });
       updateResultCount(arr.length);
       prioritizeVisibleImages();
+      // ensure newly rendered cards respect the active theme
+      applyAdmin();
     }
     function updateResultCount(n){ $('#resultCount').innerHTML = `<strong>${n}</strong> Results`; }
     function formatDates(d){ if(!d||!d.length) return ''; if(d.length===1) return d[0]; return `${d[0]} + ${d.length-1} more`; }
@@ -2553,6 +2555,8 @@ function makePosts(){
       }
       // scroll to the far right to reveal the newest
       footRow.scrollLeft = footRow.scrollWidth;
+      // apply current theme to any new footer items
+      applyAdmin();
     }
 
     function buildDetail(p){
@@ -2652,7 +2656,10 @@ function makePosts(){
       viewHistory = viewHistory.filter(x=>x.id!==id);
       viewHistory.unshift({id:p.id, title:p.title, city:p.city});
       if(viewHistory.length>100) viewHistory.length=100;
-      saveHistory(); renderFooter();
+      saveHistory();
+      renderFooter();
+      // ensure newly opened detail and history entries use active theme
+      applyAdmin();
     }
 
     function ensureGap(container, el){
@@ -2667,6 +2674,8 @@ function makePosts(){
         const replacedCard = card(p, true);
         el.replaceWith(replacedCard);
         if(container){ ensureGap(container, replacedCard); }
+        // newly inserted card should reflect current theme
+        applyAdmin();
       });
       el.querySelector('[data-act="center"]').addEventListener('click', ()=>{ if(map){ map.flyTo({center:[p.lng,p.lat], zoom:10}); } setMode('map'); });
       el.querySelector('[data-act="fav"]').addEventListener('click', (e)=>{


### PR DESCRIPTION
## Summary
- Reapply current theme after list rendering, footer updates, card close events, and post opens to keep card colors stable

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cdedbe548331823ffed532ae09ae