### PR TITLE
Fix Mapbox globe spin animation

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2249,8 +2249,21 @@ function makePosts(){
       });
     }
 
-    function startSpin(){ if(!spinEnabled || spinning || !map) return; spinning = true; function step(){ if(!spinning || !map) return; map.setBearing(map.getBearing() + 0.03); requestAnimationFrame(step); } requestAnimationFrame(step); }
-    function stopSpin(){ spinning = false; }
+    function startSpin(){
+      if(!spinEnabled || spinning || !map) return;
+      spinning = true;
+      function step(){
+        if(!spinning || !map) return;
+        const c = map.getCenter();
+        map.setCenter([c.lng + 0.03, c.lat]);
+        requestAnimationFrame(step);
+      }
+      requestAnimationFrame(step);
+    }
+    function stopSpin(){
+      spinning = false;
+      if(map) map.stop();
+    }
 
     $('#btnGeo').addEventListener('click', ()=>{
       stopSpin();


### PR DESCRIPTION
## Summary
- correct Mapbox globe spin by updating map center each frame instead of bearing
- ensure ongoing animations stop when spin is disabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a638f8cd8c8331aac8d9c96faf11bc