### PR TITLE
Stop map spin when any card is clicked

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2347,6 +2347,10 @@ function makePosts(){
       spinning = false;
     }
 
+    document.addEventListener('click', (e)=>{
+      if(e.target.closest('.card, .foot-item')) stopSpin();
+    });
+
     function updateSpinState(){
       const shouldSpin = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit));
       if(shouldSpin !== spinEnabled){


### PR DESCRIPTION
## Summary
- Stop map spinning whenever any card or footer item is clicked

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a661a63ce88331b4c3ba2e5104415e