### PR TITLE
Stop globe spin when card is clicked

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2348,7 +2348,11 @@ function makePosts(){
     }
 
     document.addEventListener('click', (e)=>{
-      if(e.target.closest('.card, .foot-item')) stopSpin();
+      if(e.target.closest('.card, .foot-item')) {
+        spinEnabled = false;
+        localStorage.setItem('spinGlobe', 'false');
+        stopSpin();
+      }
     }, {capture:true});
 
     function updateSpinState(){


### PR DESCRIPTION
## Summary
- Disable globe spin permanently when a card or footer item is clicked by clearing `spinEnabled` and updating `spinGlobe` localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6688c26948331bdbb1b8e79212f76