### PR TITLE
Disable globe spin after opening posts

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2787,6 +2787,8 @@ function makePosts(){
     }
 
     async function openPost(id, fromPosts=false){
+      spinEnabled = false;
+      localStorage.setItem('spinGlobe', 'false');
       stopSpin();
       const p = posts.find(x=>x.id===id); if(!p) return;
       if(mode !== 'posts'){


### PR DESCRIPTION
## Summary
- Stop globe rotation on post open by clearing `spinEnabled` and persisting the `spinGlobe` setting

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66bb5ff64833185a85461de8d5730