### PR TITLE
feat: disable globe spin on load by default

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1819,7 +1819,7 @@ footer .foot-row .foot-item img {
     const startZoom = savedView?.zoom || 1.5;
     const startPitch = savedView?.pitch || 0;
     let map, spinning = false,
-        spinLoadStart = JSON.parse(localStorage.getItem('spinLoadStart') ?? 'true'),
+        spinLoadStart = JSON.parse(localStorage.getItem('spinLoadStart') ?? 'false'),
         spinLoadType = localStorage.getItem('spinLoadType') || 'all',
         spinLogoClick = JSON.parse(localStorage.getItem('spinLogoClick') || 'true'),
         spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),


### PR DESCRIPTION
## Summary
- default globe spin to disabled unless enabled via admin modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66cae2d78833190c2a4a02f4e38b6