### PR TITLE
Restrict spinning globe to map view

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -2234,6 +2234,11 @@ function makePosts(){
         }
         updatePostPanel();
       }
+      if(m==='posts'){
+        spinEnabled = false;
+        localStorage.setItem('spinGlobe','false');
+        stopSpin();
+      }
       applyFilters();
     }
     $('#tab-posts').addEventListener('click',()=> setMode('posts'));
@@ -2290,6 +2295,7 @@ function makePosts(){
     }
 
     function startSpin(){
+      if(mode!=='map') setMode('map');
       if(!spinEnabled || spinning || !map) return;
       spinning = true;
       function step(){


### PR DESCRIPTION
## Summary
- Stop globe animation whenever the interface switches to Posts mode
- Automatically switch to Map mode before starting globe spin
- Ensure opening a post disables spinning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a695b8d85c8331ba87311f7dae6542