### PR TITLE
Add theme-aware hover and selection states for cards and toggles

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -79,6 +79,15 @@ button:active,
   border-color: var(--btn-active) !important;
   transform: scale(0.97);
 }
+button[aria-pressed="true"],
+button[aria-current="page"],
+button[aria-selected="true"],
+[role="button"][aria-pressed="true"],
+[role="button"][aria-current="page"],
+[role="button"][aria-selected="true"]{
+  background: var(--btn-active) !important;
+  border-color: var(--btn-active) !important;
+}
 button:focus-visible,
 [role="button"]:focus-visible{
   outline:2px solid var(--ink-d);
@@ -120,28 +129,35 @@ button:focus-visible,
 
 .view-toggle .seg{
   display: flex;
-  border: 1px solid rgba(255,255,255,.6);
+  border: 1px solid var(--btn);
   border-radius: 999px;
   overflow: hidden;
 }
 
 .view-toggle .seg button{
   border: none;
-  border-right: 1px solid rgba(255,255,255,.6);
+  border-right: 1px solid var(--btn);
   padding: 10px 14px;
-  background: rgba(255,255,255,0.2);
-  color: inherit;
+  background: var(--btn);
+  color: var(--ink);
   font-weight: 600;
   cursor: pointer;
-  transition: background .2s;
+  transition: background .2s,border-color .2s;
+}
+
+.view-toggle .seg button:hover{
+  background: var(--btn-hover);
+  border-color: var(--btn-hover);
 }
 
 .view-toggle .seg button:last-child{
   border-right: none;
 }
 
-.view-toggle .seg button[aria-current="page"]{
+.view-toggle .seg button[aria-current="page"],
+.view-toggle .seg button[aria-pressed="true"]{
   background: var(--btn-active) !important;
+  border-color: var(--btn-active) !important;
 }
 
 /* Spin controls */
@@ -156,14 +172,14 @@ button:focus-visible,
 }
   #spinType{
     display:flex;
-    border:1px solid #ccc;
+    border:1px solid var(--btn);
     border-radius:999px;
     overflow:hidden;
     margin-top:6px;
   }
   #spinType label{
     flex:1;
-    border-right:1px solid #ccc;
+    border-right:1px solid var(--btn);
   }
   #spinType label:last-child{border-right:none;}
   #spinType input{
@@ -172,12 +188,19 @@ button:focus-visible,
   #spinType span{
     display:block;
     padding:6px 10px;
-    background:#e0e0e0;
+    background:var(--btn);
+    color:var(--ink);
     font-weight:600;
     cursor:pointer;
     text-align:center;
+    transition:background .2s,border-color .2s;
   }
-  #spinType input:checked + span{background:#ccc;}
+  #spinType span:hover{
+    background:var(--btn-hover);
+  }
+  #spinType input:checked + span{
+    background:var(--btn-active);
+  }
 
 .auth{
   display: flex;
@@ -873,6 +896,24 @@ footer .foot-row .foot-item{
   text-overflow: ellipsis;
 }
 
+.card,
+footer .foot-row .foot-item{
+  transition: filter .2s, box-shadow .2s;
+}
+
+.card:hover,
+footer .foot-row .foot-item:hover{
+  filter: brightness(1.05);
+}
+
+.card.selected,
+.card[aria-selected="true"],
+footer .foot-row .foot-item.selected,
+footer .foot-row .foot-item[aria-selected="true"]{
+  filter: brightness(0.95);
+  box-shadow: 0 0 0 2px var(--ink-d);
+}
+
 .card .thumb{
   flex: 0 0 90px;
   width: 90px;
@@ -1255,10 +1296,11 @@ body.mode-posts .main .map-wrap .main-bg-overlay{
     .logo{display:flex;align-items:center;gap:10px;font-weight:800;letter-spacing:.4px;user-select:none}
     .logo img{height:48px;display:block}
     .view-toggle{position:absolute;left:calc(var(--results-w) + var(--gap) - 6px);top:50%;transform:translateY(-50%)}
-    .view-toggle .seg{display:flex;border:1px solid rgba(255,255,255,.6);border-radius:999px;overflow:hidden}
-    .view-toggle .seg button{border:none;border-right:1px solid rgba(255,255,255,.6);padding:10px 14px;background:rgba(255,255,255,0.2);color:inherit;font-weight:600;cursor:pointer}
+    .view-toggle .seg{display:flex;border:1px solid var(--btn);border-radius:999px;overflow:hidden}
+    .view-toggle .seg button{border:none;border-right:1px solid var(--btn);padding:10px 14px;background:var(--btn);color:var(--ink);font-weight:600;cursor:pointer;transition:background .2s,border-color .2s}
+    .view-toggle .seg button:hover{background:var(--btn-hover);border-color:var(--btn-hover)}
     .view-toggle .seg button:last-child{border-right:none}
-    .view-toggle .seg button[aria-current="page"]{background:var(--btn-active)!important}
+    .view-toggle .seg button[aria-current="page"],.view-toggle .seg button[aria-pressed="true"]{background:var(--btn-active)!important;border-color:var(--btn-active)!important}
     .auth{display:flex;align-items:center;gap:10px}
     .auth button{border:1px solid rgba(255,255,255,.6);border-radius:999px;padding:10px 14px;background:rgba(255,255,255,0.2);color:inherit;font-weight:600;cursor:pointer}
     .gear{width:36px;height:36px;border-radius:10px;background:rgba(255,255,255,0.2);display:grid;place-items:center}
@@ -1555,10 +1597,20 @@ footer .foot-row .foot-item img {
   .view-toggle .seg button,
   .auth button {
     background: var(--btn);
-    color: inherit;
+    border: 1px solid var(--btn);
+    color: var(--ink);
+    transition: background .2s,border-color .2s;
   }
-  .view-toggle .seg button[aria-current="page"] {
+  .view-toggle .seg button:hover,
+  .auth button:hover {
+    background: var(--btn-hover);
+    border-color: var(--btn-hover);
+  }
+  .view-toggle .seg button[aria-current="page"],
+  .view-toggle .seg button[aria-pressed="true"],
+  .auth button[aria-pressed="true"] {
     background: var(--btn-active);
+    border-color: var(--btn-active);
   }
   .sq,
   .tiny,


### PR DESCRIPTION
## Summary
- Highlight toggled buttons by styling `aria-pressed`, `aria-selected`, and `aria-current` states with theme variables
- Apply hover and selected visuals to cards and footer items that adapt to theme colors
- Update segmented and radio-style toggle controls to use theme color variables for hover and selected states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a69d3c9de083319d43b16380df87c3