### PR TITLE
Refine theming controls and card selection

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -18,7 +18,6 @@
   --btn-active: #d5d5d5;
   --btn-2: var(--btn-hover);
   --footer-h: 70px;
-  --main-background: rgba(255,255,255,0.8);
   --list-background: rgba(255,255,255,1);
   --scrollbar-track: transparent;
   --scrollbar-thumb: rgba(0,0,0,0.3);
@@ -702,9 +701,7 @@ button:focus-visible,
   stroke: var(--gold);
 }
 
-.map-wrap{
-  background: var(--main-background);
-}
+
 
 #map{
   position: absolute;
@@ -909,9 +906,11 @@ footer .foot-row .foot-item:hover{
 .card.selected,
 .card[aria-selected="true"],
 footer .foot-row .foot-item.selected,
-footer .foot-row .foot-item[aria-selected="true"]{
+footer .foot-row .foot-item[aria-selected="true"],
+.mapboxgl-popup.hover-pop .hover-card.selected,
+.mapboxgl-popup.hover-pop .hover-card[aria-selected="true"]{
   filter: brightness(0.95);
-  box-shadow: 0 0 0 2px var(--ink-d);
+  box-shadow: 0 0 0 2px var(--ink-d) inset;
 }
 
 .card .thumb{
@@ -1214,9 +1213,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   z-index: 0;
 }
 
-.map-wrap{
-  background: var(--main-background);
-}
+
 
 .results-col .res-list{
   border-radius: inherit;
@@ -1255,19 +1252,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   z-index: 0;
 }
 
-.main .map-wrap .main-bg-overlay{
-  position: absolute;
-  inset: 0;
-  background: var(--main-background, rgba(0,0,0,0.8));
-  pointer-events: none;
-  border-radius: 0;
-  z-index: 1;
-  opacity: 0;
-}
 
-body.mode-posts .main .map-wrap .main-bg-overlay{
-  opacity: 1;
-}
 
 
 
@@ -1587,7 +1572,6 @@ footer .foot-row .foot-item img {
     --btn-2: var(--btn-hover);
     --panel-grad: linear-gradient(180deg, #ffecb3, #ffe0b2);
     --bg-grad: linear-gradient(0deg, #fff8e1, #ffe0b2);
-    --main-background: rgba(255, 255, 255, 0.8);
     --list-background: rgba(255, 248, 225, 1);
   }
   body {
@@ -2296,15 +2280,6 @@ function makePosts(){
     $('#sortSelect').addEventListener('change', ()=> renderLists(filtered));
     $$('.field .x').forEach(x=> x.addEventListener('click',()=>{ const input = x.parentElement.querySelector('input'); if(input){ input.value=''; input.focus(); applyFilters(); } }));
 
-    function updateOverlayColor(){
-      let bg = 'rgba(0,0,0,0)';
-      if(mode==='posts'){
-        const el = document.querySelector('.posts-mode');
-        if(el) bg = getComputedStyle(el).backgroundColor;
-      }
-      document.documentElement.style.setProperty('--main-background', bg);
-    }
-
     function setMode(m){
       mode = m;
       document.body.classList.remove('mode-map','mode-posts');
@@ -2313,7 +2288,6 @@ function makePosts(){
       $('#tab-map').setAttribute('aria-current', m==='map'?'page':'');
       $('#tab-posts').setAttribute('aria-selected', m==='posts');
       $('#tab-map').setAttribute('aria-selected', m==='map');
-      updateOverlayColor();
       if(map){
         if(m==='map'){
           map.resize();
@@ -2868,6 +2842,7 @@ function makePosts(){
       activePostId = id;
       $$('.card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
       $$('footer .foot-row .foot-item[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
+      $$('.mapboxgl-popup .hover-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
       if(mode !== 'posts'){
         setMode('posts');
         await nextFrame(); await nextFrame();
@@ -2889,6 +2864,8 @@ function makePosts(){
       if(!target){ return; }
       const resCard = resultsEl.querySelector(`[data-id="${id}"]`);
       if(resCard) resCard.setAttribute('aria-selected','true');
+      const mapCard = document.querySelector('.mapboxgl-popup .hover-card');
+      if(mapCard) mapCard.setAttribute('aria-selected','true');
 
       const container = target.closest('.posts-mode');
       if(container){
@@ -2939,6 +2916,7 @@ function makePosts(){
         activePostId = null;
         $$('.card[aria-selected="true"]').forEach(n=>n.removeAttribute('aria-selected'));
         $$('footer .foot-row .foot-item[aria-selected="true"]').forEach(n=>n.removeAttribute('aria-selected'));
+        $$('.mapboxgl-popup .hover-card[aria-selected="true"]').forEach(n=>n.removeAttribute('aria-selected'));
       });
       el.querySelector('[data-act="center"]').addEventListener('click', ()=>{
         if(map){
@@ -2999,17 +2977,6 @@ function makePosts(){
 // 0577 helpers (safety)
 function heroUrl(p){ const id = (typeof p==='string')? p : p.id; return `https://picsum.photos/seed/${encodeURIComponent(id)}-t/1200/800`; }
 function thumbUrl(p){ const id = (typeof p==='string')? p : p.id; return `https://picsum.photos/seed/${encodeURIComponent(id)}-t/300/200`; }
-
-// 0651: ensure square MAIN background overlay exists (under shell, above map)
-(function(){
-  const wrap = document.querySelector('.main .map-wrap');
-  if (wrap && !wrap.querySelector('.main-bg-overlay')) {
-    const ov = document.createElement('div');
-    ov.className = 'main-bg-overlay';
-    wrap.appendChild(ov);
-  }
-})();
-
 const modalStack = [];
 function bringToTop(item){
   const idx = modalStack.indexOf(item);
@@ -3155,20 +3122,18 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   });
 
   const colorAreas = [
-    {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a']}},
-    {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button']}},
-    {key:'body', label:'Body', selectors:{bg:['body'], text:['body'], btn:['body button']}},
-    {key:'main', label:'Main Panel', selectors:{bg:['.main'], text:['.main'], btn:['.main button']}},
-    {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
-    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], btn:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
-    {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], card:['footer .foot-row .foot-item']}},
-    {key:'mapCards', label:'Map Cards', selectors:{bg:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], text:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], btn:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], card:['.mapboxgl-popup.hover-pop .hover-card']}},
-    {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
-    {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], btn:['#adminModal button']}},
-    {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button']}}
+    {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
+    {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button'], btnText:['.res-head button']}},
+    {key:'body', label:'Body', selectors:{bg:['body']}},
+    {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
+    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
+    {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], btnText:['footer button'], card:['footer .foot-row .foot-item']}},
+    {key:'mapCards', label:'Map Cards', selectors:{bg:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], text:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], btn:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], btnText:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], card:['.mapboxgl-popup.hover-pop .hover-card']}},
+    {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
+    {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], btn:['#adminModal button'], btnText:['#adminModal button']}},
+    {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button'], btnText:['#memberModal button']}}
   ];
 
-  const copyableKeys = new Set(['list','posts','mapCards','footer']);
   let lastFieldsetKey = null;
 
   const COLOR_PICKER_MODE = 'hex';
@@ -3187,7 +3152,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
 
   function syncAdminControls(){
     colorAreas.forEach(area=>{
-      ['bg','text','btn','card'].forEach(type=>{
+      ['bg','text','btn','btnText','card'].forEach(type=>{
         const cInput = document.getElementById(`${area.key}-${type}-c`);
         const oInput = document.getElementById(`${area.key}-${type}-o`);
         if(!cInput) return;
@@ -3198,7 +3163,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           if(!el) return false;
           const cs = getComputedStyle(el);
           if(type === 'bg' || type === 'btn' || type === 'card') col = cs.backgroundColor;
-          else if(type === 'text') col = cs.color;
+          else if(type === 'text' || type === 'btnText') col = cs.color;
           return col;
         });
         if(!col) return;
@@ -3223,28 +3188,29 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       fs.dataset.key = area.key;
       const lg = document.createElement('legend');
       lg.textContent = area.label;
-      if(copyableKeys.has(area.key)){
-        const sameBtn = document.createElement('button');
-        sameBtn.type = 'button';
-        sameBtn.textContent = 'Same';
-        sameBtn.className = 'same-btn';
-        sameBtn.addEventListener('click', ()=>{
-          if(!lastFieldsetKey || lastFieldsetKey === area.key) return;
-          ['bg','text','btn','card'].forEach(type=>{
-            const fromC = document.getElementById(`${lastFieldsetKey}-${type}-c`);
-            const fromO = document.getElementById(`${lastFieldsetKey}-${type}-o`);
-            const toC = document.getElementById(`${area.key}-${type}-c`);
-            const toO = document.getElementById(`${area.key}-${type}-o`);
-            if(fromC && toC){ toC.value = fromC.value; }
-            if(fromO && toO){ toO.value = fromO.value; }
-          });
-          applyAdmin();
-          lastFieldsetKey = area.key;
+      lg.addEventListener('click',()=>{ lastFieldsetKey = area.key; });
+      const sameBtn = document.createElement('button');
+      sameBtn.type = 'button';
+      sameBtn.textContent = 'Same';
+      sameBtn.className = 'same-btn';
+      sameBtn.addEventListener('click', (e)=>{
+        e.stopPropagation();
+        if(!lastFieldsetKey || lastFieldsetKey === area.key) return;
+        ['bg','text','btn','btnText','card'].forEach(type=>{
+          const fromC = document.getElementById(`${lastFieldsetKey}-${type}-c`);
+          const fromO = document.getElementById(`${lastFieldsetKey}-${type}-o`);
+          const toC = document.getElementById(`${area.key}-${type}-c`);
+          const toO = document.getElementById(`${area.key}-${type}-o`);
+          if(fromC && toC){ toC.value = fromC.value; }
+          if(fromO && toO){ toO.value = fromO.value; }
         });
-        lg.appendChild(sameBtn);
-      }
+        applyAdmin();
+      });
+      lg.appendChild(sameBtn);
       fs.appendChild(lg);
-      const types = ['bg','text','btn'];
+      const types = ['bg'];
+      if(area.selectors.text) types.push('text');
+      if(area.selectors.btn) types.push('btn','btnText');
       if(area.selectors.card) types.push('card');
       types.forEach(type=>{
         const row = document.createElement('div');
@@ -3258,8 +3224,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
               </div>
             `;
         } else {
+          const label = type === 'btnText' ? 'button text color' : `${type} color`;
           row.innerHTML = `
-              <label>${type} color</label>
+              <label>${label}</label>
               <div class="color-group">
                 <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
               </div>
@@ -3276,7 +3243,6 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       const [areaKey, type] = targetInput.id.split('-');
       const area = colorAreas.find(a=>a.key===areaKey);
       if(area){
-        lastFieldsetKey = areaKey;
         const colorInput = document.getElementById(`${areaKey}-${type}-c`);
         const opacityInput = document.getElementById(`${areaKey}-${type}-o`);
         const color = colorInput ? colorInput.value : '#ffffff';
@@ -3289,13 +3255,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           });
         });
       }
-      updateOverlayColor();
         const themeStr = JSON.stringify(collectThemeValues());
         localStorage.setItem('currentTheme', themeStr);
         return;
       }
     colorAreas.forEach(area=>{
-      ['bg','text','btn','card'].forEach(type=>{
+      ['bg','text','btn','btnText','card'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         if(!c) return;
@@ -3305,13 +3270,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         targets.forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
             if(type==='bg' || type==='card') el.style.backgroundColor = hexToRgba(color, opacity);
-            else if(type==='text') el.style.color = color;
+            else if(type==='text' || type==='btnText') el.style.color = color;
             else if(type==='btn'){ el.style.backgroundColor = color; el.style.borderColor = color; }
           });
         });
       });
     });
-    updateOverlayColor();
     const themeStr = JSON.stringify(collectThemeValues());
     localStorage.setItem('currentTheme', themeStr);
   }
@@ -3319,7 +3283,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function collectThemeValues(){
     const data = {};
     colorAreas.forEach(area=>{
-      ['bg','text','btn','card'].forEach(type=>{
+      ['bg','text','btn','btnText','card'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         if(c){
@@ -3337,17 +3301,23 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function initBuiltInPresets(){
     const dark = {};
     colorAreas.forEach(area=>{
-      dark[`${area.key}-bg`] = {color:'#222222', opacity:'1'};
-      dark[`${area.key}-text`] = {color:'#eeeeee', opacity:'1'};
-      dark[`${area.key}-btn`] = {color:'#444444', opacity:'1'};
+      if(area.selectors.bg) dark[`${area.key}-bg`] = {color:'#222222', opacity:'1'};
+      if(area.selectors.text) dark[`${area.key}-text`] = {color:'#eeeeee', opacity:'1'};
+      if(area.selectors.btn) {
+        dark[`${area.key}-btn`] = {color:'#444444', opacity:'1'};
+        dark[`${area.key}-btnText`] = {color:'#eeeeee', opacity:'1'};
+      }
       if(area.selectors.card) dark[`${area.key}-card`] = {color:'#222222', opacity:'1'};
     });
     builtInPresets.push({name:'Dark', data: dark});
     const ocean = {};
     colorAreas.forEach(area=>{
-      ocean[`${area.key}-bg`] = {color:'#e0f7fa', opacity:'1'};
-      ocean[`${area.key}-text`] = {color:'#006064', opacity:'1'};
-      ocean[`${area.key}-btn`] = {color:'#00838f', opacity:'1'};
+      if(area.selectors.bg) ocean[`${area.key}-bg`] = {color:'#e0f7fa', opacity:'1'};
+      if(area.selectors.text) ocean[`${area.key}-text`] = {color:'#006064', opacity:'1'};
+      if(area.selectors.btn) {
+        ocean[`${area.key}-btn`] = {color:'#00838f', opacity:'1'};
+        ocean[`${area.key}-btnText`] = {color:'#006064', opacity:'1'};
+      }
       if(area.selectors.card) ocean[`${area.key}-card`] = {color:'#e0f7fa', opacity:'1'};
     });
     builtInPresets.push({name:'Ocean', data: ocean});


### PR DESCRIPTION
## Summary
- Remove obsolete Main Panel styling and simplify Body legend to background only
- Add button text color and universal Same buttons that copy from last legend clicked
- Apply inset selection border to map cards, results, and footer cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a39268688331bcb865e84e5bbd39