### PR TITLE
feat: unify modal and popup theming

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -13,15 +13,17 @@
   --ink-d: #555;
   --gold: #ffc107;
   --muted: #777;
-  --btn: #fff;
-  --btn-hover: #e0e0e0;
-  --btn-active: #d5d5d5;
-  --btn-2: var(--btn-hover);
-  --footer-h: 70px;
-  --list-background: rgba(255,255,255,1);
-  --scrollbar-track: transparent;
-  --scrollbar-thumb: rgba(0,0,0,0.3);
-  --scrollbar-thumb-hover: rgba(0,0,0,0.5);
+    --btn: #fff;
+    --btn-hover: #e0e0e0;
+    --btn-active: #d5d5d5;
+    --btn-2: var(--btn-hover);
+    --modal-bg: rgba(0,0,0,0.7);
+    --modal-text: #fff;
+    --footer-h: 70px;
+    --list-background: rgba(255,255,255,1);
+    --scrollbar-track: transparent;
+    --scrollbar-thumb: rgba(0,0,0,0.3);
+    --scrollbar-thumb-hover: rgba(0,0,0,0.5);
 }
 
 *{
@@ -272,14 +274,17 @@ button:focus-visible,
   min-width:180px;
   max-width:260px;
 }
-#adminModal .modal-content,
-#memberModal .modal-content{
-  width:600px;
-  max-width:1200px;
-  max-height:90%;
-  background:rgba(0,0,0,0.7);
-  color:#fff;
-}
+  #adminModal .modal-content,
+  #memberModal .modal-content{
+    width:600px;
+    max-width:1200px;
+    max-height:90%;
+  }
+
+  #memberModal .modal-content{
+    background:rgba(0,0,0,0.7);
+    color:#fff;
+  }
 #filterModal .modal-content{
   width:350px;
   max-width:600px;
@@ -1552,13 +1557,18 @@ footer .foot-row .foot-item img {
 
 /* Let text shrink & wrap so width can be truly 'auto' */
 .mapboxgl-popup.hover-multi-list .multi-hover .multi-item .txt{ min-width:0; }
-.mapboxgl-popup.hover-multi-list .multi-hover .multi-item .t{
-  white-space:normal;
-  overflow-wrap:anywhere;
-  -webkit-line-clamp:2;
-  -webkit-box-orient:vertical;
-  display:-webkit-box;
-}
+  .mapboxgl-popup.hover-multi-list .multi-hover .multi-item .t{
+    white-space:normal;
+    overflow-wrap:anywhere;
+    -webkit-line-clamp:2;
+    -webkit-box-orient:vertical;
+    display:-webkit-box;
+  }
+  #adminModal .modal-content,
+  .mapboxgl-popup .mapboxgl-popup-content{
+    background: var(--modal-bg);
+    color: var(--modal-text);
+  }
 </style>
 
 <style>
@@ -3128,9 +3138,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
     {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], btn:['footer button'], btnText:['footer button'], card:['footer .foot-row .foot-item']}},
-    {key:'mapCards', label:'Map Cards', selectors:{bg:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], text:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content'], btn:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], btnText:['.mapboxgl-popup.hover-pop .mapboxgl-popup-content button'], card:['.mapboxgl-popup.hover-pop .hover-card']}},
+    {key:'mapCards', label:'Map Cards', selectors:{bg:['.mapboxgl-popup.hover-pop .hover-card'], text:['.mapboxgl-popup.hover-pop .hover-card']}},
     {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
-    {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], btn:['#adminModal button'], btnText:['#adminModal button']}},
+    {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content','.mapboxgl-popup .mapboxgl-popup-content'], text:['#adminModal .modal-content','.mapboxgl-popup .mapboxgl-popup-content'], btn:['#adminModal button','.mapboxgl-popup .mapboxgl-popup-content button'], btnText:['#adminModal button','.mapboxgl-popup .mapboxgl-popup-content button']}},
     {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button'], btnText:['#memberModal button']}}
   ];
 


### PR DESCRIPTION
## Summary
- add shared `--modal-bg` and `--modal-text` variables
- apply modal/popup theme to admin modal and map popups
- update color area mapping so admin controls style popups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ab6998488331b8c45bba5f0b1ade