### PR TITLE
Refactor color styles for admin control

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -61,9 +61,9 @@ body{
 
 button,
 [role="button"]{
-  background: var(--btn) !important;
-  border: 1px solid var(--btn) !important;
-  color: var(--ink) !important;
+  background: var(--btn);
+  border: 1px solid var(--btn);
+  color: var(--ink);
   padding: 6px 10px;
   border-radius: 6px;
   cursor: pointer;
@@ -71,13 +71,13 @@ button,
 }
 button:hover,
 [role="button"]:hover{
-  background: var(--btn-hover) !important;
-  border-color: var(--btn-hover) !important;
+  background: var(--btn-hover);
+  border-color: var(--btn-hover);
 }
 button:active,
 [role="button"]:active{
-  background: var(--btn-active) !important;
-  border-color: var(--btn-active) !important;
+  background: var(--btn-active);
+  border-color: var(--btn-active);
   transform: scale(0.97);
 }
 button[aria-pressed="true"],
@@ -86,8 +86,8 @@ button[aria-selected="true"],
 [role="button"][aria-pressed="true"],
 [role="button"][aria-current="page"],
 [role="button"][aria-selected="true"]{
-  background: var(--btn-active) !important;
-  border-color: var(--btn-active) !important;
+  background: var(--btn-active);
+  border-color: var(--btn-active);
 }
 button:focus-visible,
 [role="button"]:focus-visible{
@@ -157,8 +157,8 @@ button:focus-visible,
 
 .view-toggle .seg button[aria-current="page"],
 .view-toggle .seg button[aria-pressed="true"]{
-  background: var(--btn-active) !important;
-  border-color: var(--btn-active) !important;
+  background: var(--btn-active);
+  border-color: var(--btn-active);
 }
 
 /* Spin controls */
@@ -414,10 +414,10 @@ button:focus-visible,
   width: 30px;
   height: 30px;
   border-radius: 8px;
-  background: #e0e0e0;
+  background: var(--btn);
   display: grid;
   place-items: center;
-  border: 1px solid #ccc;
+  border: 1px solid var(--btn);
 }
 
 .sq svg{
@@ -460,9 +460,9 @@ button:focus-visible,
   border-radius: 8px;
   display: grid;
   place-items: center;
-  background: #e0e0e0;
+  background: var(--btn);
   cursor: pointer;
-  border: 1px solid #ccc;
+  border: 1px solid var(--btn);
 }
 
 .tiny{
@@ -471,9 +471,9 @@ button:focus-visible,
   width: 38px;
   height: 40px;
   border-radius: 12px;
-  background: #e0e0e0;
+  background: var(--btn);
   cursor: pointer;
-  border: 1px solid #ccc;
+  border: 1px solid var(--btn);
 }
 
 .tiny svg{
@@ -500,8 +500,8 @@ button:focus-visible,
   display: flex;
   align-items: center;
   gap: 8px;
-  background: linear-gradient(90deg,#0f243a,#14385a);
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
   cursor: pointer;
 }
 
@@ -511,8 +511,8 @@ button:focus-visible,
   border-radius: 50%;
   display: grid;
   place-items: center;
-  background: #12314f;
-  border: 1px solid rgba(255,255,255,.12);
+  background: var(--btn);
+  border: 1px solid var(--btn);
 }
 
 .cat .bar .label{
@@ -526,8 +526,8 @@ button:focus-visible,
   width: 38px;
   height: 36px;
   border-radius: 12px;
-  background: #0d2237;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
   cursor: pointer;
 }
 
@@ -545,8 +545,8 @@ button:focus-visible,
   gap: 8px;
   padding: 0 10px;
   border-radius: 999px;
-  background: #13263d;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
   font-size: 12px;
   color: var(--ink-d);
   width: max-content;
@@ -572,8 +572,8 @@ button:focus-visible,
 .reset-box .btn{
   height: 36px;
   border-radius: 999px;
-  background: #0c2236;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -595,8 +595,8 @@ button:focus-visible,
   width: 38px;
   height: 36px;
   border-radius: 12px;
-  background: #0d2237;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
 }
 
 .results-col{
@@ -689,8 +689,8 @@ button:focus-visible,
   border-radius: 12px;
   display: grid;
   place-items: center;
-  background: #0d2237;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
 }
 
 .fav svg{
@@ -737,8 +737,8 @@ button:focus-visible,
 .posts-mode .res-list{overflow:visible;padding:12px 0 0;}
 .posts-mode, .posts-mode *{color:#000;}
 .posts-mode .card,
-.posts-mode .detail-inline{background:#FFF8E1;}
-.posts-mode button{background:#2a345b;border-color:#2a345b;color:#fff;}
+.posts-mode .detail-inline{background:var(--list-background);}
+.posts-mode button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
 .posts-mode .detail-inline{margin-top:6px}
 
 .mode-posts .posts-mode{
@@ -758,8 +758,8 @@ button:focus-visible,
 
 
 .detail-inline{
-  background:#FFF8E1;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--list-background);
+  border: 1px solid var(--btn);
   border-radius: 18px;
   margin: 0 0 12px 0;
   overflow: hidden;
@@ -804,8 +804,8 @@ button:focus-visible,
 }
 
 .pill{
-  border: 1px solid rgba(255,255,255,.08);
-  background: #0d2237;
+  border: 1px solid var(--btn);
+  background: var(--btn);
   border-radius: 999px;
   padding: 8px 12px;
   font-weight: 700;
@@ -828,8 +828,8 @@ button:focus-visible,
 }
 
 .date{
-  background: #10253c;
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--btn);
+  border: 1px solid var(--btn);
   border-radius: 999px;
   padding: 6px 10px;
   font-size: 12px;
@@ -841,7 +841,7 @@ button:focus-visible,
 
 footer{
   height: var(--footer-h);
-  border-top: 1px solid rgba(255,255,255,.08);
+  border-top: 1px solid var(--btn);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -867,8 +867,8 @@ footer{
   display: flex;
   align-items: center;
   gap: 8px;
-  background: #10253c;
-  border: 1px solid rgba(255,255,255,.1);
+  background: var(--btn);
+  border: 1px solid var(--btn);
   border-radius: 12px;
   padding: 6px 10px;
   font-size: 12px;
@@ -879,8 +879,8 @@ footer{
 }
 
 footer .foot-row .foot-item{
-  background:#FFF8E1;
-  border:1px solid rgba(0,0,0,0.1);
+  background:var(--list-background);
+  border:1px solid var(--btn);
 }
 
 .chip-small img.mini{
@@ -890,7 +890,7 @@ footer .foot-row .foot-item{
   object-fit: cover;
   flex: 0 0 auto;
   display: block;
-  background: #0b2239;
+  background: var(--btn);
 }
 
 .chip-small .t{
@@ -1182,9 +1182,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 }
 
 .mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  background: linear-gradient(180deg,#0f1d2d,#0b1623);
+  background: var(--list-background);
   color: var(--ink);
-  border: 1px solid rgba(255,255,255,.08);
+  border: 1px solid var(--btn);
   border-radius: 12px;
   padding: 6px 10px 6px 8px;
 }
@@ -1290,7 +1290,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     .view-toggle .seg button{border:none;border-right:1px solid var(--btn);padding:10px 14px;background:var(--btn);color:var(--ink);font-weight:600;cursor:pointer;transition:background .2s,border-color .2s}
     .view-toggle .seg button:hover{background:var(--btn-hover);border-color:var(--btn-hover)}
     .view-toggle .seg button:last-child{border-right:none}
-    .view-toggle .seg button[aria-current="page"],.view-toggle .seg button[aria-pressed="true"]{background:var(--btn-active)!important;border-color:var(--btn-active)!important}
+    .view-toggle .seg button[aria-current="page"],.view-toggle .seg button[aria-pressed="true"]{background:var(--btn-active);border-color:var(--btn-active)}
     .auth{display:flex;align-items:center;gap:10px}
     .auth button{border:1px solid rgba(255,255,255,.6);border-radius:999px;padding:10px 14px;background:rgba(255,255,255,0.2);color:inherit;font-weight:600;cursor:pointer}
     .gear{width:36px;height:36px;border-radius:10px;background:rgba(255,255,255,0.2);display:grid;place-items:center}
@@ -1299,30 +1299,30 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     .main{height:calc(100% - var(--header-h) - var(--footer-h));display:grid;grid-template-columns:var(--results-w) 1fr;gap:var(--gap);padding:14px}
     .filters-col{display:flex;flex-direction:column;min-height:0}
     .left-tools{display:flex;gap:8px;margin-bottom:8px;padding-left:2px}
-    .sq{width:30px;height:30px;border-radius:8px;background:#0c2238;display:grid;place-items:center}
+    .sq{width:30px;height:30px;border-radius:8px;background:var(--btn);display:grid;place-items:center;border:1px solid var(--btn)}
     .sq svg{width:14px;height:14px;opacity:.9}
     .field{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin:8px 0}
     .field .input{position:relative}
     .input input,.input select{width:100%;height:40px;border-radius:12px;border:1px solid rgba(255,255,255,.1);background:#0b1a29;color:var(--ink);padding:0 38px 0 12px;outline:0}
-    .input .x,.input .down{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;border-radius:8px;display:grid;place-items:center;background:#0e2238;cursor:pointer;border:1px solid rgba(255,255,255,.08)}
-    .tiny{display:grid;place-items:center;width:38px;height:40px;border-radius:12px;background:#1e6d48;cursor:pointer;border:1px solid rgba(255,255,255,.08)}
+    .input .x,.input .down{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;border-radius:8px;display:grid;place-items:center;background:var(--btn);cursor:pointer;border:1px solid var(--btn)}
+    .tiny{display:grid;place-items:center;width:38px;height:40px;border-radius:12px;background:var(--btn);cursor:pointer;border:1px solid var(--btn)}
     .tiny svg{width:18px;height:18px}
 
     .cats{margin-top:10px}
     .cat{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin:8px 0}
-    .cat .bar{height:36px;border-radius:12px;padding-left:12px;display:flex;align-items:center;gap:8px;background:linear-gradient(90deg,#0f243a,#14385a);border:1px solid rgba(255,255,255,.08);cursor:pointer}
-    .cat .bar .dot{width:18px;height:18px;border-radius:50%;display:grid;place-items:center;background:#12314f;border:1px solid rgba(255,255,255,.12)}
+    .cat .bar{height:36px;border-radius:12px;padding-left:12px;display:flex;align-items:center;gap:8px;background:var(--btn);border:1px solid var(--btn);cursor:pointer}
+    .cat .bar .dot{width:18px;height:18px;border-radius:50%;display:grid;place-items:center;background:var(--btn);border:1px solid var(--btn)}
     .cat .bar .label{font-weight:700;letter-spacing:.2px}
-    .cat .cfg{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;background:#0d2237;border:1px solid rgba(255,255,255,.08);cursor:pointer}
+    .cat .cfg{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;background:var(--btn);border:1px solid var(--btn);cursor:pointer}
     .sub{margin:6px 0 0 6px;display:none;grid-template-columns:1fr;gap:6px}
-    .sub .chip{height:28px;display:inline-flex;align-items:center;gap:8px;padding:0 10px;border-radius:999px;background:#13263d;border:1px solid rgba(255,255,255,.08);font-size:12px;color:var(--ink-d);width:max-content;cursor:pointer}
+    .sub .chip{height:28px;display:inline-flex;align-items:center;gap:8px;padding:0 10px;border-radius:999px;background:var(--btn);border:1px solid var(--btn);font-size:12px;color:var(--ink-d);width:max-content;cursor:pointer}
     .chip.on{outline:2px solid #3cd1ff}
     .cat[aria-expanded="true"] .sub{display:grid}
 
     .reset-box{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin-top:10px}
-    .reset-box .btn{height:36px;border-radius:999px;background:#0c2236;border:1px solid rgba(255,255,255,.08);display:flex;align-items:center;gap:10px;padding:0 14px;font-weight:700;letter-spacing:.2px;color:var(--ink);cursor:pointer}
+    .reset-box .btn{height:36px;border-radius:999px;background:var(--btn);border:1px solid var(--btn);display:flex;align-items:center;gap:10px;padding:0 14px;font-weight:700;letter-spacing:.2px;color:var(--ink);cursor:pointer}
     .reset-box .btn svg{width:16px;height:16px}
-    .reset-box .arr{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;background:#0d2237;border:1px solid rgba(255,255,255,.08)}
+    .reset-box .arr{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;background:var(--btn);border:1px solid var(--btn)}
 
     .results-col{display:flex;flex-direction:column;min-width:0;min-height:0}
       .res-head{display:flex;align-items:center;justify-content:flex-start;gap:8px;margin:0 0 8px 0;color:var(--ink-d)}
@@ -1330,48 +1330,48 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
       .res-head button{border:1px solid var(--ink-d);border-radius:999px;padding:8px 12px;background:var(--btn);color:var(--ink);font-weight:600;cursor:pointer}
       .res-head select{height:40px;border:1px solid var(--ink-d);border-radius:999px;background:var(--btn);color:var(--ink);padding:0 12px}
       .res-list{overflow:auto;padding-right:6px;flex:1;min-height:0}
-    .card{display:grid;grid-template-columns:90px 1fr 36px;gap:12px;background:linear-gradient(180deg,#0f1d2d,#0b1623);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:12px;margin-bottom:12px;cursor:pointer}
+    .card{display:grid;grid-template-columns:90px 1fr 36px;gap:12px;background:var(--list-background);border:1px solid var(--btn);border-radius:16px;padding:12px;margin-bottom:12px;cursor:pointer}
     .thumb{width:90px;height:70px;border-radius:12px;object-fit:cover;display:block;background:#0b2239}
     .meta{display:flex;flex-direction:column;gap:6px;min-width:0}
     .title{font-weight:900;line-height:1.2}
     .info{display:flex;gap:16px;align-items:center;font-size:13px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
     .badge{width:18px;height:18px;border-radius:50%;display:inline-grid;place-items:center;background:#0e2540;border:1px solid rgba(255,255,255,.1);font-size:11px}
-    .fav{width:36px;height:36px;border-radius:12px;display:grid;place-items:center;background:#0d2237;border:1px solid rgba(255,255,255,.08)}
+    .fav{width:36px;height:36px;border-radius:12px;display:grid;place-items:center;background:var(--btn);border:1px solid var(--btn)}
     .fav svg{width:18px;height:18px;fill:none;stroke:var(--gold);stroke-width:1.5}
     .fav[aria-pressed="true"] svg{fill:var(--gold);stroke:var(--gold)}
 
-    .map-wrap{position:relative;background:#091a2c;border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,.08)}
+    .map-wrap{position:relative;background:var(--btn);border-radius:16px;overflow:hidden;border:1px solid var(--btn)}
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
 
     .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:0 6px;color:#000;background:rgba(0,0,0,0.7)}
     .posts-mode .res-list{overflow:visible;padding:12px 0 0}
     .posts-mode,.posts-mode *{color:#000}
-    .posts-mode .card,.posts-mode .detail-inline{background:#FFF8E1}
-    .posts-mode button{background:#2a345b;border-color:#2a345b;color:#fff}
+    .posts-mode .card,.posts-mode .detail-inline{background:var(--list-background)}
+    .posts-mode button{background:var(--btn);border-color:var(--btn);color:var(--ink)}
     .posts-mode .detail-inline{margin-top:6px}
     .mode-posts .posts-mode{display:block}
     
     .mode-map .posts-mode{display:none}
     .mode-map .map-wrap{display:block}
 
-    .detail-inline{background:#FFF8E1;border:1px solid rgba(255,255,255,.08);border-radius:18px}
+    .detail-inline{background:var(--list-background);border:1px solid var(--btn);border-radius:18px}
     .detail-inline .hero{height:160px;overflow:hidden}
     .detail-inline .hero img{width:100%;height:160px;object-fit:cover;display:block}
     .detail-inline .body{padding:14px;display:grid;grid-template-columns:1fr auto;gap:8px;align-items:start}
     .detail-inline h2{margin:0;font-size:20px;line-height:1.2}
     .detail-inline .meta{font-size:13px;display:flex;gap:12px;flex-wrap:wrap}
     .detail-inline .tools{display:flex;gap:8px}
-    .pill{border:1px solid rgba(255,255,255,.08);background:#0d2237;border-radius:999px;padding:8px 12px;font-weight:700;cursor:pointer}
+    .pill{border:1px solid var(--btn);background:var(--btn);border-radius:999px;padding:8px 12px;font-weight:700;cursor:pointer}
     .close{border:0;background:#16283f;border-radius:10px;padding:8px 12px;cursor:pointer}
     .dates{display:flex;gap:8px;flex-wrap:wrap;margin-top:4px}
-    .date{background:#10253c;border:1px solid rgba(255,255,255,.08);border-radius:999px;padding:6px 10px;font-size:12px}
+    .date{background:var(--btn);border:1px solid var(--btn);border-radius:999px;padding:6px 10px;font-size:12px}
     .desc{margin-top:8px}
 
-    footer{height:var(--footer-h);border-top:1px solid rgba(255,255,255,.08);display:flex;align-items:center;gap:10px;padding:10px 14px;position:relative;z-index:10}
+    footer{height:var(--footer-h);border-top:1px solid var(--btn);display:flex;align-items:center;gap:10px;padding:10px 14px;position:relative;z-index:10}
     .foot-row{overflow-x:auto;overflow-y:hidden;white-space:nowrap;display:flex;gap:8px;width:100%}
-    .chip-small{flex:0 0 auto;max-width:240px;display:flex;align-items:center;gap:8px;background:#10253c;border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:6px 10px;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
-    .chip-small img.mini{width:26px;height:20px;border-radius:6px;object-fit:cover;flex:0 0 auto;display:block;background:#0b2239}
+    .chip-small{flex:0 0 auto;max-width:240px;display:flex;align-items:center;gap:8px;background:var(--btn);border:1px solid var(--btn);border-radius:12px;padding:6px 10px;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
+    .chip-small img.mini{width:26px;height:20px;border-radius:6px;object-fit:cover;flex:0 0 auto;display:block;background:var(--btn)}
     .chip-small .t{overflow:hidden;text-overflow:ellipsis}
       footer .foot-row .fav-star{color:var(--gold);flex:0 0 auto;}
   
@@ -1390,9 +1390,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   max-width: 640px; /* allow a bit more width so content + scrollbar fit */
   overflow: hidden; /* no horizontal scroll on the container */
 
-  background: linear-gradient(180deg,#0f1d2d,#0b1623);
+  background: var(--list-background);
   color: var(--ink);
-  border: 1px solid rgba(255,255,255,.08);
+  border: 1px solid var(--btn);
   border-radius: 12px;
   padding: 6px 10px 6px 8px;
 }
@@ -1426,9 +1426,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 /* === 0528: Cluster contextmenu list (robust) === */
 .mapboxgl-popup.hover-pop { pointer-events: auto; }
 .mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  background: linear-gradient(180deg,#0f1d2d,#0b1623);
+  background: var(--list-background);
   color: var(--ink);
-  border: 1px solid rgba(255,255,255,.08);
+  border: 1px solid var(--btn);
   border-radius: 12px;
   padding: 6px 10px 6px 8px;
   max-width: 640px;
@@ -1615,22 +1615,22 @@ footer .foot-row .foot-item img {
   .pill,
   .close {
     background: var(--btn);
-    border-color: #ffcc80;
-    color: #333;
+    border-color: var(--btn);
+    color: var(--ink);
   }
   .input input,
   .input select,
   .cat .bar,
   .sub .chip {
-    background: #fff3e0;
-    border: 1px solid #ffcc80;
-    color: #333;
+    background: var(--list-background);
+    border: 1px solid var(--btn);
+    color: var(--ink);
   }
   .card,
   .detail-inline,
   .map-wrap {
     background: var(--list-background);
-    border-color: #ffcc80;
+    border-color: var(--btn);
   }
 </style>
 


### PR DESCRIPTION
## Summary
- allow button styles to inherit colors from admin controls
- replace map popup background gradients with configurable variables
- ensure posts mode buttons use admin-defined theme colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6b5d6871483319e3a6c7a9f6b1da2