### PR TITLE
Add header text color and font controls in admin modal

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -57,6 +57,7 @@ body{
   background: #f5f5f5;
   color: var(--ink);
   overflow: hidden;
+  cursor: default;
 }
 
 button,
@@ -312,12 +313,12 @@ button:focus-visible,
     max-height:95%;
   }
 }
-#adminModal legend{font-weight:600;padding:0 6px;display:flex;align-items:center;justify-content:space-between;}
+#adminModal legend{font-weight:600;padding:0 6px;display:flex;align-items:center;justify-content:space-between;cursor:pointer;user-select:none;}
 #adminModal legend button.same-btn{margin-left:8px}
 #adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
-#adminModal .control-row label{min-width:40px;font-size:12px;}
+#adminModal .control-row label{min-width:40px;font-size:12px;cursor:pointer;user-select:none;}
   #adminModal .color-group{width:120px;display:flex;flex-direction:column;align-items:stretch;position:relative;margin-left:auto;}
-#adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;}
+#adminModal .color-group input[type=color]{border:1px solid #ccc;border-radius:4px;padding:0;width:100%;height:40px;display:block;cursor:pointer;pointer-events:auto;}
 #adminModal .color-group input[type=range]{width:100%;}
 #adminModal .tab-bar{display:flex;gap:6px;}
 #adminModal .tab-bar button{flex:1;padding:6px 10px;border:1px solid #ccc;border-radius:6px;background:#eee;cursor:pointer;}
@@ -3133,18 +3134,19 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button'], btnText:['.res-head button']}},
     {key:'body', label:'Body', selectors:{bg:['body']}},
-    {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
-    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
+    {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], headerText:['.results-col .card .t'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
+    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], headerText:['.posts-mode .card .t','.posts-mode .detail-inline .t'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['#map'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup.hover-pop .hover-card'], text:['.mapboxgl-popup.hover-pop .hover-card'], headerText:['.mapboxgl-popup.hover-pop .hover-card .t']}},
-    {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
-    {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], btn:['#adminModal button'], btnText:['#adminModal button']}},
-    {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], btn:['#memberModal button'], btnText:['#memberModal button']}}
+    {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], headerText:['#filterModal .modal-content .t'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
+    {key:'adminModal', label:'Admin Modal', selectors:{bg:['#adminModal .modal-content'], text:['#adminModal .modal-content'], headerText:['#adminModal .modal-content .t'], btn:['#adminModal button'], btnText:['#adminModal button']}},
+    {key:'memberModal', label:'Member Modal', selectors:{bg:['#memberModal .modal-content'], text:['#memberModal .modal-content'], headerText:['#memberModal .modal-content .t'], btn:['#memberModal button'], btnText:['#memberModal button']}}
   ];
 
   let lastFieldsetKey = null;
 
   const COLOR_PICKER_MODE = 'hex';
+  const FONT_OPTIONS = ['Inter','Arial','Georgia','Courier New'];
 
   function rgbToHex(r,g,b){
     return '#' + [r,g,b].map(x=>x.toString(16).padStart(2,'0')).join('');
@@ -3194,6 +3196,8 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       const fs = document.createElement('fieldset');
       fs.className = 'admin-fieldset';
       fs.dataset.key = area.key;
+      fs.addEventListener('click',()=>{ lastFieldsetKey = area.key; });
+      fs.addEventListener('input',()=>{ lastFieldsetKey = area.key; });
       const lg = document.createElement('legend');
       lg.textContent = area.label;
       lg.addEventListener('click',()=>{ lastFieldsetKey = area.key; });
@@ -3211,8 +3215,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           const toO = document.getElementById(`${area.key}-${type}-o`);
           if(fromC && toC){ toC.value = fromC.value; }
           if(fromO && toO){ toO.value = fromO.value; }
+          const fromF = document.getElementById(`${lastFieldsetKey}-${type}-font`);
+          const toF = document.getElementById(`${area.key}-${type}-font`);
+          if(fromF && toF){ toF.value = fromF.value; }
         });
         applyAdmin();
+        syncFontControls();
       });
       lg.appendChild(sameBtn);
       fs.appendChild(lg);
@@ -3243,6 +3251,24 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
             `;
         }
         fs.appendChild(row);
+        if(type === 'text' || type === 'headerText' || type === 'btnText'){
+          const fontRow = document.createElement('div');
+          fontRow.className = 'control-row';
+          const fontLabel = document.createElement('label');
+          fontLabel.textContent = 'font';
+          const fontSelect = document.createElement('select');
+          fontSelect.className = 'font-select';
+          fontSelect.id = `${area.key}-${type}-font`;
+          FONT_OPTIONS.forEach(f=>{
+            const opt = document.createElement('option');
+            opt.value = f;
+            opt.textContent = f;
+            fontSelect.appendChild(opt);
+          });
+          fontRow.appendChild(fontLabel);
+          fontRow.appendChild(fontSelect);
+          fs.appendChild(fontRow);
+        }
       });
       wrap.appendChild(fs);
     });
@@ -3376,12 +3402,32 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     if(saved) applyPresetData(saved);
   }
 
+  function syncFontControls(){
+    const stored = localStorage.getItem('siteFont');
+    if(stored) document.body.style.fontFamily = stored;
+    const current = stored || getComputedStyle(document.body).fontFamily;
+    document.querySelectorAll('.font-select').forEach(sel=>{ sel.value = current; });
+  }
+
+  function initFontControls(){
+    syncFontControls();
+    document.addEventListener('change', e=>{
+      if(e.target.classList && e.target.classList.contains('font-select')){
+        const font = e.target.value;
+        document.body.style.fontFamily = font;
+        localStorage.setItem('siteFont', font);
+        document.querySelectorAll('.font-select').forEach(sel=>{ sel.value = font; });
+      }
+    });
+  }
+
   buildStyleControls();
   syncAdminControls();
   defaultTheme = collectThemeValues();
   initBuiltInPresets();
   loadPresets();
   loadSavedTheme();
+  initFontControls();
 
     const adminForm = document.getElementById('adminForm');
     if(adminForm){


### PR DESCRIPTION
## Summary
- Extend admin color controls with header text options for lists, posts, and modal fieldsets
- Allow global font selection via dropdown under each text color picker and improve Same button
- Default to arrow cursor and ensure color pickers work reliably in admin modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c152cdd483319042e7ed21c3e26a