### PR TITLE
feat(admin): add border customization

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -3136,7 +3136,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   const colorAreas = [
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button'], btnText:['.res-head button']}},
-    {key:'body', label:'Body', selectors:{bg:['body']}},
+    {key:'body', label:'Body', selectors:{bg:['body'], border:['button','.card','.toggle'], hoverBorder:['button:hover','.card:hover','.toggle:hover'], activeBorder:['button:active','.card.selected','.card[aria-selected="true"]','.toggle.active','.toggle[aria-selected="true"]']}},
     {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], headerText:['.results-col .card .t'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
     {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], headerText:['.posts-mode .card .t','.posts-mode .detail-inline .t'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
@@ -3249,6 +3249,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       if(area.selectors.text) types.push('text');
       if(area.selectors.headerText) types.push('headerText');
       if(area.selectors.btn) types.push('btn','btnText');
+      if(area.selectors.border) types.push('border');
+      if(area.selectors.hoverBorder) types.push('hoverAdjust','hoverBorder');
+      if(area.selectors.activeBorder) types.push('activeAdjust','activeBorder');
       types.forEach(type=>{
         const row = document.createElement('div');
         row.className = 'control-row';
@@ -3258,15 +3261,27 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           text: 'Text',
           headerText: 'Header Text',
           btn: 'Button',
-          btnText: 'Button Text'
+          btnText: 'Button Text',
+          border: 'Border',
+          hoverBorder: 'Hover Border',
+          activeBorder: 'Active Border',
+          hoverAdjust: 'Hover Brightness',
+          activeAdjust: 'Active Brightness'
         };
         const label = labelMap[type] || type;
-        if(type === 'bg' || type === 'card'){
+        if(type === 'bg' || type === 'card' || type === 'border' || type === 'hoverBorder' || type === 'activeBorder'){
           row.innerHTML = `
               <label>${label}</label>
               <div class="color-group">
                 <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
                 <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
+              </div>
+            `;
+        } else if(type === 'hoverAdjust' || type === 'activeAdjust'){
+          row.innerHTML = `
+              <label>${label}</label>
+              <div class="color-group">
+                <input id="${area.key}-${type}" type="range" min="-50" max="50" step="1" value="0" />
               </div>
             `;
         } else {
@@ -3321,6 +3336,10 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function applyAdmin(targetInput){
     if(targetInput && targetInput.id){
       const [areaKey, type] = targetInput.id.split('-');
+      if(['hoverBorder','activeBorder','hoverAdjust','activeAdjust'].includes(type)){
+        applyAdmin();
+        return;
+      }
       const area = colorAreas.find(a=>a.key===areaKey);
       if(area){
         const colorInput = document.getElementById(`${areaKey}-${type}-c`);
@@ -3341,6 +3360,8 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
             } else if(type==='btn'){
               el.style.backgroundColor = color;
               el.style.borderColor = color;
+            } else if(type==='border'){
+              el.style.borderColor = hexToRgba(color, opacity);
             }
           });
         });
@@ -3350,7 +3371,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       return;
     }
     colorAreas.forEach(area=>{
-      ['bg','card','text','headerText','btn','btnText'].forEach(type=>{
+      ['bg','card','text','headerText','btn','btnText','border'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         const f = document.getElementById(`${area.key}-${type}-font`);
@@ -3374,11 +3395,43 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
                 el.style.backgroundColor = color;
                 el.style.borderColor = color;
               }
+            } else if(type==='border'){
+              if(color) el.style.borderColor = hexToRgba(color, opacity);
             }
           });
         });
       });
     });
+    let css = '';
+    colorAreas.forEach(area=>{
+      const hC = document.getElementById(`${area.key}-hoverBorder-c`);
+      const hO = document.getElementById(`${area.key}-hoverBorder-o`);
+      const hA = document.getElementById(`${area.key}-hoverAdjust`);
+      if(area.selectors.hoverBorder && hC){
+        const rgba = hexToRgba(hC.value, hO ? hO.value : 1);
+        const adj = hA ? parseInt(hA.value) : 0;
+        area.selectors.hoverBorder.forEach(sel=>{
+          css += `${sel}{border-color:${rgba};filter:brightness(${100+adj}%);}`;
+        });
+      }
+      const aC = document.getElementById(`${area.key}-activeBorder-c`);
+      const aO = document.getElementById(`${area.key}-activeBorder-o`);
+      const aA = document.getElementById(`${area.key}-activeAdjust`);
+      if(area.selectors.activeBorder && aC){
+        const rgba = hexToRgba(aC.value, aO ? aO.value : 1);
+        const adj = aA ? parseInt(aA.value) : 0;
+        area.selectors.activeBorder.forEach(sel=>{
+          css += `${sel}{border-color:${rgba};filter:brightness(${100+adj}%);}`;
+        });
+      }
+    });
+    let styleEl = document.getElementById('adminDynamicStyles');
+    if(!styleEl){
+      styleEl = document.createElement('style');
+      styleEl.id = 'adminDynamicStyles';
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = css;
     const themeStr = JSON.stringify(collectThemeValues());
     localStorage.setItem('currentTheme', themeStr);
   }
@@ -3386,15 +3439,17 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function collectThemeValues(){
     const data = {};
     colorAreas.forEach(area=>{
-      ['bg','card','text','headerText','btn','btnText'].forEach(type=>{
+      ['bg','card','text','headerText','btn','btnText','border','hoverBorder','activeBorder','hoverAdjust','activeAdjust'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         const f = document.getElementById(`${area.key}-${type}-font`);
         const s = document.getElementById(`${area.key}-${type}-size`);
-        if(c || f || s){
+        const v = document.getElementById(`${area.key}-${type}`);
+        if(c || f || s || v){
           const entry = {};
           if(c){ entry.color = c.value; }
-          if((type==='bg' || type==='card') && o){ entry.opacity = o.value; }
+          if((['bg','card','border','hoverBorder','activeBorder'].includes(type)) && o){ entry.opacity = o.value; }
+          if(v){ entry.value = v.value; }
           if(f){ entry.font = f.value; }
           if(s){ entry.size = s.value; }
           data[`${area.key}-${type}`] = entry;
@@ -3460,8 +3515,10 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const o = document.getElementById(`${areaKey}-${type}-o`);
         const f = document.getElementById(`${areaKey}-${type}-font`);
         const s = document.getElementById(`${areaKey}-${type}-size`);
+        const v = document.getElementById(`${areaKey}-${type}`);
         if(c && val.color){ c.value = val.color; }
-        if((type==='bg' || type==='card') && o && val.opacity!==undefined){ o.value = val.opacity; }
+        if((['bg','card','border','hoverBorder','activeBorder'].includes(type)) && o && val.opacity!==undefined){ o.value = val.opacity; }
+        if(v && val.value!==undefined){ v.value = val.value; }
         if(f && val.font){ f.value = val.font; }
         if(s && val.size){ s.value = val.size; }
       });


### PR DESCRIPTION
## Summary
- add border, hover, and active border controls to Body fieldset
- apply border colors and brightness adjustments via admin panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cd911ba883319830ceb299eb8968