### PR TITLE
Limit fieldset collapse to toggle control

### DIFF
--- a/fieldsetHandler.js
+++ b/fieldsetHandler.js
@@ -1,0 +1,11 @@
+function attachFieldsetHandlers(doc) {
+  doc.addEventListener('click', (e) => {
+    const toggle = e.target.closest('[data-fieldset-toggle]');
+    if (!toggle) return;
+    const fieldset = toggle.closest('fieldset');
+    if (!fieldset) return;
+    fieldset.classList.toggle('collapsed');
+  });
+}
+
+module.exports = { attachFieldsetHandlers };

--- a/test.js
+++ b/test.js
@@ -1,8 +1,57 @@
 const assert = require('assert');
+const { attachFieldsetHandlers } = require('./fieldsetHandler');
 
-function add(a, b) {
-  return a + b;
+class MockClassList {
+  constructor() { this._set = new Set(); }
+  add(cls) { this._set.add(cls); }
+  remove(cls) { this._set.delete(cls); }
+  contains(cls) { return this._set.has(cls); }
+  toggle(cls) { if (this._set.has(cls)) { this._set.delete(cls); return false; } this._set.add(cls); return true; }
 }
 
-assert.strictEqual(add(1, 2), 3);
+class MockElement {
+  constructor({ parent = null, attrs = {}, tag = 'div' } = {}) {
+    this.parentElement = parent;
+    this.attrs = attrs;
+    this.tagName = tag;
+    this.classList = new MockClassList();
+  }
+  closest(selector) {
+    let el = this;
+    while (el) {
+      if (selector === 'fieldset' && el.tagName === 'fieldset') return el;
+      if (selector === '[data-fieldset-toggle]' && 'data-fieldset-toggle' in el.attrs) return el;
+      el = el.parentElement;
+    }
+    return null;
+  }
+}
+
+function createDocument() {
+  const handlers = {};
+  return {
+    addEventListener(type, fn) { handlers[type] = fn; },
+    dispatchEvent(type, event) { if (handlers[type]) handlers[type](event); }
+  };
+}
+
+const document = createDocument();
+attachFieldsetHandlers(document);
+
+const fieldset = new MockElement({ tag: 'fieldset' });
+const toggle = new MockElement({ parent: fieldset, attrs: { 'data-fieldset-toggle': '' }, tag: 'button' });
+const input = new MockElement({ parent: fieldset, tag: 'input' });
+
+document.dispatchEvent('click', { target: input });
+assert.strictEqual(fieldset.classList.contains('collapsed'), false);
+
+document.dispatchEvent('click', { target: toggle });
+assert.strictEqual(fieldset.classList.contains('collapsed'), true);
+
+document.dispatchEvent('click', { target: input });
+assert.strictEqual(fieldset.classList.contains('collapsed'), true);
+
+document.dispatchEvent('click', { target: toggle });
+assert.strictEqual(fieldset.classList.contains('collapsed'), false);
+
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- Add handler that only collapses fieldsets when clicking elements marked with `data-fieldset-toggle`
- Test that clicks inside the fieldset no longer trigger unwanted resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4a9ec388331a6d5eb58e44e598e