### PR TITLE
fix: guard fieldset toggle handler

### DIFF
--- a/fieldsetHandler.js
+++ b/fieldsetHandler.js
@@ -2,10 +2,14 @@ function attachFieldsetHandlers(doc) {
   doc.addEventListener('click', (e) => {
     const toggle = e.target.closest('[data-fieldset-toggle]');
     if (!toggle) return;
+
     const fieldset = toggle.closest('fieldset');
-    if (!fieldset) return;
+    // Honor admin modal settings by ignoring clicks that bubble from
+    // within a fieldset carrying the toggle attribute itself. Only
+    // the dedicated toggle elements should trigger collapsing.
+    if (!fieldset || toggle === fieldset) return;
+
     fieldset.classList.toggle('collapsed');
   });
 }
-
 module.exports = { attachFieldsetHandlers };

--- a/test.js
+++ b/test.js
@@ -54,4 +54,16 @@ assert.strictEqual(fieldset.classList.contains('collapsed'), true);
 document.dispatchEvent('click', { target: toggle });
 assert.strictEqual(fieldset.classList.contains('collapsed'), false);
 
+// Ensure clicks within a fieldset marked with the toggle attribute itself
+// do not inadvertently trigger collapsing when interacting inside.
+const outerFieldset = new MockElement({ tag: 'fieldset', attrs: { 'data-fieldset-toggle': '' } });
+const outerToggle = new MockElement({ parent: outerFieldset, attrs: { 'data-fieldset-toggle': '' }, tag: 'button' });
+const innerInput = new MockElement({ parent: outerFieldset, tag: 'input' });
+
+document.dispatchEvent('click', { target: innerInput });
+assert.strictEqual(outerFieldset.classList.contains('collapsed'), false);
+
+document.dispatchEvent('click', { target: outerToggle });
+assert.strictEqual(outerFieldset.classList.contains('collapsed'), true);
+
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- ignore bubbled clicks from fieldsets carrying `data-fieldset-toggle`
- add regression test for fieldset toggle handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6f7a108448331bc6da65569cc5c82