### PR TITLE
Fix fieldset toggle misfire on non-interactive containers

### DIFF
--- a/fieldsetHandler.js
+++ b/fieldsetHandler.js
@@ -3,11 +3,14 @@ function attachFieldsetHandlers(doc) {
     const toggle = e.target.closest('[data-fieldset-toggle]');
     if (!toggle) return;
 
+    // Ignore generic containers that happen to carry the attribute.
+    // Only explicit interactive elements (e.g. buttons or legends)
+    // should trigger collapsing.
+    const interactiveTags = ['button', 'summary', 'legend'];
+    if (!interactiveTags.includes(toggle.tagName.toLowerCase())) return;
+
     const fieldset = toggle.closest('fieldset');
-    // Honor admin modal settings by ignoring clicks that bubble from
-    // within a fieldset carrying the toggle attribute itself. Only
-    // the dedicated toggle elements should trigger collapsing.
-    if (!fieldset || toggle === fieldset) return;
+    if (!fieldset) return;
 
     fieldset.classList.toggle('collapsed');
   });

--- a/test.js
+++ b/test.js
@@ -66,4 +66,16 @@ assert.strictEqual(outerFieldset.classList.contains('collapsed'), false);
 document.dispatchEvent('click', { target: outerToggle });
 assert.strictEqual(outerFieldset.classList.contains('collapsed'), true);
 
+// Ensure non-interactive wrappers with the toggle attribute do not trigger collapsing.
+const fs = new MockElement({ tag: 'fieldset' });
+const wrapper = new MockElement({ parent: fs, attrs: { 'data-fieldset-toggle': '' }, tag: 'div' });
+const buttonToggle = new MockElement({ parent: wrapper, attrs: { 'data-fieldset-toggle': '' }, tag: 'button' });
+const inner = new MockElement({ parent: wrapper, tag: 'input' });
+
+document.dispatchEvent('click', { target: inner });
+assert.strictEqual(fs.classList.contains('collapsed'), false);
+
+document.dispatchEvent('click', { target: buttonToggle });
+assert.strictEqual(fs.classList.contains('collapsed'), true);
+
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- ensure fieldset collapse only triggers from interactive toggle elements
- add regression test for non-interactive wrappers carrying data-fieldset-toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6fa1f0cdc83319a266a1b7b495e64