### PR TITLE
Update theme organiser before applying theme

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,14 @@
 const { getUserTheme, setUserTheme } = require('./db/theme');
 const { generateTheme } = require('./themeBuilder');
+const { updateFields } = require('./themeOrganiser');
 
 function applyTheme(theme) {
   // Build a full theme palette from the stored base color
   if (theme) {
     const base = theme.data && theme.data.primary ? theme.data.primary : '#336699';
     const generated = generateTheme(base);
+    // Update theme organiser fields before applying to website
+    updateFields(generated);
     console.log(`Applying theme: ${theme.name}`, generated);
   }
 }

--- a/src/themeOrganiser.js
+++ b/src/themeOrganiser.js
@@ -1,0 +1,12 @@
+let fields = {};
+
+function updateFields(newFields) {
+  fields = { ...fields, ...newFields };
+  console.log('Theme organiser updated', fields);
+}
+
+function getFields() {
+  return fields;
+}
+
+module.exports = { updateFields, getFields };

--- a/test.js
+++ b/test.js
@@ -4,11 +4,25 @@ const seed = require('./db/seed');
 const { getUserTheme, setUserTheme } = require('./src/db/theme');
 const { DB_PATH } = require('./src/db');
 const { generateTheme } = require('./src/themeBuilder');
+const { applyTheme } = require('./src/server');
+const { getFields } = require('./src/themeOrganiser');
 
 // Theme builder tests
 const built = generateTheme('#336699');
 assert.strictEqual(built.primary, '#336699');
 assert.ok(typeof built.background === 'string');
+
+// Applying a theme updates organiser before appearance
+const logs = [];
+const originalLog = console.log;
+console.log = (...args) => {
+  logs.push(args.join(' '));
+};
+applyTheme({ name: 'preview', data: { primary: '#123456' } });
+console.log = originalLog;
+assert.ok(logs[0].startsWith('Theme organiser updated'));
+assert.ok(logs[1].startsWith('Applying theme'));
+assert.strictEqual(getFields().primary, '#123456');
 
 // Theme preference tests
 if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH);


### PR DESCRIPTION
## Summary
- Update theme application to sync organiser fields before applying generated theme
- Add theme organiser module to manage and log current theme fields
- Expand tests to verify organiser updates prior to theme application

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72c6360bc8331b2d3df024bea08b3