### PR TITLE
Synchronize theme generator with organiser and expose button text fields

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -13,9 +13,16 @@
   --ink-d: #555;
   --gold: #ffc107;
   --muted: #777;
-    --btn: #fff;
-    --btn-hover: #e0e0e0;
-    --btn-active: #d5d5d5;
+    --primary: #333;
+    --secondary: #fff;
+    --accent: #e0e0e0;
+    --background: #f5f5f5;
+    --text: #333;
+    --button-text: #333;
+    --button-hover-text: #333;
+    --btn: var(--secondary);
+    --btn-hover: var(--accent);
+    --btn-active: var(--accent);
     --btn-2: var(--btn-hover);
     --modal-bg: rgba(0,0,0,0.7);
     --modal-text: #fff;
@@ -71,21 +78,36 @@ html,body{
 body{
   margin: 0;
   font-family: Verdana,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans","Liberation Sans",sans-serif;
-  background: #f5f5f5;
-  color: var(--ink);
+  background: var(--background);
+  color: var(--text);
   overflow: hidden;
   cursor: default;
 }
 
 button,
 [role="button"]{
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  color: var(--ink);
+  background: var(--secondary);
+  border: 1px solid var(--secondary);
+  color: var(--button-text);
   padding: 6px 10px;
   border-radius: 6px;
   cursor: pointer;
   transition: background .2s,border-color .2s,color .2s,transform .05s;
+}
+
+button:hover,
+[role="button"]:hover{
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--button-hover-text);
+}
+
+a{
+  color: var(--primary);
+}
+
+a:hover{
+  color: var(--accent);
 }
 button:active,
 [role="button"]:active{
@@ -1808,6 +1830,34 @@ footer .foot-row .foot-item img {
             <input type="color" id="baseColor" value="#336699" />
             <button type="button" id="generateThemeBtn">Generate</button>
           </div>
+          <div class="modal-field">
+            <label for="primary">Primary</label>
+            <input type="color" id="primary" value="#333333" />
+          </div>
+          <div class="modal-field">
+            <label for="secondary">Secondary</label>
+            <input type="color" id="secondary" value="#ffffff" />
+          </div>
+          <div class="modal-field">
+            <label for="accent">Accent</label>
+            <input type="color" id="accent" value="#e0e0e0" />
+          </div>
+          <div class="modal-field">
+            <label for="background">Background</label>
+            <input type="color" id="background" value="#f5f5f5" />
+          </div>
+          <div class="modal-field">
+            <label for="text">Text</label>
+            <input type="color" id="text" value="#333333" />
+          </div>
+          <div class="modal-field">
+            <label for="buttonText">Button Text</label>
+            <input type="color" id="buttonText" value="#333333" />
+          </div>
+          <div class="modal-field">
+            <label for="buttonHoverText">Button Hover Text</label>
+            <input type="color" id="buttonHoverText" value="#333333" />
+          </div>
           <h3>Theme Customization</h3>
           <div id="styleControls"></div>
         </div>
@@ -3233,7 +3283,16 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     const accent = adjust(baseColor, -30);
     const background = adjust(baseColor, 60);
     const text = luminance(background) > 0.5 ? '#000000' : '#ffffff';
-    return { primary, secondary, accent, background, text };
+    const buttonText = luminance(secondary) > 0.5 ? '#000000' : '#ffffff';
+    const buttonHoverText = luminance(accent) > 0.5 ? '#000000' : '#ffffff';
+    return { primary, secondary, accent, background, text, buttonText, buttonHoverText };
+  }
+
+  function updateFields(theme){
+    Object.entries(theme).forEach(([key,val])=>{
+      const input = document.getElementById(key);
+      if(input) input.value = val;
+    });
   }
 
 
@@ -3633,6 +3692,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         }
       });
     });
+    ['primary','secondary','accent','background','text','buttonText','buttonHoverText'].forEach(id=>{
+      const input = document.getElementById(id);
+      if(input){
+        data[id] = { color: input.value };
+      }
+    });
     return data;
   }
 
@@ -3688,6 +3753,13 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function applyPresetData(data){
       Object.entries(data).forEach(([key,val])=>{
         const [areaKey,type] = key.split('-');
+        if(!type){
+          const input = document.getElementById(key);
+          if(input && val.color){ input.value = val.color; }
+          const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',background:'--background',text:'--text',buttonText:'--button-text',buttonHoverText:'--button-hover-text'};
+          if(varMap[key]) document.documentElement.style.setProperty(varMap[key], val.color);
+          return;
+        }
         const c = document.getElementById(`${areaKey}-${type}-c`);
         const o = document.getElementById(`${areaKey}-${type}-o`);
         const f = document.getElementById(`${areaKey}-${type}-font`);
@@ -3811,8 +3883,39 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   generateThemeBtn && generateThemeBtn.addEventListener('click', ()=>{
     const base = baseColorInput.value;
     const theme = generateTheme(base);
-    document.body.style.backgroundColor = theme.background;
-    document.body.style.color = theme.text;
+    const root = document.documentElement;
+    root.style.setProperty('--primary', theme.primary);
+    root.style.setProperty('--secondary', theme.secondary);
+    root.style.setProperty('--accent', theme.accent);
+    root.style.setProperty('--background', theme.background);
+    root.style.setProperty('--text', theme.text);
+    root.style.setProperty('--btn', theme.secondary);
+    root.style.setProperty('--btn-hover', theme.accent);
+    root.style.setProperty('--btn-active', theme.accent);
+    root.style.setProperty('--ink', theme.text);
+    root.style.setProperty('--ink-d', theme.text);
+    root.style.setProperty('--button-text', theme.buttonText);
+    root.style.setProperty('--button-hover-text', theme.buttonHoverText);
+    updateFields(theme);
+  });
+
+  const fieldBindings = {
+    primary: '--primary',
+    secondary: '--secondary',
+    accent: '--accent',
+    background: '--background',
+    text: '--text',
+    buttonText: '--button-text',
+    buttonHoverText: '--button-hover-text'
+  };
+  Object.entries(fieldBindings).forEach(([id, varName])=>{
+    const el = document.getElementById(id);
+    if(el){
+      el.addEventListener('input', e=>{
+        document.documentElement.style.setProperty(varName, e.target.value);
+        updateFields({ [id]: e.target.value });
+      });
+    }
   });
 
   const palette = document.getElementById('fieldPalette');

--- a/src/themeBuilder.js
+++ b/src/themeBuilder.js
@@ -39,7 +39,9 @@ function generateTheme(baseColor) {
   const accent = adjust(baseColor, -30);
   const background = adjust(baseColor, 60);
   const text = luminance(background) > 0.5 ? '#000000' : '#ffffff';
-  return { primary, secondary, accent, background, text };
+  const buttonText = luminance(secondary) > 0.5 ? '#000000' : '#ffffff';
+  const buttonHoverText = luminance(accent) > 0.5 ? '#000000' : '#ffffff';
+  return { primary, secondary, accent, background, text, buttonText, buttonHoverText };
 }
 
 module.exports = { generateTheme };

--- a/test.js
+++ b/test.js
@@ -11,6 +11,8 @@ const { getFields } = require('./src/themeOrganiser');
 const built = generateTheme('#336699');
 assert.strictEqual(built.primary, '#336699');
 assert.ok(typeof built.background === 'string');
+assert.ok(typeof built.buttonText === 'string');
+assert.ok(typeof built.buttonHoverText === 'string');
 
 // Applying a theme updates organiser before appearance
 const logs = [];


### PR DESCRIPTION
## Summary
- extend theme generator to return button text and hover text colors
- add primary/accent/etc. inputs and button text controls to admin modal
- sync theme organiser fields with generated themes and manual color edits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72ef8632483319bb909d90263a543