### PR TITLE
fix: uniform fieldset spacing in theme builder modal

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -279,6 +279,7 @@ button:focus-visible,
   min-width:180px;
   max-width:260px;
 }
+#adminModal .admin-fieldset > * + *{margin-top:10px;}
   #adminModal .modal-content,
   #memberModal .modal-content{
     width:100%;
@@ -318,9 +319,9 @@ button:focus-visible,
   }
 }
 #adminModal legend{font-weight:600;padding:0 6px;display:flex;align-items:center;justify-content:flex-start;cursor:pointer;user-select:none;}
-#adminModal .fieldset-actions{display:flex;gap:4px;margin:4px 6px;}
+#adminModal .fieldset-actions{display:flex;gap:4px;margin:0;}
 #adminModal .fieldset-actions .same-btn{flex:1 1 0;padding:6px;}
-#adminModal .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
+#adminModal .control-row{display:flex;align-items:center;gap:6px;margin:0;}
 #adminModal .control-row label{min-width:80px;font-size:12px;cursor:pointer;user-select:none;}
 #adminModal .color-group{
   flex:1 1 220px;


### PR DESCRIPTION
## Summary
- ensure consistent 10px spacing between all elements inside admin modal fieldsets
- normalize margins for action buttons and field rows in theme builder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7720cebe4833182d0f0dbd2cbf1d0