### PR TITLE
Use Mapbox geocoder and geolocate controls

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -821,15 +821,6 @@ button:focus-visible,
   inset: 0;
 }
 
-#mapControls{
-  position:absolute;
-  top:10px;
-  left:10px;
-  z-index:1;
-  padding:10px;
-  margin:0;
-}
-
 .map-overlay{
   position: absolute;
   inset: 0;
@@ -1763,13 +1754,6 @@ footer .foot-row .foot-item img {
 
     <section class="map-wrap" aria-label="Map">
       <div id="map"></div>
-      <div id="mapControls" class="field" role="search">
-        <div class="input">
-          <input id="locationInput" type="text" placeholder="Enter a city or address and press Enter" aria-label="Location" />
-          <div class="x" role="button" aria-label="Clear location">X</div>
-        </div>
-        <div id="btnGeo" class="tiny" role="button" aria-label="Find my location">Locate</div>
-      </div>
       <div class="map-overlay">Loading Map…</div>
     </section>
     <section class="posts-mode" aria-label="Posts">
@@ -1960,7 +1944,7 @@ footer .foot-row .foot-item img {
     const startCenter = savedView?.center || [0,0];
     const startZoom = savedView?.zoom || 1.5;
     const startPitch = savedView?.pitch || 0;
-    let map, spinning = false,
+    let map, geocoder, spinning = false,
         spinLoadStart = JSON.parse(localStorage.getItem('spinLoadStart') ?? 'false'),
         spinLoadType = localStorage.getItem('spinLoadType') || 'all',
         spinLogoClick = JSON.parse(localStorage.getItem('spinLogoClick') || 'true'),
@@ -2378,7 +2362,7 @@ function makePosts(){
       selection.cats.clear(); selection.subs.clear();
       $$('.cat').forEach(el=>el.setAttribute('aria-expanded','false'));
       $$('.chip.on').forEach(ch=>ch.classList.remove('on'));
-      $('#kwInput').value=''; $('#dateInput').value='This month'; $('#locationInput').value='';
+      $('#kwInput').value=''; $('#dateInput').value='This month'; if(geocoder) geocoder.clear();
       applyFilters();
     });
 
@@ -2417,11 +2401,17 @@ function makePosts(){
 
     // Mapbox
     function loadMapbox(cb){
-      if(window.mapboxgl) return cb();
+      if(window.mapboxgl && window.MapboxGeocoder) return cb();
       const link = document.createElement('link'); link.rel='stylesheet'; link.href='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css';
       document.head.appendChild(link);
+      const gLink = document.createElement('link'); gLink.rel='stylesheet'; gLink.href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.css';
+      document.head.appendChild(gLink);
       const s = document.createElement('script'); s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
-      s.onload = cb; document.head.appendChild(s);
+      s.onload = ()=>{
+        const g = document.createElement('script'); g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.min.js';
+        g.onload = cb; document.head.appendChild(g);
+      };
+      document.head.appendChild(s);
     }
     loadMapbox(initMap);
 
@@ -2436,6 +2426,17 @@ function makePosts(){
         pitch: startPitch,
         attributionControl:true
       });
+      geocoder = new MapboxGeocoder({
+        accessToken: mapboxgl.accessToken,
+        mapboxgl,
+        marker: false,
+        placeholder: 'Try: Federation Square, Swanston St & Flinders St, Melbourne VIC 3000, Australia'
+      });
+      geocoder.on('result', ()=>{ stopSpin(); applyFilters(); });
+      map.addControl(geocoder, 'top-left');
+      const geolocate = new mapboxgl.GeolocateControl({ positionOptions:{ enableHighAccuracy:true }, trackUserLocation:true });
+      geolocate.on('geolocate', stopSpin);
+      map.addControl(geolocate, 'top-left');
       try{
         map.scrollZoom.setWheelZoomRate(1/240);
         map.scrollZoom.setZoomRate(1/240);
@@ -2510,36 +2511,6 @@ function makePosts(){
       updateSpinState,
       updateLogoClickState
     };
-
-    $('#btnGeo').addEventListener('click', ()=>{
-      stopSpin();
-      if(navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(pos=>{
-          const {longitude:lng, latitude:lat} = pos.coords;
-          if(map) map.flyTo({center:[lng,lat], zoom:10});
-        });
-      }
-    });
-
-    // Geocode
-    const locInput = $('#locationInput');
-    locInput.placeholder = 'Try: Federation Square, Swanston St & Flinders St, Melbourne VIC 3000, Australia';
-    locInput.addEventListener('keydown', async (e)=>{
-      if(e.key !== 'Enter') return;
-      const q = locInput.value.trim(); if(!q) return;
-      try{
-        locInput.disabled = true;
-        const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${MAPBOX_TOKEN}&limit=1`;
-        const res = await fetch(url);
-        const data = await res.json();
-        const f = data.features && data.features[0];
-        if(f && f.center){
-          stopSpin(); map.flyTo({center:f.center, zoom: Math.max(8, map.getZoom())});
-          await sleep(500); applyFilters(); locInput.style.borderColor = '#1ee6a1';
-        } else { locInput.style.borderColor = '#ff6b6b'; }
-      }catch(err){ console.error(err); locInput.style.borderColor = '#ff6b6b'; }
-      finally{ setTimeout(()=>{locInput.style.borderColor=''; locInput.disabled=false;}, 900); }
-    });
 
     // Map layers
     function postsToGeoJSON(list){


### PR DESCRIPTION
## Summary
- remove custom location input and geolocate button from map
- load Mapbox Geocoder plugin and GeolocateControl
- clear geocoder search on filter reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a778ce63788331b27f186608feb19d