### PR TITLE
Enable full-edge modal resizing and fix hidden map

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -263,9 +263,17 @@ button:focus-visible,
   display:flex;
   flex-direction:column;
   overflow:hidden;
-  resize:both;
   pointer-events:auto;
 }
+.modal-content .resizer{position:absolute;z-index:10;background:transparent;}
+.modal-content .resizer.n{top:0;left:0;right:0;height:6px;cursor:n-resize;}
+.modal-content .resizer.s{bottom:0;left:0;right:0;height:6px;cursor:s-resize;}
+.modal-content .resizer.e{top:0;right:0;bottom:0;width:6px;cursor:e-resize;}
+.modal-content .resizer.w{top:0;left:0;bottom:0;width:6px;cursor:w-resize;}
+.modal-content .resizer.ne{top:0;right:0;width:10px;height:10px;cursor:ne-resize;}
+.modal-content .resizer.nw{top:0;left:0;width:10px;height:10px;cursor:nw-resize;}
+.modal-content .resizer.se{bottom:0;right:0;width:10px;height:10px;cursor:se-resize;}
+.modal-content .resizer.sw{bottom:0;left:0;width:10px;height:10px;cursor:sw-resize;}
 .modal-body{
   flex:1 1 auto;
   overflow:auto;
@@ -504,6 +512,7 @@ button:focus-visible,
     height: calc(100vh - var(--header-h) - var(--footer-h));
     display: grid;
     grid-template-columns: var(--results-w) 1fr;
+    grid-template-rows: 1fr;
     gap: var(--gap);
     padding: 14px;
   }
@@ -1327,6 +1336,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 
 .main .map-wrap{
   position: relative;
+  height: 100%;
 }
 
 .main .posts-mode{
@@ -1393,7 +1403,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     .gear{width:36px;height:36px;border-radius:10px;background:rgba(255,255,255,0.2);display:grid;place-items:center}
     .gear svg{width:18px;height:18px;opacity:.9}
 
-    .main{height:calc(100% - var(--header-h) - var(--footer-h));display:grid;grid-template-columns:var(--results-w) 1fr;gap:var(--gap);padding:14px}
+    .main{height:calc(100% - var(--header-h) - var(--footer-h));display:grid;grid-template-columns:var(--results-w) 1fr;grid-template-rows:1fr;gap:var(--gap);padding:14px}
     .filters-col{display:flex;flex-direction:column;min-height:0}
     .left-tools{display:flex;gap:8px;margin-bottom:8px;padding-left:2px}
     .sq{width:30px;height:30px;border-radius:8px;background:var(--btn);display:grid;place-items:center;border:none}
@@ -1435,7 +1445,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     .fav svg{width:18px;height:18px;fill:none;stroke:var(--gold);stroke-width:1.5}
     .fav[aria-pressed="true"] svg{fill:var(--gold);stroke:var(--gold)}
 
-    .map-wrap{position:relative;background:var(--btn);border-radius:16px;overflow:hidden;border:1px solid var(--border)}
+    .map-wrap{position:relative;background:var(--btn);border-radius:16px;overflow:hidden;border:1px solid var(--border);height:100%}
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
 
@@ -3184,6 +3194,57 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
       }
+
+    const handles = ['n','e','s','w','ne','nw','se','sw'];
+    handles.forEach(dir=>{
+      const h = document.createElement('div');
+      h.className = 'resizer ' + dir;
+      content.appendChild(h);
+      h.addEventListener('mousedown', e=> initResize(e, dir));
+    });
+    let startX, startY, startW, startH, startL, startT, resizeDir;
+    function initResize(e, dir){
+      e.preventDefault();
+      e.stopPropagation();
+      resizeDir = dir;
+      const rect = content.getBoundingClientRect();
+      startX = e.clientX;
+      startY = e.clientY;
+      startW = rect.width;
+      startH = rect.height;
+      startL = rect.left;
+      startT = rect.top;
+      content.style.left = `${startL}px`;
+      content.style.top = `${startT}px`;
+      content.style.transform = 'none';
+      document.addEventListener('mousemove', onResize);
+      document.addEventListener('mouseup', stopResize);
+    }
+    const minW = 200, minH = 150;
+    function onResize(e){
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      if(resizeDir.includes('e')){
+        content.style.width = `${Math.max(minW, startW + dx)}px`;
+      }
+      if(resizeDir.includes('s')){
+        content.style.height = `${Math.max(minH, startH + dy)}px`;
+      }
+      if(resizeDir.includes('w')){
+        const newW = Math.max(minW, startW - dx);
+        content.style.width = `${newW}px`;
+        content.style.left = `${startL + dx}px`;
+      }
+      if(resizeDir.includes('n')){
+        const newH = Math.max(minH, startH - dy);
+        content.style.height = `${newH}px`;
+        content.style.top = `${startT + dy}px`;
+      }
+    }
+    function stopResize(){
+      document.removeEventListener('mousemove', onResize);
+      document.removeEventListener('mouseup', stopResize);
+    }
   });
 
   const adminTabs = document.querySelectorAll('#adminModal .tab-bar button');


### PR DESCRIPTION
## Summary
- Allow modals to be resized from any edge or corner with new resize handles and logic
- Ensure main layout uses a fixed row and map container fills available space, restoring the map display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77c048bac83318f3aa9dcec3d0671