### PR TITLE
Place geolocate control next to search and disable unwanted spin

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1448,7 +1448,8 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     .map-wrap{position:relative;background:var(--btn);border-radius:16px;overflow:hidden;border:1px solid var(--border);height:100%}
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
-    .geocoder{position:absolute;top:10px;left:10px;z-index:10;min-width:240px}
+    .geocoder{position:absolute;top:10px;left:10px;z-index:10;min-width:240px;display:flex;gap:4px}
+    .geocoder .mapboxgl-ctrl-geocoder{flex:1}
 
     .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:0 6px;color:#000;background:rgba(0,0,0,0.7)}
     .posts-mode .res-list{overflow:visible;padding:12px 0 0}
@@ -2455,9 +2456,9 @@ function makePosts(){
           accessToken: mapboxgl.accessToken,
           mapboxgl,
           marker: false,
-          placeholder: 'Try: Federation Square, Swanston St & Flinders St, Melbourne VIC 3000, Australia'
+          placeholder: 'Search Location'
         });
-        geocoder.on('result', ()=>{ stopSpin(); applyFilters(); });
+        geocoder.on('result', ()=>{ spinEnabled = false; localStorage.setItem('spinGlobe','false'); stopSpin(); applyFilters(); });
         const gc = document.getElementById('geocoder');
         if(gc) gc.appendChild(geocoder.onAdd(map));
       } else {
@@ -2486,8 +2487,9 @@ function makePosts(){
       });
       addGeocoder();
       const geolocate = new mapboxgl.GeolocateControl({ positionOptions:{ enableHighAccuracy:true }, trackUserLocation:true });
-      geolocate.on('geolocate', stopSpin);
-      map.addControl(geolocate, 'top-right');
+      geolocate.on('geolocate', ()=>{ spinEnabled = false; localStorage.setItem('spinGlobe','false'); stopSpin(); });
+      const geoContainer = document.getElementById('geocoder');
+      if(geoContainer) geoContainer.appendChild(geolocate.onAdd(map));
       try{
         map.scrollZoom.setWheelZoomRate(1/240);
         map.scrollZoom.setZoomRate(1/240);


### PR DESCRIPTION
## Summary
- Align geolocate button immediately to the right of the address box
- Replace search placeholder with "Search Location"
- Prevent globe spin from reactivating after geolocation or search results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7853787d08331ac5f377927f1a17b