### PR TITLE
Fix geocoder suggestions overlay

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1449,9 +1449,26 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     #map{position:absolute;inset:0}
     .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
     .geocoder{position:absolute;top:10px;left:10px;z-index:10;min-width:240px;display:flex;gap:4px}
-    .geocoder .mapboxgl-ctrl-geocoder{flex:1}
+    .geocoder .mapboxgl-ctrl-geocoder{flex:1;position:relative}
     .geocoder .mapboxgl-ctrl-group{height:40px;width:40px;box-shadow:none}
     .geocoder .mapboxgl-ctrl-geolocate{width:100%;height:100%;margin:0;padding:0;border:1px solid var(--border);border-radius:4px;background:#fff;display:flex;align-items:center;justify-content:center;background-position:center;background-size:20px 20px}
+    .geocoder .mapboxgl-ctrl-geocoder--suggestions,
+    .geocoder .mapboxgl-ctrl-geocoder .suggestions{
+      position:absolute;
+      top:100%;
+      left:0;
+      width:100%;
+      margin-top:4px;
+      background:#fff;
+      border:1px solid var(--border);
+      border-radius:4px;
+      box-shadow:0 2px 4px rgba(0,0,0,0.1);
+      z-index:5;
+    }
+    .geocoder .mapboxgl-ctrl-geocoder .suggestions li{
+      background:#fff;
+      color:#000;
+    }
 
     .posts-mode{display:none;height:100%;overflow:auto;min-height:0;padding:0 6px;color:#000;background:rgba(0,0,0,0.7)}
     .posts-mode .res-list{overflow:visible;padding:12px 0 0}


### PR DESCRIPTION
## Summary
- ensure Mapbox geocoder suggestions dropdown is styled and positioned correctly
- prevent black rectangle overlay when typing in the address bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78bc1a7d08331a3fee5c0872951cf