### PR TITLE
Fix admin modal map style scope

### DIFF
--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1993,7 +1993,7 @@ footer .foot-row .foot-item img {
           spinLogoClick = JSON.parse(localStorage.getItem('spinLogoClick') || 'true'),
           spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),
           spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
-          mapStyle = localStorage.getItem('mapStyle') || 'mapbox://styles/mapbox/outdoors-v12';
+          mapStyle = window.mapStyle = localStorage.getItem('mapStyle') || 'mapbox://styles/mapbox/outdoors-v12';
       localStorage.setItem('spinGlobe', JSON.stringify(spinEnabled));
       const logoEl = document.querySelector('.logo');
       function updateLogoClickState(){
@@ -4062,9 +4062,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         if(themeSelect){
           themeSelect.value = mapStyle;
           themeSelect.addEventListener("change", ()=>{
-            mapStyle = themeSelect.value;
+            mapStyle = window.mapStyle = themeSelect.value;
             localStorage.setItem("mapStyle", mapStyle);
-            if(map) map.setStyle(mapStyle);
+            if(window.map) window.map.setStyle(mapStyle);
           });
         }
         if(speedInput && speedVal){


### PR DESCRIPTION
## Summary
- expose `mapStyle` to `window` so admin controls can access current map theme
- update admin theme selector to keep global map style in sync

## Testing
- `npm test`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a79269e3c88331a03d62cdcb517ea5