### PR TITLE
Validate theme color input

### DIFF
--- a/src/themeBuilder.js
+++ b/src/themeBuilder.js
@@ -33,15 +33,22 @@ function luminance(hex) {
   return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
 }
 
+const DEFAULT_BASE_COLOR = '#336699';
+
+function isValidHex(hex) {
+  return /^#([0-9a-fA-F]{6})$/.test(hex);
+}
+
 function generateTheme(baseColor) {
-  const primary = baseColor;
-  const secondary = adjust(baseColor, 30);
-  const accent = adjust(baseColor, -30);
-  const background = adjust(baseColor, 60);
+  const base = isValidHex(baseColor) ? baseColor : DEFAULT_BASE_COLOR;
+  const primary = base;
+  const secondary = adjust(base, 30);
+  const accent = adjust(base, -30);
+  const background = adjust(base, 60);
   const text = luminance(background) > 0.5 ? '#000000' : '#ffffff';
   const buttonText = luminance(secondary) > 0.5 ? '#000000' : '#ffffff';
   const buttonHoverText = luminance(accent) > 0.5 ? '#000000' : '#ffffff';
   return { primary, secondary, accent, background, text, buttonText, buttonHoverText };
 }
 
-module.exports = { generateTheme };
+module.exports = { generateTheme, DEFAULT_BASE_COLOR };

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const seed = require('./db/seed');
 const { getUserTheme, setUserTheme } = require('./src/db/theme');
 const { DB_PATH } = require('./src/db');
-const { generateTheme } = require('./src/themeBuilder');
+const { generateTheme, DEFAULT_BASE_COLOR } = require('./src/themeBuilder');
 const { applyTheme } = require('./src/server');
 const { getFields } = require('./src/themeOrganiser');
 
@@ -13,6 +13,10 @@ assert.strictEqual(built.primary, '#336699');
 assert.ok(typeof built.background === 'string');
 assert.ok(typeof built.buttonText === 'string');
 assert.ok(typeof built.buttonHoverText === 'string');
+
+// Invalid color falls back to default
+const fallbackTheme = generateTheme('blue');
+assert.strictEqual(fallbackTheme.primary, DEFAULT_BASE_COLOR);
 
 // Applying a theme updates organiser before appearance
 const logs = [];


### PR DESCRIPTION
## Summary
- guard theme generation against invalid color strings and fallback to a default palette
- add regression test for invalid color input

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7c436852c8331a20be41c111c545e