### PR TITLE
feat: add admin tab backups and save controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+db/database.json

--- a/ChatGPT-to-Codex-2025-08-18.html
+++ b/ChatGPT-to-Codex-2025-08-18.html
@@ -1897,6 +1897,8 @@ footer .foot-row .foot-item img {
         <div class="header-top">
           <h2>Admin Settings</h2>
           <div class="modal-actions">
+            <button type="button" id="discardChanges">Discard Changes</button>
+            <button type="button" id="saveNow">Save Now</button>
             <button type="button" class="close-modal">Close</button>
           </div>
         </div>
@@ -1928,6 +1930,11 @@ footer .foot-row .foot-item img {
           </div>
           <h3>Theme Builder</h3>
           <div id="styleControls"></div>
+          <div class="modal-field">
+            <label for="themeRestore">Restore Backup</label>
+            <select id="themeRestore"></select>
+            <button type="button" data-restore="theme">Restore</button>
+          </div>
         </div>
           <div id="tab-mapbox" class="tab-panel">
             <div class="modal-field">
@@ -2009,6 +2016,11 @@ footer .foot-row .foot-item img {
           <div class="modal-field">
             <label><input type="checkbox" id="spinLogoClick"> Start on logo click</label>
           </div>
+          <div class="modal-field">
+            <label for="mapboxRestore">Restore Backup</label>
+            <select id="mapboxRestore"></select>
+            <button type="button" data-restore="mapbox">Restore</button>
+          </div>
         </div>
         <div id="tab-settings" class="tab-panel">
           <div class="modal-field">
@@ -2031,6 +2043,11 @@ footer .foot-row .foot-item img {
             <div class="field-item" draggable="true" data-type="location">Location</div>
           </div>
           <div id="formBuilder" class="builder-zone" aria-label="Form fields drop zone"></div>
+          <div class="modal-field">
+            <label for="settingsRestore">Restore Backup</label>
+            <select id="settingsRestore"></select>
+            <button type="button" data-restore="settings">Restore</button>
+          </div>
         </div>
       </form>
     </div>
@@ -4265,6 +4282,112 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           applyAdmin(e.target);
         });
     }
+
+    // Save/Discard/Restore logic
+    const saveBtn = document.getElementById('saveNow');
+    const discardBtn = document.getElementById('discardChanges');
+    const adminClose = document.querySelector('#adminModal .close-modal');
+    const tabPanels = ['theme','mapbox','settings'];
+    const savedData = {};
+
+    function snapshot(tab){
+      const panel = document.getElementById(`tab-${tab}`);
+      const inputs = panel.querySelectorAll('input,select,textarea');
+      const data = {};
+      inputs.forEach(el=>{
+        if(!el.id && el.name) el.id = el.name; // ensure key
+        if(el.type === 'checkbox') data[el.id] = el.checked;
+        else if(el.type === 'radio'){ if(el.checked) data[el.name] = el.value; }
+        else data[el.id] = el.value;
+      });
+      return data;
+    }
+
+    function applyData(tab,data){
+      const panel = document.getElementById(`tab-${tab}`);
+      Object.entries(data||{}).forEach(([id,val])=>{
+        const el = panel.querySelector(`#${id}`);
+        if(!el) return;
+        if(el.type === 'checkbox') el.checked = !!val;
+        else if(el.type === 'radio'){
+          const r = panel.querySelector(`input[name="${id}"][value="${val}"]`);
+          if(r) r.checked = true;
+        } else {
+          el.value = val;
+        }
+      });
+    }
+
+    function populateBackups(tab){
+      const select = document.getElementById(`${tab}Restore`);
+      if(!select) return;
+      const backups = JSON.parse(localStorage.getItem(`admin-${tab}-backups`) || '[]');
+      select.innerHTML = '';
+      backups.slice().reverse().forEach((b,i)=>{
+        const opt = document.createElement('option');
+        opt.value = backups.length - 1 - i;
+        opt.textContent = b.name;
+        select.appendChild(opt);
+      });
+    }
+
+    function loadSaved(){
+      tabPanels.forEach(tab=>{
+        const raw = localStorage.getItem(`admin-${tab}-current`);
+        if(raw){
+          savedData[tab] = JSON.parse(raw);
+          applyData(tab, savedData[tab]);
+        } else {
+          savedData[tab] = snapshot(tab);
+        }
+        populateBackups(tab);
+      });
+    }
+
+    function saveTab(tab){
+      const data = snapshot(tab);
+      if(JSON.stringify(data) === JSON.stringify(savedData[tab])) return false;
+      savedData[tab] = data;
+      localStorage.setItem(`admin-${tab}-current`, JSON.stringify(data));
+      const backups = JSON.parse(localStorage.getItem(`admin-${tab}-backups`) || '[]');
+      backups.push({ name:`ADMIN ${tab} Backup ${new Date().toISOString()}`, data });
+      localStorage.setItem(`admin-${tab}-backups`, JSON.stringify(backups));
+      populateBackups(tab);
+      return true;
+    }
+
+    saveBtn && saveBtn.addEventListener('click', ()=>{
+      let changed = false;
+      tabPanels.forEach(tab=>{ if(saveTab(tab)) changed = true; });
+      alert(changed ? 'Saved' : 'No changes were made');
+    });
+
+    discardBtn && discardBtn.addEventListener('click', ()=>{
+      if(!confirm('Are you sure you want to Discard Your Changes?')) return;
+      tabPanels.forEach(tab=> applyData(tab, savedData[tab]));
+    });
+
+    adminClose && adminClose.addEventListener('click', ()=>{
+      let changed = false;
+      tabPanels.forEach(tab=>{ if(saveTab(tab)) changed = true; });
+      alert(changed ? 'Saved' : 'No changes were made');
+    });
+
+    document.querySelectorAll('button[data-restore]').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const tab = btn.dataset.restore;
+        const select = document.getElementById(`${tab}Restore`);
+        const idx = parseInt(select.value,10);
+        const backups = JSON.parse(localStorage.getItem(`admin-${tab}-backups`) || '[]');
+        const backup = backups[idx];
+        if(backup){
+          applyData(tab, backup.data);
+          saveTab(tab);
+        }
+      });
+    });
+
+    loadSaved();
 
   const presetSelect = document.getElementById('themePreset');
   presetSelect && presetSelect.addEventListener('change', e=>{

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -16,3 +16,73 @@ CREATE TABLE user_theme_preferences (
   FOREIGN KEY(user_id) REFERENCES users(id),
   FOREIGN KEY(theme_id) REFERENCES themes(id)
 );
+
+-- Admin tables for each settings tab
+CREATE TABLE admin_theme (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  primary TEXT,
+  secondary TEXT,
+  accent TEXT,
+  background TEXT,
+  text TEXT,
+  button_text TEXT,
+  button_hover_text TEXT,
+  saved_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE admin_mapbox (
+  id INTEGER PRIMARY KEY,
+  map_theme TEXT,
+  sky_theme TEXT,
+  spin_speed REAL,
+  map_pitch INTEGER,
+  map_bearing INTEGER,
+  spin_load_start INTEGER,
+  spin_type TEXT,
+  spin_logo_click INTEGER,
+  saved_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE admin_settings (
+  id INTEGER PRIMARY KEY,
+  categories TEXT,
+  subcategories TEXT,
+  color TEXT,
+  saved_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Backup tables for version control
+CREATE TABLE admin_theme_backups (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  primary TEXT,
+  secondary TEXT,
+  accent TEXT,
+  background TEXT,
+  text TEXT,
+  button_text TEXT,
+  button_hover_text TEXT,
+  saved_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE admin_mapbox_backups (
+  id INTEGER PRIMARY KEY,
+  map_theme TEXT,
+  sky_theme TEXT,
+  spin_speed REAL,
+  map_pitch INTEGER,
+  map_bearing INTEGER,
+  spin_load_start INTEGER,
+  spin_type TEXT,
+  spin_logo_click INTEGER,
+  saved_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE admin_settings_backups (
+  id INTEGER PRIMARY KEY,
+  categories TEXT,
+  subcategories TEXT,
+  color TEXT,
+  saved_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/db/admin.js
+++ b/src/db/admin.js
@@ -1,0 +1,36 @@
+const { read, write } = require('./index');
+
+function saveTab(tab, data) {
+  const db = read();
+  const tableName = `admin_${tab}`;
+  const backupTable = `${tableName}_backups`;
+  db[tableName] = db[tableName] || [];
+  db[backupTable] = db[backupTable] || [];
+  const id = (db[tableName][db[tableName].length - 1]?.id || 0) + 1;
+  const record = { id, ...data, saved_at: new Date().toISOString() };
+  db[tableName].push(record);
+  db[backupTable].push(record);
+  write(db);
+  return record;
+}
+
+function listBackups(tab) {
+  const db = read();
+  return db[`admin_${tab}_backups`] || [];
+}
+
+function restoreBackup(tab, id) {
+  const db = read();
+  const backupTable = `admin_${tab}_backups`;
+  const tableName = `admin_${tab}`;
+  const backup = (db[backupTable] || []).find(b => b.id === id);
+  if (!backup) return null;
+  db[tableName] = db[tableName] || [];
+  const newId = (db[tableName][db[tableName].length - 1]?.id || 0) + 1;
+  const record = { ...backup, id: newId, restored_at: new Date().toISOString() };
+  db[tableName].push(record);
+  write(db);
+  return record;
+}
+
+module.exports = { saveTab, listBackups, restoreBackup };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -8,7 +8,13 @@ function ensureDb() {
     const initial = {
       users: [],
       themes: [],
-      user_theme_preferences: []
+      user_theme_preferences: [],
+      admin_theme: [],
+      admin_mapbox: [],
+      admin_settings: [],
+      admin_theme_backups: [],
+      admin_mapbox_backups: [],
+      admin_settings_backups: []
     };
     fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
     fs.writeFileSync(DB_PATH, JSON.stringify(initial, null, 2));

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const seed = require('./db/seed');
 const { getUserTheme, setUserTheme } = require('./src/db/theme');
 const { DB_PATH } = require('./src/db');
+const { saveTab, listBackups, restoreBackup } = require('./src/db/admin');
 const { generateTheme, DEFAULT_BASE_COLOR } = require('./src/themeBuilder');
 const { applyTheme } = require('./src/server');
 const { getFields } = require('./src/themeOrganiser');
@@ -46,5 +47,12 @@ assert.strictEqual(updated.data.color, '#fff');
 // Switch back to light theme
 const changed = setUserTheme(1, 1);
 assert.strictEqual(changed.name, 'light');
+
+// Admin tab backup tests
+const themeSave = saveTab('theme', { name: 'test', primary: '#000000' });
+assert.strictEqual(themeSave.id, 1);
+assert.ok(listBackups('theme').length === 1);
+const restored = restoreBackup('theme', themeSave.id);
+assert.strictEqual(restored.id, 2);
 
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- add database tables and JSON storage for theme, mapbox and settings tabs with backup tables
- provide admin helper to save, list and restore tab data
- enhance admin modal UI with Save Now/Discard buttons and restore dropdowns with local backup logic

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7e215b3a083319e8455b269d6188e