### PR TITLE
feat: add open post theme settings and cleanup UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1763,10 +1763,10 @@ footer .foot-row .foot-item img {
     border-color: var(--btn);
   }
   .detail-inline{ overflow:visible; }
-  .detail-header{ display:flex; justify-content:space-between; align-items:center; padding:8px 12px; position:sticky; top:0; background:var(--list-background); z-index:3; }
+  .detail-header{ display:flex; justify-content:space-between; align-items:center; padding:8px 12px; position:sticky; top:0; z-index:3; }
   .detail-header .title{ font-size:20px; font-weight:700; margin:0; }
   .detail-header .sub{ font-size:14px; color:var(--muted); }
-  .image-row{ display:flex; gap:8px; overflow-x:auto; padding:8px 12px; position:sticky; top:56px; background:var(--list-background); z-index:2; }
+  .image-row{ display:flex; gap:8px; overflow-x:auto; padding:8px 12px; position:sticky; top:56px; z-index:2; }
   .image-row img{ height:400px; object-fit:cover; cursor:pointer; }
   .map-calendar{ display:flex; gap:12px; padding:8px 12px; }
   .map-container{ width:300px; height:200px; }
@@ -3556,7 +3556,8 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'subheader', label:'Subheader', selectors:{bg:['.res-head'], text:['.res-head'], btn:['.res-head button'], btnText:['.res-head button']}},
     {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
     {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], title:['.results-col .card .t','.results-col .card .title'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
-    {key:'posts', label:'Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], title:['.posts-mode .card .t','.posts-mode .card .title','.posts-mode .detail-inline .t','.posts-mode .detail-inline .title'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card','.posts-mode .detail-inline']}},
+    {key:'closedPosts', label:'Closed Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], title:['.posts-mode .card .t','.posts-mode .card .title'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card']}},
+    {key:'openPosts', label:'Open Posts', selectors:{bg:['.detail-inline'], text:['.detail-inline','.detail-inline *'], title:['.detail-inline .t','.detail-inline .title'], btn:['.detail-inline button'], btnText:['.detail-inline button'], card:['.detail-inline']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['#map'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup.hover-pop .hover-card'], text:['.mapboxgl-popup.hover-pop .hover-card'], title:['.mapboxgl-popup.hover-pop .hover-card .t','.mapboxgl-popup.hover-pop .hover-card .title']}},
     {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], title:['#filterModal .modal-content .t','#filterModal .modal-content .title'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},


### PR DESCRIPTION
## Summary
- remove background from open post header and image row
- rename theme builder Posts section to Closed Posts
- add theme builder fieldset for Open Posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f4b8d25483318827ee4be6dedcf1