### PR TITLE
Add configurable background for open posts header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1763,7 +1763,7 @@ footer .foot-row .foot-item img {
     border-color: var(--btn);
   }
   .detail-inline{ overflow:visible; }
-  .detail-header{ display:flex; justify-content:space-between; align-items:center; padding:8px 12px; position:sticky; top:0; z-index:3; }
+  .detail-header{ display:flex; justify-content:space-between; align-items:center; padding:8px 12px; position:sticky; top:0; z-index:3; background-size:cover; background-position:center; background-blend-mode:multiply; }
   .detail-header .title{ font-size:20px; font-weight:700; margin:0; }
   .detail-header .sub{ font-size:14px; color:var(--muted); }
   .image-row{ display:flex; gap:8px; overflow-x:auto; padding:8px 12px; position:sticky; top:56px; z-index:2; }
@@ -3111,9 +3111,10 @@ function makePosts(){
       const wrap = document.createElement('div');
       wrap.className = 'detail-inline';
       wrap.dataset.id = p.id;
-      const imgs = [imgHero(p)];
+      const headerImg = imgHero(p);
+      const imgs = [headerImg];
       wrap.innerHTML = `
-        <div class="detail-header">
+        <div class="detail-header" style="background-image:url('${headerImg}')">
           <div>
             <div class="title">${p.title}</div>
             <div class="sub">${p.city}</div>
@@ -3557,7 +3558,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
     {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], title:['.results-col .card .t','.results-col .card .title'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
     {key:'closedPosts', label:'Closed Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], title:['.posts-mode .card .t','.posts-mode .card .title'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card']}},
-    {key:'openPosts', label:'Open Posts', selectors:{bg:['.detail-inline'], text:['.detail-inline','.detail-inline *'], title:['.detail-inline .t','.detail-inline .title'], btn:['.detail-inline button'], btnText:['.detail-inline button'], card:['.detail-inline']}},
+    {key:'openPosts', label:'Open Posts', selectors:{bg:['.detail-inline'], headerBg:['.detail-inline .detail-header'], text:['.detail-inline','.detail-inline *'], title:['.detail-inline .t','.detail-inline .title'], btn:['.detail-inline button'], btnText:['.detail-inline button'], card:['.detail-inline']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['#map'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup.hover-pop .hover-card'], text:['.mapboxgl-popup.hover-pop .hover-card'], title:['.mapboxgl-popup.hover-pop .hover-card .t','.mapboxgl-popup.hover-pop .hover-card .title']}},
     {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], title:['#filterModal .modal-content .t','#filterModal .modal-content .title'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
@@ -3739,7 +3740,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         if(bearingVal) bearingVal.textContent = b.toFixed(0);
       }
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText','border','hoverBorder','activeBorder'].forEach(type=>{
+      ['bg','card','headerBg','text','title','btn','btnText','border','hoverBorder','activeBorder'].forEach(type=>{
         const cInput = document.getElementById(`${area.key}-${type}-c`);
         const oInput = document.getElementById(`${area.key}-${type}-o`);
         const fontSel = document.getElementById(`${area.key}-${type}-font`);
@@ -3777,7 +3778,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           if(!el) return false;
           const cs = getComputedStyle(el);
           if(cInput){
-            if(type === 'bg' || type === 'btn' || type === 'card') col = cs.backgroundColor;
+            if(type === 'bg' || type === 'btn' || type === 'card' || type === 'headerBg') col = cs.backgroundColor;
             else if(type === 'text' || type === 'btnText' || type === 'title') col = cs.color;
             else if(type === 'border' || type === 'hoverBorder' || type === 'activeBorder') col = cs.borderColor;
           }
@@ -3798,7 +3799,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
             const bVal = parseInt(match[3],10);
             const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
             cInput.value = rgbToHex(r,g,bVal);
-            if((type==='bg' || type==='card' || type==='border' || type==='hoverBorder' || type==='activeBorder') && oInput) oInput.value = alpha;
+            if((type==='bg' || type==='card' || type==='headerBg' || type==='border' || type==='hoverBorder' || type==='activeBorder') && oInput) oInput.value = alpha;
           }
         }
         if(fontSel && font){
@@ -3854,7 +3855,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       colBtn.addEventListener('click', (e)=>{
         e.stopPropagation();
         if(!lastFieldsetKey || lastFieldsetKey === area.key) return;
-        ['bg','card','btn','border','hoverBorder','activeBorder'].forEach(type=>{
+        ['bg','card','headerBg','btn','border','hoverBorder','activeBorder'].forEach(type=>{
           const fromC = document.getElementById(`${lastFieldsetKey}-${type}-c`);
           const fromO = document.getElementById(`${lastFieldsetKey}-${type}-o`);
           const toC = document.getElementById(`${area.key}-${type}-c`);
@@ -3911,6 +3912,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         });
       }
       const types = ['bg'];
+      if(area.selectors.headerBg) types.push('headerBg');
       if(area.selectors.card) types.push('card');
       if(area.selectors.text) types.push('text');
       if(area.selectors.title) types.push('title');
@@ -3927,6 +3929,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           btn: 'Button',
           btnText: 'Button Text',
           border: 'Border',
+          headerBg: 'Header Background',
           hoverBorder: 'Hover Border',
           activeBorder: 'Active Border',
           hoverAdjust: 'Hover Brightness',
@@ -3997,7 +4000,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         }
         const row = document.createElement('div');
         row.className = 'control-row';
-        if(type === 'bg' || type === 'card' || type === 'border' || type === 'hoverBorder' || type === 'activeBorder'){
+        if(type === 'bg' || type === 'card' || type === 'headerBg' || type === 'border' || type === 'hoverBorder' || type === 'activeBorder'){
           row.innerHTML = `
               <label>${label}</label>
               <div class="color-group">
@@ -4070,7 +4073,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       }
     });
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText'].forEach(type=>{
+      ['bg','card','headerBg','text','title','btn','btnText'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         const f = document.getElementById(`${area.key}-${type}-font`);
@@ -4089,7 +4092,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const targets = area.selectors[type] || [];
         targets.forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{
-            if(type==='bg' || type==='card'){
+            if(type==='bg' || type==='card' || type==='headerBg'){
               if(color) el.style.backgroundColor = hexToRgba(color, opacity);
               if(type==='card'){
                 const shadowColor = sc ? sc.value : null;
@@ -4133,7 +4136,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   function collectThemeValues(){
     const data = {};
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText','border','hoverBorder','activeBorder','hoverAdjust','activeAdjust'].forEach(type=>{
+      ['bg','card','headerBg','text','title','btn','btnText','border','hoverBorder','activeBorder','hoverAdjust','activeAdjust'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         const f = document.getElementById(`${area.key}-${type}-font`);
@@ -4147,7 +4150,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         if(c || f || s || v || w || sc){
           const entry = {};
           if(c){ entry.color = c.value; }
-          if((['bg','card','border','hoverBorder','activeBorder'].includes(type)) && o){ entry.opacity = o.value; }
+          if((['bg','card','headerBg','border','hoverBorder','activeBorder'].includes(type)) && o){ entry.opacity = o.value; }
           if(v){ entry.value = v.value; }
           if(f){ entry.font = f.value; }
           if(s){ entry.size = s.value; }
@@ -4246,7 +4249,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         const sb = document.getElementById(`${areaKey}-${type}-shadow-blur`);
         const v = document.getElementById(`${areaKey}-${type}`);
         if(c && val.color){ c.value = val.color; }
-        if((['bg','card','border','hoverBorder','activeBorder'].includes(type)) && o && val.opacity!==undefined){ o.value = val.opacity; }
+        if((['bg','card','headerBg','border','hoverBorder','activeBorder'].includes(type)) && o && val.opacity!==undefined){ o.value = val.opacity; }
         if(v && val.value!==undefined){ v.value = val.value; }
         if(f && val.font){ f.value = val.font; }
         if(s && val.size){ s.value = val.size; }


### PR DESCRIPTION
## Summary
- show hero image behind open post headers with blended background
- add `headerBg` field to open post theme settings for color and opacity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fc592e2c83319be9a5e4938b6524