### PR TITLE
Remove Open Posts background field from theme builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -3598,7 +3598,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
     {key:'list', label:'Results List', selectors:{bg:['.results-col .res-list'], text:['.results-col'], title:['.results-col .card .t','.results-col .card .title'], btn:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], btnText:['.results-col .res-list button','.results-col .res-list .sq','.results-col .res-list .tiny','.results-col .res-list .btn'], card:['.results-col .card']}},
     {key:'closedPosts', label:'Closed Posts', selectors:{bg:['.posts-mode'], text:['.posts-mode','.posts-mode *'], title:['.posts-mode .card .t','.posts-mode .card .title'], btn:['.posts-mode button'], btnText:['.posts-mode button'], card:['.posts-mode .card']}},
-    {key:'openPosts', label:'Open Posts', selectors:{bg:['.detail-inline'], headerBg:['.detail-inline .detail-header'], text:['.detail-inline','.detail-inline *'], title:['.detail-inline .t','.detail-inline .title'], btn:['.detail-inline button'], btnText:['.detail-inline button'], card:['.detail-inline']}},
+    {key:'openPosts', label:'Open Posts', selectors:{headerBg:['.detail-inline .detail-header'], text:['.detail-inline','.detail-inline *'], title:['.detail-inline .t','.detail-inline .title'], btn:['.detail-inline button'], btnText:['.detail-inline button'], card:['.detail-inline']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['#map'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup.hover-pop .hover-card'], text:['.mapboxgl-popup.hover-pop .hover-card'], title:['.mapboxgl-popup.hover-pop .hover-card .t','.mapboxgl-popup.hover-pop .hover-card .title']}},
     {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], title:['#filterModal .modal-content .t','#filterModal .modal-content .title'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn']}},
@@ -3951,7 +3951,8 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
           fs.appendChild(row);
         });
       }
-      const types = ['bg'];
+      const types = [];
+      if(area.selectors.bg) types.push('bg');
       if(area.selectors.headerBg) types.push('headerBg');
       if(area.selectors.card) types.push('card');
       if(area.selectors.text) types.push('text');


### PR DESCRIPTION
## Summary
- drop Open Posts background selector so the section inherits list styling
- avoid rendering a background color control when no selector exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9053df2688331b5589a4012f3414e