### PR TITLE
Fix date range filter handling for Litepicker selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2611,8 +2611,8 @@ function imgHero(pOrId){
         inlineMode: true,
         singleMode: false,
         onSelect: (start, end) => {
-          const fmt = d => d ? d.toLocaleDateString('en-US', { weekday:'short', day:'numeric', month:'short' }) : '';
-          const iso = d => d ? d.toISOString().split('T')[0] : '';
+          const fmt = d => d ? d.toDate().toLocaleDateString('en-US', { weekday:'short', day:'numeric', month:'short' }) : '';
+          const iso = d => d ? d.format('YYYY-MM-DD') : '';
           const hasRange = start && end;
           $('#dateInput').value = hasRange ? `${fmt(start)} to ${fmt(end)}` : '';
           $('#dateInput').dataset.range = hasRange ? `${iso(start)} to ${iso(end)}` : '';


### PR DESCRIPTION
## Summary
- Convert Litepicker date objects to proper strings when updating filter input
- Ensure selected range displays in the filter modal and drives filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a922e1744c8331b794aed102dbf0b4