### PR TITLE
refactor date filtering logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -3469,18 +3469,9 @@ function imgHero(pOrId){
     }
     function kwMatch(p){ const kw = $('#kwInput').value.trim().toLowerCase(); if(!kw) return true; return (p.title+' '+p.city+' '+p.category+' '+p.subcategory).toLowerCase().includes(kw); }
     function dateMatch(p){
-      const val = ($('#dateInput').dataset.range || '').trim();
-      if(!val) return true;
-      let start, end;
-      const parts = val.split(/to/i).map(s=>s.trim()).filter(Boolean);
-      if(parts[0]) start = new Date(parts[0]);
-      if(parts[1]) end = new Date(parts[1]);
-      return p.dates.some(d => {
-        const dt = new Date(d);
-        if(start && dt < start) return false;
-        if(end && dt > end) return false;
-        return true;
-      });
+      const [start, end] = ($('#dateInput').dataset.range || '')
+        .split(/to/i).map(s=>s.trim()).filter(Boolean);
+      return p.dates.some(d => (!start || d >= start) && (!end || d <= end));
     }
     function catMatch(p){ if(selection.cats.size===0 && selection.subs.size===0) return true; const cOk = selection.cats.size===0 || selection.cats.has(p.category); const sOk = selection.subs.size===0 || selection.subs.has(p.category+'::'+p.subcategory); return cOk && sOk; }
 


### PR DESCRIPTION
## Summary
- simplify dateMatch by comparing date strings directly
- confirm Litepicker onSelect stores ISO `YYYY-MM-DD` date strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a931e75a6883318a857fa7d8461afe