### PR TITLE
Replace server persistence with localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4655,11 +4655,6 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       backups.push({ name:`ADMIN ${tab} Backup ${new Date().toISOString()}`, data });
       localStorage.setItem(`admin-${tab}-backups`, JSON.stringify(backups));
       populateBackups(tab);
-      fetch('/admin/save', {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ tab, data })
-      }).catch(()=>{});
       return true;
     }
 

--- a/test.js
+++ b/test.js
@@ -1,8 +1,7 @@
 const assert = require('assert');
-const fs = require('fs');
 const seed = require('./db/seed');
 const { getUserTheme, setUserTheme } = require('./src/db/theme');
-const { DB_PATH } = require('./src/db');
+const { clear } = require('./src/db');
 const { saveTab, listBackups, restoreBackup } = require('./src/db/admin');
 const { generateTheme, DEFAULT_BASE_COLOR } = require('./src/themeBuilder');
 const { applyTheme } = require('./src/server');
@@ -32,7 +31,7 @@ assert.ok(logs[1].startsWith('Applying theme'));
 assert.strictEqual(getFields().primary, '#123456');
 
 // Theme preference tests
-if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH);
+clear();
 seed();
 
 // Initially user has no preference


### PR DESCRIPTION
## Summary
- Store database data in browser localStorage with a Node-friendly polyfill
- Drop server fetch call from admin save flow
- Update tests to use localStorage-backed DB

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a941a5c0e48331b398b9c860255ddf