### PR TITLE
Reduce image loader concurrency limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -3058,7 +3058,7 @@ function imgHero(pOrId){
     });
 
     const imageLoader = (() => {
-      const max = 50;
+      const max = 10;
       const loaded = new Set();
       const queue = [];
       let inFlight = 0;


### PR DESCRIPTION
## Summary
- lower image loader concurrent request cap from 50 to 10 for faster image retrieval

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a946e3fca88331ad7c4a5f08fce4cf