### PR TITLE
Implement staged image loading with increased concurrency

### DIFF
--- a/index.html
+++ b/index.html
@@ -3081,7 +3081,7 @@ function imgHero(pOrId){
     });
 
     const imageLoader = (() => {
-      const max = 10;
+      const max = 50;
       const loaded = new Set();
       const queue = [];
       let inFlight = 0;
@@ -3274,6 +3274,7 @@ function imgHero(pOrId){
       wrap.className = 'detail-inline';
       wrap.dataset.id = p.id;
       const imgs = p.images && p.images.length ? p.images : [imgHero(p)];
+      const ph = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
       wrap.innerHTML = `
         <div class="detail-header">
           <div>
@@ -3285,9 +3286,9 @@ function imgHero(pOrId){
           </button>
         </div>
         ${imgs.length ? `<div class="image-box-wrap">
-          <div class="img-box"><img src="${imgs[0]}" data-index="0" loading="lazy" alt=""/></div>
+          <div class="img-box"><img src="${ph}" data-src="${imgs[0]}" data-index="0" alt="" style="width:100%;height:100%;object-fit:cover;"/></div>
           <div class="thumb-list">
-            ${imgs.map((src,i)=>`<img src="${toThumb(src,100)}" data-src="${src}" data-index="${i}" loading="lazy" alt=""/>`).join('')}
+            ${imgs.map((src,i)=>`<img src="${ph}" data-src="${src}" data-index="${i}" alt=""/>`).join('')}
           </div>
         </div>` : ''}
         ${(p.lng!=null && p.lat!=null && p.dates && p.dates.length) ? `
@@ -3403,14 +3404,18 @@ function imgHero(pOrId){
       thumbs.forEach(thumb=>{
         thumb.addEventListener('click',()=>{
           if(mainImg){
-            const full = thumb.dataset.src || thumb.src;
             const idx = thumb.dataset.index;
-            mainImg.src = thumb.src;
+            const full = thumb.dataset.src || thumb.src;
             mainImg.dataset.index = idx;
-            if(thumb.dataset.src){
-              const img = new Image();
-              img.onload = ()=>{ if(mainImg.dataset.index === idx) mainImg.src = full; };
-              img.src = full;
+            if(thumb.src === full){
+              mainImg.src = full;
+            } else {
+              mainImg.src = thumb.src;
+              if(full){
+                const img = new Image();
+                img.onload = ()=>{ if(mainImg.dataset.index === idx) mainImg.src = full; };
+                img.src = full;
+              }
             }
           }
         });
@@ -3422,6 +3427,22 @@ function imgHero(pOrId){
             openImageModal(thumbs, idx);
           }
         });
+      }
+      if(mainImg && mainImg.dataset.src){
+        const full = mainImg.dataset.src;
+        const img = new Image();
+        img.onload = ()=>{
+          mainImg.src = full;
+          mainImg.removeAttribute('style');
+          thumbs.forEach(t=>{
+            const tSrc = t.dataset.src;
+            if(!tSrc) return;
+            const ti = new Image();
+            ti.onload = ()=>{ t.src = tSrc; };
+            ti.src = tSrc;
+          });
+        };
+        img.src = full;
       }
       const mapDiv = detail.querySelector('.map-container');
       let detailMap = null;


### PR DESCRIPTION
## Summary
- Load placeholders for post images and thumbnails, then progressively load main image followed by full-size thumbnails for quick switching
- Increase concurrent image loading capacity from 10 to 50

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a94fe367288331bfb9661367ed0196