### PR TITLE
Synchronize theme builder fields with organizer

### DIFF
--- a/src/themeOrganiser.js
+++ b/src/themeOrganiser.js
@@ -2,6 +2,12 @@ let fields = {};
 
 function updateFields(newFields) {
   fields = { ...fields, ...newFields };
+  if (typeof document !== 'undefined') {
+    Object.entries(newFields).forEach(([key, val]) => {
+      const input = document.getElementById(key);
+      if (input) input.value = val;
+    });
+  }
   console.log('Theme organiser updated', fields);
 }
 


### PR DESCRIPTION
## Summary
- Update theme organiser to sync input fields with new theme values, matching sample implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a95493c60483318a4b60e11b4621ee