### PR TITLE
Add Litepicker date filter and instant theme color updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1878,8 +1878,15 @@ footer .foot-row .foot-item img {
             </div>
 
 
-          <h3>Categories</h3>
-          <div class="cats" id="cats"></div>
+            <h3>Date Range</h3>
+            <div class="field">
+              <div class="input"><input id="dateInput" type="text" aria-label="Date range" />
+                <div class="x" role="button" aria-label="Clear date">X</div>
+              </div>
+            </div>
+
+            <h3>Categories</h3>
+            <div class="cats" id="cats"></div>
 
             <div class="reset-box">
               <div id="resetBtn" class="btn" role="button" aria-label="Reset all filters">
@@ -2165,6 +2172,7 @@ footer .foot-row .foot-item img {
     let viewHistory = loadHistory();
     let hoverPopup = null, hoverId = null;
     let activePostId = null;
+    let datePicker = null;
 
     const $ = (sel, root=document) => root.querySelector(sel);
     const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
@@ -2609,14 +2617,31 @@ function imgHero(pOrId){
       $$('.cat').forEach(el=>el.setAttribute('aria-expanded','false'));
       $$('.chip.on').forEach(ch=>ch.classList.remove('on'));
       $('#kwInput').value='';
+      $('#dateInput').value='';
+      if(datePicker) datePicker.clearSelection();
       if(geocoder) geocoder.clear();
       applyFilters();
     });
 
     $('#kwInput').addEventListener('input', applyFilters);
+    $('#dateInput').addEventListener('input', applyFilters);
+    datePicker = new Litepicker({
+      element: $('#dateInput'),
+      singleMode: false,
+      setup: (picker) => {
+        picker.on('selected', (start, end) => {
+          $('#dateInput').value = start && end ? `${start.format('YYYY-MM-DD')} to ${end.format('YYYY-MM-DD')}` : '';
+          applyFilters();
+        });
+        picker.on('clear:selection', () => {
+          $('#dateInput').value = '';
+          applyFilters();
+        });
+      }
+    });
     $('#sortSelect').addEventListener('change', ()=> renderLists(filtered));
     $('#favTop').addEventListener('change', ()=> renderLists(filtered));
-    $$('.field .x').forEach(x=> x.addEventListener('click',()=>{ const input = x.parentElement.querySelector('input'); if(input){ input.value=''; input.focus(); applyFilters(); } }));
+    $$('.field .x').forEach(x=> x.addEventListener('click',()=>{ const input = x.parentElement.querySelector('input'); if(input){ input.value=''; input.focus(); if(input.id==='dateInput' && datePicker) datePicker.clearSelection(); applyFilters(); } }));
 
     function setMode(m){
       mode = m;
@@ -3174,6 +3199,7 @@ function imgHero(pOrId){
       return {
         bounds: map ? map.getBounds().toArray() : null,
         kw: $('#kwInput').value,
+        date: $('#dateInput').value,
         cats: [...selection.cats],
         subs: [...selection.subs]
       };
@@ -3182,6 +3208,19 @@ function imgHero(pOrId){
     function restoreState(st){
       if(!st) return;
       $('#kwInput').value = st.kw || '';
+      $('#dateInput').value = st.date || '';
+      if(datePicker){
+        if(st.date){
+          const parts = st.date.split(/to/i).map(s=>s.trim()).filter(Boolean);
+          if(parts[0] && parts[1]){
+            datePicker.setDateRange(new Date(parts[0]), new Date(parts[1]));
+          } else {
+            datePicker.clearSelection();
+          }
+        } else {
+          datePicker.clearSelection();
+        }
+      }
       selection.cats = new Set(st.cats || []);
       selection.subs = new Set(st.subs || []);
       $$('.cat').forEach(el=>{
@@ -3522,10 +3561,24 @@ function imgHero(pOrId){
              p.lat >= postPanel.getSouth() && p.lat <= postPanel.getNorth();
     }
     function kwMatch(p){ const kw = $('#kwInput').value.trim().toLowerCase(); if(!kw) return true; return (p.title+' '+p.city+' '+p.category+' '+p.subcategory).toLowerCase().includes(kw); }
+    function dateMatch(p){
+      const val = $('#dateInput').value.trim();
+      if(!val) return true;
+      let start, end;
+      const parts = val.split(/to/i).map(s=>s.trim()).filter(Boolean);
+      if(parts[0]) start = new Date(parts[0]);
+      if(parts[1]) end = new Date(parts[1]);
+      return p.dates.some(d => {
+        const dt = new Date(d);
+        if(start && dt < start) return false;
+        if(end && dt > end) return false;
+        return true;
+      });
+    }
     function catMatch(p){ if(selection.cats.size===0 && selection.subs.size===0) return true; const cOk = selection.cats.size===0 || selection.cats.has(p.category); const sOk = selection.subs.size===0 || selection.subs.has(p.category+'::'+p.subcategory); return cOk && sOk; }
 
     function applyFilters(){
-      filtered = posts.filter(p => inBounds(p) && kwMatch(p) && catMatch(p));
+      filtered = posts.filter(p => inBounds(p) && kwMatch(p) && dateMatch(p) && catMatch(p));
       renderLists(filtered);
       if(map && map.getSource('posts')){ map.getSource('posts').setData(postsToGeoJSON(filtered)); }
     }
@@ -4819,6 +4872,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     primary: '--primary',
     secondary: '--secondary',
     accent: '--accent',
+    background: '--background',
+    text: '--text',
+    buttonText: '--button-text',
     buttonHoverText: '--button-hover-text'
   };
   Object.entries(fieldBindings).forEach(([id, varName])=>{

--- a/src/themeOrganiser.js
+++ b/src/themeOrganiser.js
@@ -15,4 +15,18 @@ function getFields() {
   return fields;
 }
 
-module.exports = { updateFields, getFields };
+// Bind color input elements to CSS variables for instant theme updates
+// bindings: { inputId: cssVariable }
+function bindColorInputs(bindings) {
+  if (typeof document === 'undefined') return;
+  Object.entries(bindings).forEach(([id, varName]) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener('input', e => {
+      document.documentElement.style.setProperty(varName, e.target.value);
+      updateFields({ [id]: e.target.value });
+    });
+  });
+}
+
+module.exports = { updateFields, getFields, bindColorInputs };


### PR DESCRIPTION
## Summary
- add date range filter with Litepicker in filter modal
- allow instant updates of theme colors via new bindings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95a9dfc108331ad9602458bc1979b