### PR TITLE
feat: enhance date picker and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@ button,
   border-radius: 6px;
   cursor: pointer;
   transition: background .2s,border-color .2s,color .2s,transform .05s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 button:hover,
@@ -1787,7 +1790,7 @@ footer .foot-row .foot-item img {
   .detail-header .sub{ font-size:14px; color:var(--muted); }
   .image-box-wrap{ display:flex; gap:8px; padding:8px 12px; }
   .img-box{ width:400px; height:400px; display:flex; align-items:center; justify-content:center; background:var(--img-box-bg, rgba(0,0,0,0.05)); cursor:pointer; padding:8px; box-sizing:border-box; }
-  .img-box img{ max-width:100%; max-height:100%; object-fit:contain; }
+  .img-box img{ width:100%; height:100%; object-fit:cover; }
   .thumb-list{ display:flex; flex-direction:column; gap:8px; max-height:400px; overflow-y:auto; padding-right:4px; }
   .thumb-list img{ width:100px; height:100px; object-fit:cover; cursor:pointer; }
   .map-calendar{ display:flex; gap:12px; padding:8px 12px; }
@@ -1884,6 +1887,7 @@ footer .foot-row .foot-item img {
                 <div class="x" role="button" aria-label="Clear date">X</div>
               </div>
             </div>
+            <div id="datePicker"></div>
 
             <h3>Categories</h3>
             <div class="cats" id="cats"></div>
@@ -2627,7 +2631,8 @@ function imgHero(pOrId){
     $('#kwInput').addEventListener('input', applyFilters);
     $('#dateInput').addEventListener('input', applyFilters);
     datePicker = new Litepicker({
-      element: $('#dateInput'),
+      element: $('#datePicker'),
+      inlineMode: true,
       singleMode: false,
       setup: (picker) => {
         picker.on('selected', (start, end) => {


### PR DESCRIPTION
## Summary
- show Litepicker calendar inline below the date range filter
- center icons inside all buttons
- stretch post images to fill their containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a960a4041c83319d595f5b0070798a