### PR TITLE
feat: reset theme fields before applying new theme

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,12 @@
 const { generateTheme, DEFAULT_BASE_COLOR } = require('./themeBuilder');
-const { updateFields } = require('./themeOrganiser');
+const { updateFields, resetFields } = require('./themeOrganiser');
 const http = require('http');
 const url = require('url');
 
 function applyTheme(theme) {
   if (!theme) return null;
+  // Clear any previous theme values before applying the new one
+  resetFields();
   const base = theme.data && theme.data.primary ? theme.data.primary : DEFAULT_BASE_COLOR;
   const generated = generateTheme(base);
   // Update theme organiser fields before applying to website

--- a/src/themeOrganiser.js
+++ b/src/themeOrganiser.js
@@ -1,14 +1,31 @@
 let fields = {};
 
-function updateFields(newFields) {
+// Update the tracked fields. By default new values are merged with any
+// existing ones, but passing `true` for `replace` will overwrite the entire
+// set. DOM inputs are updated to reflect the provided values.
+function updateFields(newFields, replace = false) {
+  if (replace) fields = {};
   fields = { ...fields, ...newFields };
   if (typeof document !== 'undefined') {
-    Object.entries(newFields).forEach(([key, val]) => {
+    const entries = replace ? fields : newFields;
+    Object.entries(entries).forEach(([key, val]) => {
       const input = document.getElementById(key);
       if (input) input.value = val;
     });
   }
   console.log('Theme organiser updated', fields);
+}
+
+// Clear all stored fields and any associated DOM input values so that stale
+// data does not linger when a new theme is applied.
+function resetFields() {
+  if (typeof document !== 'undefined') {
+    Object.keys(fields).forEach(key => {
+      const input = document.getElementById(key);
+      if (input) input.value = '';
+    });
+  }
+  fields = {};
 }
 
 function getFields() {
@@ -29,4 +46,4 @@ function bindColorInputs(bindings) {
   });
 }
 
-module.exports = { updateFields, getFields, bindColorInputs };
+module.exports = { updateFields, getFields, bindColorInputs, resetFields };


### PR DESCRIPTION
## Summary
- allow `updateFields` to replace existing values or merge updates
- add `resetFields` helper to clear organiser state
- clear old fields before applying new theme so stale values aren't kept

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a98fcf27208331a926e0822ce42d33