### PR TITLE
feat: add beige transparency theme and rename default

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Events Platform</title>
-  <style id="theme-default">
+  <style id="theme-old">
 :root{
   --header-h: 72px;
   --panel-w: 260px;
@@ -35,44 +35,6 @@
   --border: rgba(255,255,255,1);
   --border-hover: rgba(224,224,224,1);
   --border-active: rgba(213,213,213,1);
-}
-  </style>
-  <style id="theme-dark" disabled>
-:root{
-  --ink: #eee;
-  --ink-d: #aaa;
-  --primary: #eeeeee;
-  --secondary: #222222;
-  --accent: #444444;
-  --background: #222222;
-  --text: #eeeeee;
-  --button-text: #eeeeee;
-  --button-hover-text: #eeeeee;
-  --btn: #444444;
-  --btn-hover: #555555;
-  --btn-active: #555555;
-  --border: rgba(34,34,34,1);
-  --border-hover: rgba(68,68,68,1);
-  --border-active: rgba(85,85,85,1);
-}
-  </style>
-  <style id="theme-ocean" disabled>
-:root{
-  --ink: #006064;
-  --ink-d: #004d56;
-  --primary: #006064;
-  --secondary: #e0f7fa;
-  --accent: #00838f;
-  --background: #e0f7fa;
-  --text: #006064;
-  --button-text: #006064;
-  --button-hover-text: #006064;
-  --btn: #00838f;
-  --btn-hover: #00acc1;
-  --btn-active: #00acc1;
-  --border: rgba(224,247,250,1);
-  --border-hover: rgba(0,131,143,1);
-  --border-active: rgba(0,172,193,1);
 }
   </style>
   <style>
@@ -4199,6 +4161,426 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     if(redoBtn) redoBtn.disabled = redoStack.length === 0;
   }
 
+  const beigePreset = {
+    name: 'Beige Transparency',
+    data: {
+      "header-bg": {
+        "color": "#a3956c",
+        "opacity": "1"
+      },
+      "header-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "header-btn": {
+        "color": "#8c7b5f",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "header-btnText": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "subheader-bg": {
+        "color": "#000000",
+        "opacity": "0"
+      },
+      "subheader-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "12",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "subheader-btn": {
+        "color": "#8f8367",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "subheader-btnText": {
+        "color": "#ececec",
+        "font": "Verdana",
+        "size": "14",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "body-bg": {
+        "color": "#a3956c",
+        "opacity": "1"
+      },
+      "body-border": {
+        "color": "#adadad",
+        "opacity": "1"
+      },
+      "body-hoverBorder": {
+        "color": "#ff8800",
+        "opacity": "1"
+      },
+      "body-activeBorder": {
+        "color": "#ffc800",
+        "opacity": "1"
+      },
+      "body-hoverAdjust": {
+        "value": "0"
+      },
+      "body-activeAdjust": {
+        "value": "-11"
+      },
+      "list-bg": {
+        "color": "#000000",
+        "opacity": "0"
+      },
+      "list-card": {
+        "color": "#867f69",
+        "opacity": "1",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "list-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "list-title": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "14",
+        "weight": "bold",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "list-btn": {
+        "color": "#867f69",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "list-btnText": {
+        "color": "#333333",
+        "font": "Arial",
+        "size": "",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "posts-bg": {
+        "color": "#000000",
+        "opacity": "0"
+      },
+      "posts-card": {
+        "color": "#000000",
+        "opacity": "0.74",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "posts-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "posts-title": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "14",
+        "weight": "bold",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "posts-btn": {
+        "color": "#121212",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "posts-btnText": {
+        "color": "#333333",
+        "font": "Arial",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "footer-bg": {
+        "color": "#000000",
+        "opacity": "0"
+      },
+      "footer-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "footer-card": {
+        "color": "#000000",
+        "opacity": "0",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "map-bg": {
+        "color": "#000000",
+        "opacity": "0"
+      },
+      "map-card": {
+        "color": "#313131",
+        "opacity": "0.8",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "map-text": {
+        "color": "#a6a6a6",
+        "font": "Arial",
+        "size": "",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "map-title": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "12",
+        "weight": "bold",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "filter-bg": {
+        "color": "#000000",
+        "opacity": "0.65"
+      },
+      "filter-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "filter-title": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "10",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "filter-btn": {
+        "color": "#a1a3a6",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "filter-btnText": {
+        "color": "#ffffff",
+        "font": "Arial",
+        "size": "",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "adminModal-bg": {
+        "color": "#000000",
+        "opacity": "0.65"
+      },
+      "adminModal-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "adminModal-title": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "10",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "adminModal-btn": {
+        "color": "#2a7372",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "adminModal-btnText": {
+        "color": "#f8f5f5",
+        "font": "Arial",
+        "size": "",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "memberModal-bg": {
+        "color": "#000000",
+        "opacity": "0.65"
+      },
+      "memberModal-text": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "16",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "memberModal-title": {
+        "color": "#ffffff",
+        "font": "Verdana",
+        "size": "10",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "memberModal-btn": {
+        "color": "#732b4e",
+        "shadow": {
+          "color": "#000000",
+          "blur": "0"
+        }
+      },
+      "memberModal-btnText": {
+        "color": "#ffffff",
+        "font": "Arial",
+        "size": "",
+        "weight": "normal",
+        "shadow": {
+          "color": "#000000",
+          "x": "0",
+          "y": "0",
+          "blur": "0"
+        }
+      },
+      "primary": {
+        "color": "#000000"
+      },
+      "secondary": {
+        "color": "#000000"
+      },
+      "accent": {
+        "color": "#000000"
+      },
+      "buttonHoverText": {
+        "color": "#000000"
+      }
+    }
+  };
   let presets = [];
   let defaultTheme = {};
   const builtInPresets = [];
@@ -4247,7 +4629,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
 
   function loadPresets(){
     const stored = JSON.parse(localStorage.getItem('themePresets')||'[]');
-    presets = [{name:'Default', data: defaultTheme}, ...builtInPresets, ...stored];
+    presets = [beigePreset, {name:'Old Theme', data: defaultTheme}, ...builtInPresets, ...stored];
     updatePresetOptions();
   }
 
@@ -4307,6 +4689,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   initBuiltInPresets().then(() => {
     loadPresets();
     loadSavedTheme();
+    if(!localStorage.getItem('currentTheme')) applyPresetData(beigePreset.data);
     currentState = collectThemeValues();
     updateHistoryButtons();
   });


### PR DESCRIPTION
## Summary
- remove unused global theme styles
- add Beige Transparency preset and apply it by default
- rename default preset to Old Theme and prioritize Beige Transparency in admin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9bee06f308331aed612911dcf0535