### PR TITLE
Use dark transparency theme and tidy date picker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,32 +11,32 @@
   --panel-w: 260px;
   --results-w: 520px;
   --gap: 12px;
-  --ink: #ffffff;
-  --ink-d: #ececec;
-  --gold: #ffc107;
-  --muted: #777;
-    --primary: #a3956c;
-    --secondary: #867f69;
-    --accent: #ff8800;
-    --background: #a3956c;
-    --text: #ffffff;
-    --button-text: #ffffff;
-    --button-hover-text: #000000;
-    --btn: #8c7b5f;
-    --btn-hover: #ff8800;
-    --btn-active: #ffc800;
-    --btn-2: var(--btn-hover);
-    --modal-bg: rgba(0,0,0,0.7);
-    --modal-text: #fff;
-    --footer-h: 70px;
-    --list-background: rgba(255,255,255,1);
-    --scrollbar-track: transparent;
-    --scrollbar-thumb: rgba(0,0,0,0.3);
-    --scrollbar-thumb-hover: rgba(0,0,0,0.5);
-    --border: rgba(173,173,173,1);
-    --border-hover: rgba(255,136,0,1);
-    --border-active: rgba(255,200,0,1);
-      --dropdown-radius: 6px;
+    --ink: #ffffff;
+    --ink-d: #ececec;
+    --gold: #ffc107;
+    --muted: #777;
+      --primary: #000000;
+      --secondary: #000000;
+      --accent: #000000;
+      --background: rgba(41,41,41,1);
+      --text: #ffffff;
+      --button-text: #ffffff;
+      --button-hover-text: #000000;
+      --btn: #22343f;
+      --btn-hover: #22343f;
+      --btn-active: #22343f;
+      --btn-2: var(--btn-hover);
+      --modal-bg: rgba(0,0,0,0.7);
+      --modal-text: #ffffff;
+      --footer-h: 70px;
+      --list-background: rgba(0,0,0,0);
+      --scrollbar-track: transparent;
+      --scrollbar-thumb: rgba(0,0,0,0.3);
+      --scrollbar-thumb-hover: rgba(0,0,0,0.5);
+      --border: rgba(173,173,173,0.31);
+      --border-hover: rgba(255,136,0,0.43);
+      --border-active: rgba(255,200,0,0.45);
+        --dropdown-radius: 6px;
 }
 
 *{
@@ -564,16 +564,16 @@ button:focus-visible,
   position: relative;
 }
 
-.input input,.input select{
-  width: 100%;
-  height: 40px;
-  border-radius: 12px;
-  border: none;
-  background: rgba(255,255,255,0.9);
-  color: var(--ink);
-  padding: 0 38px 0 12px;
-  outline: 0;
-}
+  .input input,.input select{
+    width: 100%;
+    height: 40px;
+    border-radius: 12px;
+    border: none;
+    background: var(--btn);
+    color: var(--ink);
+    padding: 0 38px 0 12px;
+    outline: 0;
+  }
 .input select{border-radius:var(--dropdown-radius);}
 
 .input .x,.input .down{
@@ -1426,343 +1426,107 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   z-index: 0;
 }
 
-
-
-
-
-<style>
-    :root{
-      --header-h:72px;
-      --panel-w:260px;
-      --results-w:520px;
-      --gap:12px;
-      --ink:#e8eff7;
-      --ink-d:#bcd0e6;
-      --gold:#ffc107;
-      --muted:#87a2c2;
-      --btn:#204261;
-      --btn-hover:#1a3853;
-      --btn-active:#162f46;
-      --btn-2:var(--btn-hover);
-      --footer-h:70px;
-      --panel-grad:linear-gradient(180deg,#0f1b2a,#0b1623);
-      --bg-grad:linear-gradient(0deg,#152944,#192a46);
-    }
-    *{box-sizing:border-box}
-    html,body{height:100%}
-    body{margin:0;font-family:Verdana,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans","Liberation Sans",sans-serif;background:#071422;color:var(--ink);overflow:hidden}
-    .header{height:var(--header-h);display:flex;align-items:center;justify-content:space-between;padding:0 20px;background:#A3956c;color:#fff;position:relative;z-index:20}
-    .logo{display:flex;align-items:center;gap:10px;font-weight:800;letter-spacing:.4px;user-select:none}
-    .logo img{height:48px;display:block}
-    .view-toggle{position:absolute;left:calc(var(--results-w) + var(--gap) - 6px);top:50%;transform:translateY(-50%);display:flex;gap:8px}
-    .view-toggle button{border:1px solid var(--btn);border-radius:999px;padding:10px 14px;background:var(--btn);color:var(--ink);font-weight:600;cursor:pointer;transition:background .2s,border-color .2s}
-    .auth{display:flex;align-items:center;gap:10px}
-    .auth button{border:1px solid rgba(255,255,255,.6);border-radius:999px;padding:10px 14px;background:rgba(255,255,255,0.2);color:inherit;font-weight:600;cursor:pointer}
-    .gear{width:36px;height:36px;border-radius:10px;background:rgba(255,255,255,0.2);display:grid;place-items:center}
-    .gear svg{width:18px;height:18px;opacity:.9}
-
-    .main{height:calc(100% - var(--header-h) - var(--footer-h));display:grid;grid-template-columns:var(--results-w) 1fr;grid-template-rows:1fr;gap:var(--gap);padding:14px}
-    .filters-col{display:flex;flex-direction:column;min-height:0}
-    .left-tools{display:flex;gap:8px;margin-bottom:8px;padding-left:2px}
-    .sq{width:30px;height:30px;border-radius:8px;display:grid;place-items:center;border:none}
-    .sq svg{width:14px;height:14px;opacity:.9}
-    .field{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin:8px 0}
-    .field .input{position:relative}
-    .input input,.input select{width:100%;height:40px;border-radius:12px;border:none;background:#0b1a29;color:var(--ink);padding:0 38px 0 12px;outline:0}
-    .input .x,.input .down{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;border-radius:8px;display:grid;place-items:center;cursor:pointer;border:none}
-    .tiny{display:grid;place-items:center;width:38px;height:40px;border-radius:12px;cursor:pointer;border:none}
-    .tiny svg{width:18px;height:18px}
-
-    .cats{margin-top:10px}
-    .cat{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin:8px 0}
-    .cat .bar{height:36px;border-radius:12px;padding-left:12px;display:flex;align-items:center;gap:8px;border:1px solid;cursor:pointer}
-    .cat .bar .dot{width:18px;height:18px;border-radius:50%;display:grid;place-items:center;border:1px solid}
-    .cat .bar .label{font-weight:700;letter-spacing:.2px}
-    .cat .cfg{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;border:1px solid;cursor:pointer}
-    .sub{margin:6px 0 0 6px;display:none;grid-template-columns:1fr;gap:6px}
-    .sub .chip{height:28px;display:inline-flex;align-items:center;gap:8px;padding:0 10px;border-radius:999px;border:1px solid;font-size:12px;width:max-content;cursor:pointer}
-
-    .reset-box{display:grid;grid-template-columns:1fr 38px;gap:8px;align-items:center;margin-top:10px}
-    .reset-box .btn{height:36px;border-radius:999px;border:1px solid;display:flex;align-items:center;gap:10px;padding:0 14px;font-weight:700;letter-spacing:.2px;cursor:pointer}
-    .reset-box .btn svg{width:16px;height:16px}
-    .reset-box .arr{display:grid;place-items:center;width:38px;height:36px;border-radius:12px;border:1px solid}
-
-    .results-col{display:flex;flex-direction:column;min-width:0;min-height:0}
-      .subheader{display:flex;align-items:center;justify-content:flex-start;gap:8px;margin:0 0 8px 0;color:var(--ink-d)}
-      .res-actions{margin-left:auto;display:flex;align-items:center;gap:8px}
-      .subheader button{border:1px solid var(--ink-d);border-radius:999px;padding:8px 12px;font-weight:600;cursor:pointer}
-      .subheader select{height:40px;border:1px solid var(--ink-d);border-radius:var(--dropdown-radius);padding:0 12px}
-      .res-list{overflow:auto;padding-right:6px;flex:1;min-height:0}
-    .card{display:grid;grid-template-columns:90px 1fr 36px;gap:12px;border:1px solid var(--border);border-radius:16px;padding:12px;margin-bottom:12px;cursor:pointer}
-    .thumb{width:90px;height:70px;border-radius:12px;object-fit:cover;display:block;background:var(--modal-bg)}
-    .meta{display:flex;flex-direction:column;gap:6px;min-width:0}
-    .title{font-weight:900;line-height:1.2}
-    .info{display:flex;gap:16px;align-items:center;font-size:13px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
-    .badge{width:18px;height:18px;border-radius:50%;display:inline-grid;place-items:center;background:#0e2540;border:1px solid rgba(255,255,255,.1);font-size:11px}
-    .fav{width:36px;height:36px;border-radius:12px;display:grid;place-items:center;background:var(--btn);border:1px solid var(--btn)}
-    .fav svg{width:18px;height:18px;fill:none;stroke:var(--gold);stroke-width:1.5}
-    .fav[aria-pressed="true"] svg{fill:var(--gold);stroke:var(--gold)}
-
-    .map-wrap{position:relative;background:var(--btn);border-radius:16px;overflow:hidden;border:1px solid var(--border);height:100%}
-    #map{position:absolute;inset:0}
-    .map-overlay{position:absolute;inset:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none}
-    .geocoder{position:absolute;top:10px;left:10px;z-index:10;min-width:240px;display:flex;gap:4px}
-    .geocoder .mapboxgl-ctrl-geocoder{flex:1;position:relative}
-    .geocoder .mapboxgl-ctrl-group{height:40px;width:40px;box-shadow:none}
-    .geocoder .mapboxgl-ctrl-geolocate{width:100%;height:100%;margin:0;padding:0;border:1px solid var(--border);border-radius:4px;background:#fff;display:flex;align-items:center;justify-content:center;background-position:center;background-size:20px 20px}
-    .geocoder .mapboxgl-ctrl-geocoder--suggestions,
-    .geocoder .mapboxgl-ctrl-geocoder .suggestions{
-      position:absolute;
-      top:100%;
-      left:0;
-      width:100%;
-      margin-top:4px;
-      background:#fff;
-      border:1px solid var(--border);
-      border-radius:4px;
-      box-shadow:0 2px 4px rgba(0,0,0,0.1);
-      z-index:5;
-    }
-    .geocoder .mapboxgl-ctrl-geocoder .suggestions li{
-      background:#fff;
-      color:#000;
-    }
-
-    .closed-posts{display:none;height:100%;overflow:auto;min-height:0;padding:0 6px}
-    .closed-posts .res-list{overflow:visible;padding:12px 0 0}
-    .closed-posts .open-posts{margin-top:6px}
-    .mode-posts .closed-posts{display:block}
-
-    .mode-map .closed-posts{display:none}
-    .mode-map .map-wrap{display:block}
-
-    .open-posts{border:1px solid var(--border);border-radius:18px;margin:0 0 12px 0;overflow:hidden}
-    .open-posts .detail-header{display:flex;justify-content:space-between;align-items:center;padding:8px 12px;border-top-left-radius:inherit;border-top-right-radius:inherit}
-    .open-posts-sticky .open-posts .detail-header{position:sticky;top:0;z-index:3}
-    .open-posts .body{padding:14px}
-    .open-posts .text{margin-top:12px}
-    .open-posts .img-area{display:flex;gap:8px}
-    .open-posts .img-box{width:400px;height:400px;overflow:hidden;border:1px solid var(--border);border-radius:18px;flex-shrink:0;cursor:pointer;background:var(--list-background)}
-    .open-posts .img-box img{width:100%;height:100%;object-fit:contain;display:block}
-    .open-posts .thumb-column{display:flex;flex-direction:column;height:400px;overflow-y:auto;gap:4px}
-    .open-posts .thumb-column img{width:100px;height:100px;object-fit:cover;border:1px solid var(--border);border-radius:8px;cursor:pointer}
-    .open-posts .detail-header .title{margin:0;font-size:20px;line-height:1.2}
-    .open-posts .meta{font-size:13px;display:flex;gap:12px;flex-wrap:wrap}
-    .img-modal{position:fixed;inset:0;background:var(--modal-bg);display:flex;justify-content:center;align-items:center;z-index:1000}
-    .img-modal img{max-width:90vw;max-height:90vh;cursor:pointer}
-    .pill{border:1px solid var(--btn);background:var(--btn);border-radius:999px;padding:8px 12px;font-weight:700;cursor:pointer}
-    .close{border:0;background:#16283f;border-radius:10px;padding:8px 12px;cursor:pointer}
-    .dates{display:flex;gap:8px;flex-wrap:wrap;margin-top:4px}
-    .date{background:var(--btn);border:1px solid var(--btn);border-radius:999px;padding:6px 10px;font-size:12px}
-    .desc{margin-top:8px}
-
-    footer{height:var(--footer-h);display:flex;align-items:center;gap:10px;padding:10px 14px;position:relative;z-index:10}
-    .foot-row{overflow-x:auto;overflow-y:hidden;white-space:nowrap;display:flex;gap:8px;width:100%}
-    .chip-small{flex:0 0 auto;max-width:240px;display:flex;align-items:center;gap:8px;background:var(--btn);border-radius:12px;padding:6px 10px;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
-    .chip-small img.mini{width:26px;height:20px;border-radius:6px;object-fit:cover;flex:0 0 auto;display:block;background:var(--btn)}
-    .chip-small .t{overflow:hidden;text-overflow:ellipsis}
-      footer .foot-row .fav-star{color:var(--gold);flex:0 0 auto;}
-  
-/* === 0512 Clean fix: prevent text/image overlap in closed cards without !important === */
-.card{display:flex;gap:12px;align-items:flex-start;opacity:1;border:1px solid var(--border)}
-.card .thumb{flex:0 0 90px;width:90px;height:70px;display:block;object-fit:cover;border-radius:12px}
-.closed-posts .card .thumb{flex-basis:70px;width:70px;height:70px}
-.card .meta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:6px}
-.card .fav{flex:0 0 auto}
-.title{margin:0;font-weight:900;line-height:1.2;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
-.info{display:flex;gap:16px;align-items:center;font-size:13px;min-width:0;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
-
-
-/* === 0514: Hover popup styling for map markers === */
-.mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  max-width: 640px; /* allow a bit more width so content + scrollbar fit */
-  overflow: hidden; /* no horizontal scroll on the container */
-  border-radius: 12px;
-  padding: 6px 10px 6px 8px;
-}
-.hover-card{display:flex;gap:10px;align-items:center;max-width:280px}
-.hover-card img{width:64px;height:44px;object-fit:cover;border-radius:8px;flex:0 0 auto;display:block;background:var(--modal-bg)}
-.hover-card .t{font-weight:800;font-size:13px;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px}
-.hover-card .s{font-size:12px;opacity:.8}
-
-/* restore triangular popup tip */
-.mapboxgl-popup-tip{
-  width:0!important;
-  height:0!important;
-  background:transparent!important;
-  border:0 solid transparent;
-  border-left:10px solid transparent;
-  border-right:10px solid transparent;
-  transform:none!important;
-}
-.mapboxgl-popup-anchor-top .mapboxgl-popup-tip{border-bottom:10px solid var(--modal-bg)}
-.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip{border-top:10px solid var(--modal-bg)}
-.mapboxgl-popup-anchor-left .mapboxgl-popup-tip{border-right:10px solid var(--modal-bg)}
-.mapboxgl-popup-anchor-right .mapboxgl-popup-tip{border-left:10px solid var(--modal-bg)}
-
-
-/* === 0515: Robust wrapping/clamping for hover popups === */
-.mapboxgl-popup.hover-pop{max-width:320px}
-.mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  max-width: 640px;
-  width:auto;
-  padding: 6px 10px 6px 8px;
-}
-.hover-card{display:flex;gap:10px;align-items:flex-start;max-width:300px}
-.hover-card img{width:64px;height:44px;object-fit:cover;border-radius:8px;flex:0 0 auto;display:block;background:var(--modal-bg)}
-.hover-card .t{
-  font-weight:800;font-size:13px;line-height:1.25;
-  white-space:normal;word-break:break-word;overflow-wrap:anywhere;
-  display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:3;overflow:hidden;
-}
-.hover-card .s{
-  font-size:12px;opacity:.8;margin-top:2px;
-  white-space:normal;word-break:break-word;overflow-wrap:anywhere;
-  display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1;overflow:hidden;
-}
-
-
-/* === 0528: Cluster contextmenu list (robust) === */
-.mapboxgl-popup.hover-pop { pointer-events: auto; }
-.mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  border-radius: 12px;
-  padding: 6px 10px 6px 8px;
-  max-width: 640px;
-}
-.multi-hover{max-width:360px}
-.multi-hover h4{margin:0 0 8px 0;font-size:13px;color:var(--ink-d);font-weight:700;letter-spacing:.3px}
-.multi-list{
-  max-height: 360px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-gutter: stable;
-  padding: 2px 6px 2px 2px;
-  box-sizing: border-box;
-}
-.multi-item{
-  display:flex;
-  gap: 8px;
-  align-items:center;
-  padding: 4px 6px;
-  border-radius:10px;
-  cursor:pointer;
-  min-width:0;               /* allow shrinking within container */
-}
-.multi-item .t{
-  font-weight:800;
-  font-size:13px;
-  line-height:1.25;
-  overflow:hidden;
-  display:-webkit-box;
-  -webkit-line-clamp:2;
-  -webkit-box-orient:vertical;
-  word-break:break-word;
-  overflow-wrap:anywhere;
-}
-.multi-item .s{font-size:12px;opacity:.8;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.multi-ctrls{display:flex;justify-content:space-between;align-items:center;gap:10px;margin-top:8px}
-.multi-ctrls .hint{font-size:12px;color:var(--ink-d)}
-.multi-ctrls .close{border:0;background:var(--btn);border-radius:10px;padding:6px 10px;cursor:pointer}
-
-.multi-item > div{ min-width:0; }
-.multi-item .hover-card{ max-width:100%; }
-.hover-card > div{min-width:0;flex:1}
-
-/* 0540: Allow full title width inside list rows */
-.multi-item .hover-card{ max-width:none; width:100%; }
-.multi-item .hover-card .t{ max-width:none; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; }
-
-.nowrap{white-space:nowrap}
-.multi-hover .soonest{color:var(--ink-d); font-weight:600}
-
-/* 0577: LQIP blur-up for hero images */
-.hero img.lqip{ filter: blur(10px); transform: scale(1.02); transition: filter .22s ease, transform .22s ease; }
-.hero img.ready{ filter: none; transform: none; }
-/* end 0577 */
-
-/* 0588: enforce 1:1 thumbnails everywhere (crop via object-fit: cover) */
-#results .card img.thumb,
-#postsWide .card img.thumb { width:80px; height:80px; object-fit:cover; }
-
-/* map hover & popups */
-.hover-card img,
-.mapboxgl-popup .hover-card img { width:64px; height:64px; object-fit:cover; }
-
-/* footer history */
-.foot-item img { width:40px; height:40px; object-fit:cover; border-radius:8px; }
-
-/* generic catch-all for any .thumb not caught above */
-img.thumb { width:80px; height:80px; object-fit:cover; }
-
-
-/* 0589: precise 1:1 enforcement for list & footer */
-#results .card > img,
-#results .card img.thumb{
-  width:80px; height:80px; aspect-ratio:1/1;
-  object-fit:cover; display:block;
-}
-footer .foot-row .foot-item > img,
-footer .foot-row .foot-item img{
-  width:40px; height:40px; aspect-ratio:1/1;
-  object-fit:cover; display:block; border-radius:8px;
-}
-
-
-/* 0592: ensure footer history thumbnails are 40x40 (override chip-small mini sizing) */
-footer .chip-small img.mini,
-footer .foot-row .foot-item img {
-  width: 40px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: 8px;
-}
-
-/* release Mapbox clamp */
-}
-
- */
-}
-
-
-/* removed legacy 0606 clamp block */
-.mapboxgl-popup.hover-pop.hover-multi-list { 
-  max-width: none !important;              /* beats .hover-pop{max-width:320px} */
-}
-
-.mapboxgl-popup.hover-pop.hover-multi-list .mapboxgl-popup-content { 
-  max-width: none !important;              /* remove 240px inline clamp */
-  width: auto !important;
-}
-
-.mapboxgl-popup.hover-pop.hover-multi-list .multi-hover {
-  width: auto !important;                 /* requested width */
-  max-width: none !important;
-}
-/* 0618: Multi hover — clean auto width from 0610 STABLE */
-.mapboxgl-popup.hover-pop:not(.hover-multi-list){ max-width:320px; } /* singles/clusters only */
-
-.mapboxgl-popup.hover-multi-list .mapboxgl-popup-content{
-  max-width:none;   /* release Mapbox's 240px clamp for multi, JS also sets maxWidth:'none' */
-  width:auto;
-}
-
-.mapboxgl-popup.hover-multi-list .multi-hover{ width:auto; }
-
-/* Let text shrink & wrap so width can be truly 'auto' */
-.mapboxgl-popup.hover-multi-list .multi-hover .multi-item .txt{ min-width:0; }
-  .mapboxgl-popup.hover-multi-list .multi-hover .multi-item .t{
-    white-space:normal;
-    overflow-wrap:anywhere;
-    -webkit-line-clamp:2;
-    -webkit-box-orient:vertical;
-    display:-webkit-box;
-  }
-  #adminModal .modal-content,
-  .mapboxgl-popup .mapboxgl-popup-content{
-    background: var(--modal-bg);
-    color: var(--modal-text);
-  }
 </style>
+<style id="theme-dark-transparency">
+:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);}
+.header{background-color:rgba(41,41,41,1);}
+.header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.header button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
+.header .gear{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
+.header a{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
+.header button{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.header .gear{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.header a{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.subheader{background-color:rgba(0,0,0,0);}
+.subheader{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.subheader button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
+.subheader button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+body{background-color:rgba(41,41,41,1);}
+.res-list{background-color:rgba(0,0,0,0);}
+.res-list .card{background-color:rgba(41,41,41,1);box-shadow:0 0 0px #000000;}
+.res-list{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.res-list .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.res-list button{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
+.res-list .sq{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
+.res-list .tiny{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
+.res-list .btn{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
+.res-list button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .sq{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .tiny{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .btn{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.closed-posts{background-color:rgba(0,0,0,0);}
+.closed-posts .card{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;}
+.closed-posts .open-posts{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;}
+.closed-posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.closed-posts .res-list{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.closed-posts .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts .open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts button{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
+.closed-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #ca6363;}
+.open-posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.open-posts button{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
+.open-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .detail-header{background-color:#000000;}
+.open-posts .img-box{background-color:#000000;}
+footer{background-color:rgba(0,0,0,0);}
+footer .foot-row .foot-item{background-color:rgba(0,0,0,0.32);box-shadow:0 0 0px #000000;}
+footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.map-wrap{background-color:rgba(0,0,0,1);}
+.mapboxgl-popup .mapboxgl-popup-content{background-color:rgba(0,0,0,0.7);box-shadow:0 0 0px #000000;}
+.mapboxgl-popup .hover-card{background-color:rgba(0,0,0,0.7);box-shadow:0 0 0px #000000;}
+.mapboxgl-popup .chip{background-color:rgba(0,0,0,0.7);box-shadow:0 0 0px #000000;}
+.mapboxgl-popup .chip-small{background-color:rgba(0,0,0,0.7);box-shadow:0 0 0px #000000;}
+.mapboxgl-popup .multi-item{background-color:rgba(0,0,0,0.7);box-shadow:0 0 0px #000000;}
+.mapboxgl-popup .hover-card{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .hover-card .t{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip .t{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small .t{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item .t{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .hover-card .title{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip .title{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small .title{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item .title{color:#ff7575;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+#filterModal .modal-content{background-color:rgba(0,0,0,0.7);}
+#filterModal .modal-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterModal .modal-content .t{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterModal .modal-content .title{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterModal button{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
+#filterModal .sq{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
+#filterModal .tiny{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
+#filterModal .btn{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
+#filterModal button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterModal .sq{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterModal .tiny{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterModal .btn{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminModal .modal-content{background-color:rgba(0,0,0,0.7);}
+#adminModal .modal-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminModal .modal-content .t{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminModal .modal-content .title{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminModal button{background-color:#165d6f;border-color:#165d6f;box-shadow:0 0 0px #000000;}
+#adminModal #spinType span{background-color:#165d6f;border-color:#165d6f;box-shadow:0 0 0px #000000;}
+#adminModal button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminModal #spinType span{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberModal .modal-content{background-color:rgba(0,0,0,0.7);}
+#memberModal .modal-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberModal .modal-content .t{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberModal .modal-content .title{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberModal button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
+#memberModal button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+
+</style>
+
+
+
+
 
 </head>
 <body class="mode-map">
@@ -1838,8 +1602,8 @@ footer .foot-row .foot-item img {
             <div class="input"><input id="dateInput" type="text" value="This month" aria-label="Date range" />
               <div class="x" role="button" aria-label="Clear date">X</div>
             </div>
-            <div id="datePicker"></div>
           </div>
+          <div id="datePicker"></div>
 
           <h3>Categories</h3>
           <div class="cats" id="cats"></div>
@@ -4079,6 +3843,32 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       }
       wrap.appendChild(fs);
     });
+    const misc = document.createElement('fieldset');
+    misc.className = 'admin-fieldset';
+    misc.innerHTML = '<legend>Miscellaneous</legend>';
+    const miscFields = [
+      {id:'btn', label:'Button Base'},
+      {id:'btnHover', label:'Button Hover'},
+      {id:'btnActive', label:'Button Active'},
+      {id:'modalBg', label:'Modal Background'},
+      {id:'modalText', label:'Modal Text'},
+      {id:'scrollbarTrack', label:'Scrollbar Track'},
+      {id:'scrollbarThumb', label:'Scrollbar Thumb'},
+      {id:'scrollbarThumbHover', label:'Scrollbar Thumb Hover'},
+      {id:'listBackground', label:'List Background'}
+    ];
+    miscFields.forEach(p=>{
+      const row = document.createElement('div');
+      row.className = 'control-row';
+      row.innerHTML = `
+            <label>${p.label}</label>
+            <div class="color-group">
+              <input id="${p.id}" type="color" data-mode="${COLOR_PICKER_MODE}" />
+            </div>
+          `;
+      misc.appendChild(row);
+    });
+    wrap.appendChild(misc);
   }
 
   function applyAdmin(targetInput){
@@ -4223,7 +4013,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     });
     const sticky = document.getElementById('open-posts-sticky');
     if(sticky){ data['open-posts-sticky'] = { value: sticky.checked ? '1' : '0' }; }
-    ['primary','secondary','accent','buttonHoverText'].forEach(id=>{
+    ['primary','secondary','accent','buttonHoverText','btn','btnHover','btnActive','modalBg','modalText','scrollbarTrack','scrollbarThumb','scrollbarThumbHover','listBackground'].forEach(id=>{
       const input = document.getElementById(id);
       if(input){
         data[id] = { color: input.value };
@@ -4233,10 +4023,10 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   }
 
   function generateCss(data){
-    const varNames = {primary:'--primary',secondary:'--secondary',accent:'--accent',buttonHoverText:'--button-hover-text',border:'--border',hoverBorder:'--border-hover',activeBorder:'--border-active'};
+    const varNames = {primary:'--primary',secondary:'--secondary',accent:'--accent',buttonHoverText:'--button-hover-text',btn:'--btn',btnHover:'--btn-hover',btnActive:'--btn-active',modalBg:'--modal-bg',modalText:'--modal-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',border:'--border',hoverBorder:'--border-hover',activeBorder:'--border-active'};
     let css = '';
     const rootVars = [];
-    ['primary','secondary','accent','buttonHoverText'].forEach(key=>{
+    ['primary','secondary','accent','buttonHoverText','btn','btnHover','btnActive','modalBg','modalText','scrollbarTrack','scrollbarThumb','scrollbarThumbHover','listBackground'].forEach(key=>{
       if(data[key] && data[key].color){
         rootVars.push(`${varNames[key]}:${data[key].color};`);
       }
@@ -4340,7 +4130,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
         if(!type){
           const input = document.getElementById(key);
           if(input && val.color){ input.value = val.color; }
-          const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',buttonHoverText:'--button-hover-text'};
+          const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',buttonHoverText:'--button-hover-text',btn:'--btn',btnHover:'--btn-hover',btnActive:'--btn-active',modalBg:'--modal-bg',modalText:'--modal-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background'};
           if(varMap[key]) document.documentElement.style.setProperty(varMap[key], val.color);
           return;
         }
@@ -4712,12 +4502,21 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     updateHistoryButtons();
   });
 
-  const fieldBindings = {
-    primary: '--primary',
-    secondary: '--secondary',
-    accent: '--accent',
-    buttonHoverText: '--button-hover-text'
-  };
+    const fieldBindings = {
+      primary: '--primary',
+      secondary: '--secondary',
+      accent: '--accent',
+      buttonHoverText: '--button-hover-text',
+      btn: '--btn',
+      btnHover: '--btn-hover',
+      btnActive: '--btn-active',
+      modalBg: '--modal-bg',
+      modalText: '--modal-text',
+      scrollbarTrack: '--scrollbar-track',
+      scrollbarThumb: '--scrollbar-thumb',
+      scrollbarThumbHover: '--scrollbar-thumb-hover',
+      listBackground: '--list-background'
+    };
   Object.entries(fieldBindings).forEach(([id, varName])=>{
     const el = document.getElementById(id);
     if(el){


### PR DESCRIPTION
## Summary
- Embed dark transparency theme as the site's default style block
- Move Litepicker below the date range input for clearer layout
- Add "Miscellaneous" fieldset to manage additional color settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2b8036b08331ade8d59157663fd6