### PR TITLE
Allow open posts overflow when sticky

### DIFF
--- a/index.html
+++ b/index.html
@@ -953,6 +953,10 @@ select option:hover{
   overflow:hidden;
 }
 
+.open-posts-sticky .open-posts{
+  overflow:visible;
+}
+
 .open-posts .detail-header{
   display:flex;
   justify-content:space-between;


### PR DESCRIPTION
## Summary
- ensure open posts can overflow when sticky toggle is enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5216af4c8331b810cc7721bf8288