### PR TITLE
Make open post image area sticky and shrink thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -989,6 +989,12 @@ select option:hover{
   gap:8px;
 }
 
+.open-posts-sticky .open-posts .img-area{
+  position:sticky;
+  top:calc(var(--header-h) + 8px);
+  align-self:start;
+}
+
 .open-posts .img-box{
   width:400px;
   height:400px;
@@ -1016,8 +1022,8 @@ select option:hover{
 }
 
 .open-posts .thumb-column img{
-  width:100px;
-  height:100px;
+  width:50px;
+  height:50px;
   object-fit:cover;
   border:1px solid var(--border);
   border-radius:8px;


### PR DESCRIPTION
## Summary
- keep open post image area fixed beneath the header
- shrink vertical thumbnail slider images to 50x50 so they remain square

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5b22c3988331bc93d272cd8dc52a