### PR TITLE
fix: update Leaflet SRI hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <title>Events Platform</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/litepicker/dist/css/litepicker.css" />
   <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/bundle.js"></script>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+S7sJv0QNXh9gS2wpry9vywgqbiZz05kM1f9x0i3A=" crossorigin="" />
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1jGyXus7nEob1jULICwhf66A1VpzwuWgGfp9aggY=" crossorigin=""></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <style>:root{
   --header-h: 72px;
   --panel-w: 260px;


### PR DESCRIPTION
## Summary
- fix blocked Leaflet resources by updating CDN integrity hashes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7bc4f11483318ecf3404d702defc