### PR TITLE
Fix alignment of post map with image box

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,7 +1022,7 @@ select option:hover{
 }
 
 .open-posts .text{
-  margin-top:12px;
+  margin-top:0;
 }
 
 .open-posts .img-area{


### PR DESCRIPTION
## Summary
- Remove unwanted top margin from `.open-posts .text` so the map aligns with the top of the image box

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8ba7d8e48331b4e6d1fce3a66f4a