### PR TITLE
Prevent post content from overlapping sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -996,6 +996,7 @@ select option:hover{
 .open-posts-sticky-header .open-posts,
 .open-posts-sticky-images .open-posts{
   overflow:visible;
+  clip-path: inset(0 round 18px);
 }
 
 .open-posts .detail-header{


### PR DESCRIPTION
## Summary
- clip open post content when sticky header is enabled so content can't show above it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9013435c833198cbc9a8dd8c4753