### PR TITLE
Fix overflow of closed posts list to avoid header overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,7 +964,7 @@ select option:hover{
   color:#000;
   background:rgba(0,0,0,0.7);
 }
-.closed-posts .res-list{overflow:visible;padding:0;}
+.closed-posts .res-list{overflow:auto;padding:0;}
 .closed-posts{color:#000;}
 .closed-posts .card{background:var(--list-background);}
 .closed-posts button{background:var(--btn);border-color:var(--btn);color:var(--ink);}


### PR DESCRIPTION
## Summary
- Ensure closed-post list uses `overflow:auto` so content is clipped before reaching the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa931bf4788331a942540f2b7fa402