### PR TITLE
feat: allow theme builder to style dropdown fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,10 +158,6 @@ select{
   border:1px solid var(--border);
   border-radius: var(--dropdown-radius);
 }
-.location-select{
-  color: var(--dropdown-venue-text);
-}
-
 .location-select option{
   white-space: pre-line;
 }
@@ -176,6 +172,20 @@ select option:checked{
 select option:hover{
   background: var(--dropdown-hover-bg);
   color: var(--dropdown-hover-text);
+}
+
+select.unstyled-select{
+  background: revert;
+  color: inherit;
+  border: revert;
+  border-radius: revert;
+  appearance: revert;
+}
+select.unstyled-select option,
+select.unstyled-select option:checked,
+select.unstyled-select option:hover{
+  background: revert;
+  color: inherit;
 }
 
   .header{
@@ -1761,7 +1771,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
             <div id="resultCount" aria-live="polite"><strong>0</strong> Results</div>
           </div>
           <div class="res-actions">
-            <select id="sortSelect" aria-label="Sort order">
+            <select id="sortSelect" class="unstyled-select" aria-label="Sort order">
               <option value="az">Title A - Z</option>
               <option value="nearest">Closest</option>
               <option value="soon">Soonest</option>
@@ -3232,12 +3242,12 @@ function makePosts(){
             <div class="location-section">
               <div class="map-container">
                 <div id="map-${p.id}" class="post-map"></div>
-                ${p.locations.length>1 ? `<select id="loc-${p.id}">${p.locations.map((loc,i)=>`<option value="${i}">${loc.venue}&#10;${loc.address}</option>`).join('')}</select>` : ``}
+                ${p.locations.length>1 ? `<select id="loc-${p.id}" class="location-select unstyled-select">${p.locations.map((loc,i)=>`<option value="${i}">${loc.venue}&#10;${loc.address}</option>`).join('')}</select>` : ``}
                 <div id="loc-info-${p.id}" class="location-info"></div>
               </div>
               <div class="calendar-container">
                 <div id="cal-${p.id}" class="post-calendar"></div>
-                <select id="sess-${p.id}">
+                <select id="sess-${p.id}" class="unstyled-select">
                   <option value="">Select session</option>
                 </select>
                 <div id="session-info-${p.id}" class="session-info">
@@ -3723,11 +3733,11 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
 
   const colorAreas = [
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
-    {key:'subheader', label:'Subheader', selectors:{bg:['.subheader'], text:['.subheader'], btn:['.subheader button'], btnText:['.subheader button']}},
+    {key:'subheader', label:'Subheader', selectors:{bg:['.subheader'], text:['.subheader','#sortSelect'], btn:['.subheader button'], btnText:['.subheader button']}},
     {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
     {key:'list', label:'Results List', selectors:{bg:['.res-list'], text:['.res-list'], title:['.res-list .card .t','.res-list .card .title'], btn:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], btnText:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], card:['.res-list .card']}},
     {key:'closed-posts', label:'Closed Posts', selectors:{bg:['.closed-posts'], text:['.closed-posts','.closed-posts .res-list'], title:['.closed-posts .card .t','.closed-posts .card .title','.closed-posts .open-posts .t','.closed-posts .open-posts .title'], btn:['.closed-posts button'], btnText:['.closed-posts button'], card:['.closed-posts .card','.closed-posts .open-posts']}},
-    {key:'open-posts', label:'Open Posts', selectors:{text:['.open-posts'], title:['.open-posts .t','.open-posts .title'], btn:['.open-posts button'], btnText:['.open-posts button'], card:['.open-posts'], header:['.open-posts .detail-header'], image:['.open-posts .img-box'], litepickerText:['.open-posts .litepicker','.open-posts .litepicker .day-item']}},
+    {key:'open-posts', label:'Open Posts', selectors:{text:['.open-posts','.open-posts select'], title:['.open-posts .t','.open-posts .title'], btn:['.open-posts button'], btnText:['.open-posts button'], card:['.open-posts'], header:['.open-posts .detail-header'], image:['.open-posts .img-box'], litepickerText:['.open-posts .litepicker','.open-posts .litepicker .day-item']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['.map-wrap'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], text:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
     {key:'filter', label:'Filter Modal', selectors:{bg:['#filterModal .modal-content'], text:['#filterModal .modal-content'], title:['#filterModal .modal-content .t','#filterModal .modal-content .title'], btn:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], btnText:['#filterModal button','#filterModal .sq','#filterModal .tiny','#filterModal .btn'], catText:['#filterModal .cat .bar .label'], subText:['#filterModal .sub .chip'], litepickerText:['#filterModal .litepicker','#filterModal .litepicker .day-item']}},


### PR DESCRIPTION
## Summary
- remove default styling from sort and post detail dropdowns
- let theme builder control their font family, size and weight

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaf1a148788331860714dc7bf19bab