### PR TITLE
Widen CSS editor within admin modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,6 +516,7 @@ select option:hover{
   flex-direction:column;
 }
 #adminModal .modal-field{margin:0;max-width:320px;}
+#adminModal #cssEditorContainer{width:100%;max-width:none;}
 #baseColorRow{
   flex-direction:row;
   align-items:center;


### PR DESCRIPTION
## Summary
- Allow CSS editor container to span full width of the admin modal by overriding modal-field max-width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaff1024148331934e0c128d99153d