### PR TITLE
feat: expand theme CSS editor height

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,7 @@ select option:hover{
 }
 #adminModal .modal-field{margin:0;max-width:320px;}
 #adminModal #cssEditorContainer{width:100%;max-width:none;}
+#adminModal #themeCssEditor{height:600px;}
 #baseColorRow{
   flex-direction:row;
   align-items:center;


### PR DESCRIPTION
## Summary
- ensure theme builder's CSS editor loads at a 600px height by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab01056ee88331bc4050a04c1d7c88