### PR TITLE
Sync Save CSS button with CSS editor for live theme updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -4831,6 +4831,10 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     styleEl.textContent = css;
   }
 
+  cssEditor && cssEditor.addEventListener('input', ()=>{
+    applyCustomCss(cssEditor.value);
+  });
+
   function updatePresetOptions(){
     const sel = document.getElementById('themePreset');
     if(!sel) return;
@@ -5222,16 +5226,23 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   });
 
   saveCssBtn && saveCssBtn.addEventListener('click', ()=>{
-    const css = generateCss(collectThemeValues());
-    cssEditor.value = css;
+    undoStack.push(JSON.parse(JSON.stringify(currentState)));
+    redoStack.length = 0;
+    const css = cssEditor.value;
+    applyCustomCss(css);
+    syncAdminControls();
+    const data = collectThemeValues();
+    currentState = JSON.parse(JSON.stringify(data));
     const idx = parseInt(presetSelect.value, 10);
     const p = presets[idx];
     if(p){
+      p.data = data;
       p.css = css;
       localStorage.setItem('themePresets', JSON.stringify(presets.slice(1)));
     }
     localStorage.setItem('currentThemeCss', css);
-    applyCustomCss(css);
+    localStorage.setItem('currentTheme', JSON.stringify(data));
+    updateHistoryButtons();
   });
 
   const baseColorInput = document.getElementById('baseColor');


### PR DESCRIPTION
## Summary
- Apply custom CSS from the editor in real time while typing
- Update Save CSS to persist editor changes, refresh theme controls, and sync presets/local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab073bfe848331829a90275602f8bf