### PR TITLE
Fix sticky open post header preventing upward scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -1017,6 +1017,7 @@ select option:hover{
   border-radius:18px;
   margin:0 0 12px 0;
   overflow:hidden;
+  scroll-margin-top:calc(var(--header-h) + 8px);
 }
 
 .open-posts-sticky-header .open-posts,
@@ -1035,7 +1036,7 @@ select option:hover{
 }
 .open-posts-sticky-header .open-posts .detail-header{
   position:sticky;
-  top:-1px;
+  top:calc(var(--header-h) + 8px);
   z-index:3;
   background:var(--list-background);
   border:1px solid var(--border);
@@ -1634,7 +1635,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 </style>
 <style id="theme-dark-transparency">
 :root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:rgba(74,74,74,0.9);--btn-hover:rgba(0,0,0,1);--btn-active:rgba(0,0,0,1);--modal-bg:rgba(0,0,0,0.62);--modal-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:#d1d1d1;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);}
-.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}
+.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:calc(var(--header-h) + 8px);z-index:3;background:var(--list-background);}
 .header{background-color:rgba(41,41,41,1);}
 .header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
@@ -4742,7 +4743,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       css += `:root{${rootVars.join('')}}\n`;
     }
     if(data['open-posts-sticky-header'] && data['open-posts-sticky-header'].value === '1'){
-      css += '.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}\n';
+      css += '.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:calc(var(--header-h) + 8px);z-index:3;background:var(--list-background);}\n';
     }
     colorAreas.forEach(area=>{
       ['bg','card','text','title','btn','btnText','catText','subText','litepickerText','header','image'].forEach(type=>{


### PR DESCRIPTION
## Summary
- offset sticky open post header by the page header height
- add scroll margin so preceding posts remain reachable
- update theme and dynamic CSS to use the same offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab91f4d15083319ce3399c8cdb86af