### PR TITLE
Fix sticky post header overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   --panel-w: 260px;
   --results-w: 520px;
   --gap: 12px;
+  --post-header-offset: 0px;
     --ink: #ffffff;
     --ink-d: #ececec;
     --gold: #ffc107;
@@ -1036,7 +1037,7 @@ select option:hover{
 }
 .open-posts-sticky-header .open-posts .detail-header{
   position:sticky;
-  top:calc(var(--header-h) + 8px);
+  top:var(--post-header-offset);
   z-index:3;
   background:var(--list-background);
   border:1px solid var(--border);
@@ -1063,7 +1064,7 @@ select option:hover{
 
 .open-posts-sticky-images .open-posts .img-area{
   position:sticky;
-  top:calc(var(--header-h) + 8px);
+  top:var(--post-header-offset);
   align-self:start;
 }
 
@@ -1634,8 +1635,8 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 
 </style>
 <style id="theme-dark-transparency">
-:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:rgba(74,74,74,0.9);--btn-hover:rgba(0,0,0,1);--btn-active:rgba(0,0,0,1);--modal-bg:rgba(0,0,0,0.62);--modal-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:#d1d1d1;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);}
-.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:calc(var(--header-h) + 8px);z-index:3;background:var(--list-background);}
+:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:rgba(74,74,74,0.9);--btn-hover:rgba(0,0,0,1);--btn-active:rgba(0,0,0,1);--modal-bg:rgba(0,0,0,0.62);--modal-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:#d1d1d1;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);--post-header-offset:0px;}
+.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:var(--post-header-offset);z-index:3;background:var(--list-background);}
 .header{background-color:rgba(41,41,41,1);}
 .header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
@@ -4743,7 +4744,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       css += `:root{${rootVars.join('')}}\n`;
     }
     if(data['open-posts-sticky-header'] && data['open-posts-sticky-header'].value === '1'){
-      css += '.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:calc(var(--header-h) + 8px);z-index:3;background:var(--list-background);}\n';
+      css += '.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:var(--post-header-offset);z-index:3;background:var(--list-background);}\n';
     }
     colorAreas.forEach(area=>{
       ['bg','card','text','title','btn','btnText','catText','subText','litepickerText','header','image'].forEach(type=>{
@@ -5368,8 +5369,17 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     dragEl = null;
   });
 
+  function updatePostHeaderOffset(){
+    const headerH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 0;
+    const offset = Math.max(headerH - window.scrollY, 0);
+    document.documentElement.style.setProperty('--post-header-offset', `${offset}px`);
+  }
+
+  window.addEventListener('scroll', updatePostHeaderOffset);
   window.addEventListener('resize', window.adjustListHeight);
+  window.addEventListener('resize', updatePostHeaderOffset);
   window.adjustListHeight();
+  updatePostHeaderOffset();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Adjust sticky post header and image positioning using a dynamic `--post-header-offset` variable
- Update offset on scroll/resize so open posts no longer sit beneath the site header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab98ac01b483319ad4d7df04d0aab2