### PR TITLE
Ensure posts close when opening another

### DIFF
--- a/index.html
+++ b/index.html
@@ -3288,12 +3288,14 @@ function makePosts(){
       if(!postsWideEl.children.length){ renderLists(filtered); await nextFrame(); }
 
       (function(){
-        const ex = postsWideEl.querySelector('.open-posts');
-        if(ex){
+        const container = document.querySelector('.closed-posts');
+        const openEls = container ? container.querySelectorAll('.open-posts') : [];
+        openEls.forEach(ex => {
           const exId = ex.dataset && ex.dataset.id;
           const prev = posts.find(x=> x.id===exId);
-          if(prev){ ex.replaceWith(card(prev, true)); } else { ex.remove(); }
-        }
+          if(prev){ postsWideEl.prepend(card(prev, true)); }
+          ex.remove();
+        });
       })();
 
       let target = postsWideEl.querySelector(`[data-id="${id}"]`);


### PR DESCRIPTION
## Summary
- Remove any existing open post before opening a new one to keep only one post expanded at a time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab9cc1db3c83319aac7308fbb14712