### PR TITLE
Remove custom Litepicker styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -678,21 +678,6 @@ select option:hover{
   height: 18px;
 }
 
-.litepicker{
-  background: var(--btn);
-  color: var(--ink);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-}
-.litepicker *{
-  color: var(--ink);
-}
-.litepicker .day-item.is-start-date,
-.litepicker .day-item.is-end-date,
-.litepicker .day-item.is-in-range{
-  background: var(--accent);
-  color: var(--button-hover-text);
-}
 
 .cats{
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- Restore Litepicker's native colors by removing custom `.litepicker` style rules.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abaf79929c833183f6a8b71a0f9b19