### PR TITLE
Avoid reloading post when favouriting

### DIFF
--- a/index.html
+++ b/index.html
@@ -3262,10 +3262,20 @@ function makePosts(){
         favBtn.addEventListener('click', (e)=>{
           e.stopPropagation();
           p.fav = !p.fav;
-          favBtn.setAttribute('aria-pressed', p.fav?'true':'false');
+          favBtn.setAttribute('aria-pressed', p.fav ? 'true' : 'false');
+          const detailEl = el;
+          const container = detailEl.closest('.closed-posts');
           renderLists(filtered);
-          stopSpin();
-          openPost(p.id, !!el.closest('.closed-posts'));
+          renderFooter();
+          const replacement = postsWideEl.querySelector(`[data-id="${p.id}"]`);
+          if(replacement){
+            replacement.replaceWith(detailEl);
+            if(container){
+              ensureGap(container, detailEl);
+            } else {
+              detailEl.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
+            }
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- Preserve the currently open post when toggling favourites
- Update lists and footer without rebuilding the open post

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abca6fd9a08331a1f63b8769966111