### PR TITLE
Add favourites checkbox to sort dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,6 +816,34 @@ select option:hover{
   border-radius: 999px;
 }
 
+.sort-box{
+  position: relative;
+  display: inline-block;
+}
+
+.sort-box select{
+  padding-right: 140px;
+}
+
+.sort-box .fav-check{
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--dropdown-text);
+  z-index: 1;
+  background: var(--dropdown-bg);
+  padding: 0 4px;
+}
+
+.sort-box .fav-check input{
+  margin: 0;
+}
+
 .res-list{
   overflow: auto;
   padding-right: 6px;
@@ -1713,14 +1741,17 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
   <main class="main">
       <div class="subheader">
         <button id="filterBtn" aria-label="Open filters modal">Filters</button>
-        <select id="sortSelect" aria-label="Sort order">
-          <option value="az">Title A - Z</option>
-          <option value="nearest">Closest</option>
-          <option value="soon">Soonest</option>
-        </select>
-        <button id="favToggle" class="fav" aria-pressed="false" aria-label="Toggle favourites on top">
-          <svg viewBox="0 0 24 24"><path d="M12 17.3 6.2 21l1.6-6.7L2 9.3l6.9-.6L12 2l3.1 6.7 6.9.6-5.8 4.9L17.8 21 12 17.3z"/></svg>
-        </button>
+        <div class="sort-box">
+          <select id="sortSelect" aria-label="Sort order">
+            <option value="az">Title A - Z</option>
+            <option value="nearest">Closest</option>
+            <option value="soon">Soonest</option>
+          </select>
+          <label class="fav-check">
+            <input type="checkbox" id="favToggle" aria-label="Toggle favourites on top" />
+            Favourites to top
+          </label>
+        </div>
         <div id="resultCount" aria-live="polite"><strong>0</strong> Results</div>
       </div>
       <section class="results-col" aria-label="Results">
@@ -2123,7 +2154,7 @@ function buildClusterListHTML(items){
     let ref = {lng:0,lat:0}; if(map){ const c = map.getCenter(); ref = {lng:c.lng,lat:c.lat}; }
     arr.sort((a,b)=> distKm({lng:a.lng,lat:a.lat}, ref) - distKm({lng:b.lng,lat:b.lat}, ref));
   }
-  if($('#favToggle').getAttribute('aria-pressed')==='true') arr.sort((a,b)=> (b.fav - a.fav));
+  if($('#favToggle').checked) arr.sort((a,b)=> (b.fav - a.fav));
   const list = arr.map(p => {
     return `
       <div class="multi-item" data-id="${p.id}">
@@ -2556,11 +2587,7 @@ function makePosts(){
     });
     $('#sortSelect').addEventListener('change', ()=> renderLists(filtered));
     const favToggleBtn = $('#favToggle');
-    favToggleBtn.addEventListener('click', ()=>{
-      const on = favToggleBtn.getAttribute('aria-pressed') === 'true';
-      favToggleBtn.setAttribute('aria-pressed', on ? 'false' : 'true');
-      renderLists(filtered);
-    });
+    favToggleBtn.addEventListener('change', ()=> renderLists(filtered));
     $$('.field .x').forEach(x=> x.addEventListener('click',()=>{
       const input = x.parentElement.querySelector('input');
       if(input){
@@ -2995,7 +3022,7 @@ function makePosts(){
         let ref = {lng:0,lat:0}; if(map){ const c = map.getCenter(); ref = {lng:c.lng,lat:c.lat}; }
         arr.sort((a,b)=> distKm({lng:a.lng,lat:a.lat}, ref) - distKm({lng:b.lng,lat:b.lat}, ref));
       }
-      if($('#favToggle').getAttribute('aria-pressed')==='true') arr.sort((a,b)=> (b.fav - a.fav));
+      if($('#favToggle').checked) arr.sort((a,b)=> (b.fav - a.fav));
 
         resultsEl.innerHTML = '';
         postsWideEl.innerHTML = '';


### PR DESCRIPTION
## Summary
- embed a "Favourites to top" checkbox inside the sort dropdown and remove the old star button
- style the new sort box and checkbox
- update sorting logic to respect the checkbox state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abcc5b875c8331b54e1cc7c2008573