### PR TITLE
Add subheader options dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,6 +816,11 @@ select option:hover{
   border-radius: 999px;
 }
 
+.options-dropdown{ position:relative; }
+.options-menu{ position:absolute; top:calc(100% + 4px); left:0; background:var(--dropdown-bg); color:var(--dropdown-text); border:1px solid var(--border); border-radius:var(--dropdown-radius); padding:10px; display:flex; flex-direction:column; gap:6px; box-shadow:0 2px 6px rgba(0,0,0,0.2); z-index:30; }
+.options-menu[hidden]{ display:none; }
+.options-menu label{ display:flex; align-items:center; gap:6px; white-space:nowrap; }
+
 .res-list{
   overflow: auto;
   padding-right: 6px;
@@ -1713,14 +1718,19 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
   <main class="main">
       <div class="subheader">
         <button id="filterBtn" aria-label="Open filters modal">Filters</button>
-        <select id="sortSelect" aria-label="Sort order">
-          <option value="az">Title A - Z</option>
-          <option value="nearest">Closest</option>
-          <option value="soon">Soonest</option>
-        </select>
-        <button id="favToggle" class="fav" aria-pressed="false" aria-label="Toggle favourites on top">
-          <svg viewBox="0 0 24 24"><path d="M12 17.3 6.2 21l1.6-6.7L2 9.3l6.9-.6L12 2l3.1 6.7 6.9.6-5.8 4.9L17.8 21 12 17.3z"/></svg>
-        </button>
+        <div class="options-dropdown">
+          <button id="optionsBtn" aria-haspopup="true" aria-expanded="false">Options</button>
+          <div id="optionsMenu" class="options-menu" hidden>
+            <label><input type="checkbox" id="favChk" /> Favourites to Top</label>
+            <label>Sort Order
+              <select id="sortSelect" aria-label="Sort order">
+                <option value="az">Title A - Z</option>
+                <option value="nearest">Closest</option>
+                <option value="soon">Soonest</option>
+              </select>
+            </label>
+          </div>
+        </div>
         <div id="resultCount" aria-live="polite"><strong>0</strong> Results</div>
       </div>
       <section class="results-col" aria-label="Results">
@@ -2123,7 +2133,7 @@ function buildClusterListHTML(items){
     let ref = {lng:0,lat:0}; if(map){ const c = map.getCenter(); ref = {lng:c.lng,lat:c.lat}; }
     arr.sort((a,b)=> distKm({lng:a.lng,lat:a.lat}, ref) - distKm({lng:b.lng,lat:b.lat}, ref));
   }
-  if($('#favToggle').getAttribute('aria-pressed')==='true') arr.sort((a,b)=> (b.fav - a.fav));
+  if($('#favChk').checked) arr.sort((a,b)=> (b.fav - a.fav));
   const list = arr.map(p => {
     return `
       <div class="multi-item" data-id="${p.id}">
@@ -2555,11 +2565,25 @@ function makePosts(){
       }
     });
     $('#sortSelect').addEventListener('change', ()=> renderLists(filtered));
-    const favToggleBtn = $('#favToggle');
-    favToggleBtn.addEventListener('click', ()=>{
-      const on = favToggleBtn.getAttribute('aria-pressed') === 'true';
-      favToggleBtn.setAttribute('aria-pressed', on ? 'false' : 'true');
-      renderLists(filtered);
+    const favChk = $('#favChk');
+    favChk.addEventListener('change', ()=> renderLists(filtered));
+    const optionsBtn = $('#optionsBtn');
+    const optionsMenu = $('#optionsMenu');
+    optionsBtn.addEventListener('click', e=>{
+      e.stopPropagation();
+      const open = !optionsMenu.hasAttribute('hidden');
+      if(open){
+        optionsMenu.setAttribute('hidden','');
+        optionsBtn.setAttribute('aria-expanded','false');
+      } else {
+        optionsMenu.removeAttribute('hidden');
+        optionsBtn.setAttribute('aria-expanded','true');
+      }
+    });
+    optionsMenu.addEventListener('click', e=> e.stopPropagation());
+    document.addEventListener('click', ()=>{
+      optionsMenu.setAttribute('hidden','');
+      optionsBtn.setAttribute('aria-expanded','false');
     });
     $$('.field .x').forEach(x=> x.addEventListener('click',()=>{
       const input = x.parentElement.querySelector('input');
@@ -2995,7 +3019,7 @@ function makePosts(){
         let ref = {lng:0,lat:0}; if(map){ const c = map.getCenter(); ref = {lng:c.lng,lat:c.lat}; }
         arr.sort((a,b)=> distKm({lng:a.lng,lat:a.lat}, ref) - distKm({lng:b.lng,lat:b.lat}, ref));
       }
-      if($('#favToggle').getAttribute('aria-pressed')==='true') arr.sort((a,b)=> (b.fav - a.fav));
+      if($('#favChk').checked) arr.sort((a,b)=> (b.fav - a.fav));
 
         resultsEl.innerHTML = '';
         postsWideEl.innerHTML = '';


### PR DESCRIPTION
## Summary
- Add options dropdown to subheader with favourites checkbox and sort select
- Style dropdown with theme-aware variables
- Update scripts to toggle dropdown and respect favourites-first sorting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd2b9c1a88331a9dba8f391fc0f72