### PR TITLE
Fix Litepicker width and calendar click handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1296,7 +1296,7 @@ select option:hover{
 
 .open-posts .post-calendar .litepicker{
   font-size:16px;
-  width:100%;
+  width:400px;
   box-sizing:border-box;
 }
 
@@ -3752,6 +3752,7 @@ function makePosts(){
           numberOfMonths: 1,
           numberOfColumns: 1
         });
+        calendarEl.addEventListener('click', e=> e.stopPropagation());
         let ignoreSelect = false;
         function highlightMonth(){
           calendarEl.querySelectorAll('.month-name').forEach(n=> n.classList.remove('selected-month-name'));


### PR DESCRIPTION
## Summary
- Keep post calendar Litepicker at fixed 400px width
- Prevent map mode when interacting with post calendar by stopping click propagation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5e53bc108331b0808c96a28ed166