### PR TITLE
Fix admin modal close and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,6 +350,7 @@ select option:hover{
 }
 .admin-fieldset legend{cursor:pointer;display:flex;align-items:center;justify-content:space-between;}
 .admin-fieldset legend .fs-toggle{margin-left:8px;padding:2px 6px;font-size:12px;}
+.admin-fieldset.collapsed{height:50px;overflow:hidden;}
 .admin-fieldset.collapsed > *:not(legend):not(.fieldset-actions){display:none;}
 #adminModal #styleControls{display:flex;flex-wrap:wrap;gap:10px;align-items:flex-start;}
 #adminModal .admin-fieldset{
@@ -854,6 +855,8 @@ select option:hover{
   flex: 1;
   min-height: 0;
   scrollbar-gutter: stable;
+  margin-left:14px;
+  margin-bottom:14px;
 }
 
 .card{
@@ -1034,6 +1037,7 @@ select option:hover{
   border-radius:18px;
   margin:0 0 12px 0;
   overflow:visible;
+  padding-left:14px;
 }
 
 .open-posts .detail-header{
@@ -4051,7 +4055,9 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
   document.querySelectorAll('.modal .close-modal').forEach(btn=>{
     btn.addEventListener('click', ()=>{
       const modal = btn.closest('.modal');
-      if(modal && modal.id === 'adminModal') return;
+      if(modal && modal.id === 'adminModal' && typeof window.saveAdminChanges === 'function'){
+        window.saveAdminChanges();
+      }
       requestCloseModal(modal);
     });
   });
@@ -5370,7 +5376,6 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     // Save/Discard/Restore logic
     const saveBtn = document.getElementById('saveNow');
     const discardBtn = document.getElementById('discardChanges');
-    const adminClose = document.querySelector('#adminModal .close-modal');
     const tabPanels = ['theme','mapbox','settings'];
     const savedData = {};
 
@@ -5495,11 +5500,6 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     discardBtn && discardBtn.addEventListener('click', ()=>{
       if(!confirm('Are you sure you want to Discard Your Changes? Y/N')) return;
       tabPanels.forEach(tab=> applyData(tab, savedData[tab]));
-    });
-
-    adminClose && adminClose.addEventListener('click', ()=>{
-      saveAllTabs();
-      requestCloseModal(adminClose.closest('.modal'));
     });
 
     document.querySelectorAll('button[data-restore]').forEach(btn=>{


### PR DESCRIPTION
## Summary
- Ensure admin modal close button saves changes and closes modal
- Add left padding to open posts panel and margins for results list
- Collapse fieldsets to fixed 50px height for compact admin UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acd1a311a08331a3567e6c0cfa1632