### PR TITLE
Use flex layout for main content

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,9 @@ body{
   overflow: hidden;
   cursor: default;
   caret-color: transparent;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 input,
@@ -587,13 +590,13 @@ select option:hover{
 .field-instance{margin:4px 0;}
 
 .main{
-    height: calc(100vh - var(--header-h) - var(--footer-h));
     display: grid;
     grid-template-columns: var(--results-w) 1fr;
     grid-template-rows: auto 1fr;
     row-gap: var(--gap);
     column-gap: 0;
     padding: 0;
+    flex: 1 0 auto;
   }
 
 .filters-col{


### PR DESCRIPTION
## Summary
- switch to a flex-based layout by turning `<body>` into a flex column and allowing `<main>` to grow
- retain `--footer-h` variable so themes can manage footer height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf6f641048331914348f12ca66d76