### PR TITLE
Prevent admin balloon buttons from submitting form

### DIFF
--- a/index.html
+++ b/index.html
@@ -5971,6 +5971,7 @@ window.addEventListener('resize', updateStickyImages);
 
     Object.keys(SHAPES).forEach((name,idx)=>{
       const btn = document.createElement('button');
+      btn.type = 'button';
       btn.className = 'shape-button';
       btn.appendChild(createBalloon(name, '#000', 24));
       btn.appendChild(document.createTextNode(LABELS[name] || name));


### PR DESCRIPTION
## Summary
- Avoid unintended form submissions in admin modal balloon generator by setting shape buttons' type to `button`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad43d30d548331812191fc6aaa17a1