### PR TITLE
Re-filter map results when list toggled

### DIFF
--- a/index.html
+++ b/index.html
@@ -2992,7 +2992,13 @@ function makePosts(){
         resultsToggle.setAttribute('aria-pressed', hidden ? 'false' : 'true');
         resultsCol.setAttribute('aria-hidden', hidden ? 'true' : 'false');
         window.adjustListHeight();
-        setTimeout(()=>{ if(window.map) map.resize(); }, 310);
+        setTimeout(()=>{
+          if(window.map){
+            map.resize();
+            updatePostPanel();
+            applyFilters();
+          }
+        }, 310);
       });
 
       function setMode(m){


### PR DESCRIPTION
## Summary
- Recalculate map bounds and reapply filters when the results list is shown or hidden so visible posts reflect current map area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad62432efc8331a30bec493e097e13