### PR TITLE
Remove side margins around map

### DIFF
--- a/index.html
+++ b/index.html
@@ -1904,7 +1904,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 .subheader button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #main-tab-map[aria-selected="true"]{color:#ff0000;}
 body{background-color:rgba(41,41,41,1);}
-.main{margin:14px;}
+.main{margin:0;}
+
+.main .post-panel{padding:0;}
 
 .hide-map-calendar .open-posts .map-container,
 .hide-map-calendar .open-posts .calendar-container{display:none;}

--- a/themes/readable.css
+++ b/themes/readable.css
@@ -14,7 +14,9 @@
 .subheader button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .options-menu{background-color:rgba(255,255,255,1);}
 body{background-color:rgba(41,41,41,1);}
-.main{margin:14px;}
+.main{margin:0;}
+
+.main .post-panel{padding:0;}
 
 .hide-map-calendar .open-posts .map-container,
 .hide-map-calendar .open-posts .calendar-container{display:none;}


### PR DESCRIPTION
## Summary
- Remove default margin from main layout and padding from map panel to eliminate side bars
- Apply margin and padding fixes to theme CSS for consistent full-width map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6a951344833192904abb05095a88