### PR TITLE
Center geocoder over map and ensure header sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1020,7 +1020,7 @@ select option:hover{
   pointer-events: none;
 }
 
-.geocoder{position:absolute;top:10px;left:calc(var(--results-w) + 10px);z-index:10;min-width:240px;display:flex;gap:4px;pointer-events:auto;}
+.geocoder{position:absolute;top:10px;left:50%;transform:translateX(-50%);z-index:10;min-width:240px;display:flex;gap:4px;pointer-events:auto;}
 .geocoder .mapboxgl-ctrl-geocoder{flex:1;position:relative;height:40px;display:flex;align-items:center;}
 .geocoder .mapboxgl-ctrl-group{height:40px;width:40px;box-shadow:none;}
 .geocoder .mapboxgl-ctrl-geolocate{width:100%;height:100%;margin:0;padding:0;border:1px solid var(--border);border-radius:4px;background:#fff;display:flex;align-items:center;justify-content:center;background-position:center;background-size:20px 20px;}
@@ -1028,7 +1028,6 @@ select option:hover{
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:40px;}
 .geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:40px;padding:0 30px;}
 
-.main.hide-results + .post-panel .geocoder{left:10px;}
 .main.hide-results + .post-panel .map-overlay{left:0;}
 
 .closed-posts{
@@ -2024,6 +2023,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 
   <section class="map-area" aria-label="Map">
     <div id="map"></div>
+    <div id="geocoder" class="geocoder"></div>
   </section>
 
   <main class="main">
@@ -2053,7 +2053,6 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
   </main>
 
   <section class="post-panel" aria-label="Map Controls">
-    <div id="geocoder" class="geocoder"></div>
     <div class="map-overlay">Loading Map…</div>
   </section>
 


### PR DESCRIPTION
## Summary
- Place Mapbox address search and geolocation controls inside the map area and center them at the top of the map.
- Confirm header and subheader heights via CSS variables for consistent layout.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7791fc408331a00e80228cf38b43