### PR TITLE
Keep map visible while viewing posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1061,12 +1061,6 @@ select option:hover{
 .mode-map .closed-posts{
   display: none;
 }
-
-
-.mode-posts .map-area{
-  display: none;
-}
-
 .map-area{
   position: fixed;
   top: var(--header-h);
@@ -3072,7 +3066,7 @@ function makePosts(){
       $('#tab-posts').setAttribute('aria-selected', m==='posts');
       $('#main-tab-map').setAttribute('aria-selected', m==='map');
       if(map){
-        if(m==='map' && typeof map.resize === 'function'){
+        if(typeof map.resize === 'function'){
           map.resize();
         }
         updatePostPanel();


### PR DESCRIPTION
## Summary
- Allow map to remain visible when `mode-posts` class is active by removing CSS rule that hid it
- Resize map regardless of mode to keep layout consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad830c96bc8331be4599a9b1dc5285