### PR TITLE
Improve layout and modal navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ select option:hover{
   .logo{
     position: absolute;
     left: 50%;
-    top: 75px;
+    top: 50%;
     transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
@@ -848,7 +848,7 @@ select option:hover{
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  padding: 0 0 14px 14px;
+  padding: 0 0 14px 0;
   max-width: var(--results-w);
   transition: max-width .3s ease, padding .3s ease;
   position: relative;
@@ -868,7 +868,7 @@ select option:hover{
   color: var(--ink-d);
   grid-column: 1 / -1;
   height: var(--subheader-h);
-  padding: 14px;
+  padding: 14px 14px 14px 0;
   position: relative;
   z-index: 3;
 }
@@ -1026,7 +1026,7 @@ select option:hover{
   pointer-events: none;
 }
 
-.geocoder{position:absolute;top:10px;left:50%;transform:translateX(-50%);z-index:10;min-width:240px;display:flex;gap:4px;pointer-events:auto;}
+.geocoder{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:10;min-width:240px;display:flex;gap:4px;pointer-events:auto;}
 .geocoder .mapboxgl-ctrl-geocoder{flex:1;position:relative;height:40px;display:flex;align-items:center;}
 .geocoder .mapboxgl-ctrl-group{height:40px;width:40px;box-shadow:none;}
 .geocoder .mapboxgl-ctrl-geolocate{width:100%;height:100%;margin:0;padding:0;border:1px solid var(--border);border-radius:4px;background:#fff;display:flex;align-items:center;justify-content:center;background-position:center;background-size:20px 20px;}
@@ -1874,6 +1874,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   grid-row: 2;
   position: relative;
   z-index: 1;
+  pointer-events: none;
 }
 
 
@@ -2023,7 +2024,6 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 
   <section class="map-area" aria-label="Map">
     <div id="map"></div>
-    <div id="geocoder" class="geocoder"></div>
   </section>
 
   <main class="main">
@@ -2040,6 +2040,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
             </div>
           </div>
         </div>
+        <div id="geocoder" class="geocoder"></div>
         <button id="resultsToggle" aria-pressed="true">Results List</button>
         <div id="resultCount" aria-live="polite"><strong>0</strong> Results</div>
       </div>
@@ -2066,6 +2067,8 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
         <div class="header-top">
           <h2>Filters</h2>
           <div class="modal-actions">
+            <button type="button" class="move-left" aria-label="Move modal left">&lt;</button>
+            <button type="button" class="move-right" aria-label="Move modal right">&gt;</button>
             <button type="button" class="close-modal">Close</button>
           </div>
         </div>
@@ -2112,6 +2115,8 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
           <h2>Create Post</h2>
           <div class="modal-actions">
             <button type="submit" form="memberForm">Save</button>
+            <button type="button" class="move-left" aria-label="Move modal left">&lt;</button>
+            <button type="button" class="move-right" aria-label="Move modal right">&gt;</button>
             <button type="button" class="close-modal">Close</button>
           </div>
         </div>
@@ -2149,6 +2154,8 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
           <div class="modal-actions">
             <button type="button" id="discardChanges">Discard Changes</button>
             <button type="button" id="saveNow">Save Now</button>
+            <button type="button" class="move-left" aria-label="Move modal left">&lt;</button>
+            <button type="button" class="move-right" aria-label="Move modal right">&gt;</button>
             <button type="button" class="close-modal">Close</button>
           </div>
         </div>
@@ -4164,6 +4171,23 @@ function toggleModal(m){
     openModal(m);
   }
 }
+function moveModalToEdge(modal, side){
+  if(!modal) return;
+  const content = modal.querySelector('.modal-content');
+  if(!content) return;
+  const subHead = document.querySelector('.subheader');
+  const topPos = subHead ? subHead.getBoundingClientRect().bottom : parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 0;
+  content.style.top = `${topPos}px`;
+  content.style.transform = 'none';
+  if(side === 'left'){
+    content.style.left = '0';
+    content.style.right = '';
+  } else {
+    content.style.left = '';
+    content.style.right = '0';
+  }
+  saveModalState(modal);
+}
 function handleEsc(){
   const top = modalStack[modalStack.length-1];
   if(!top) return;
@@ -4200,6 +4224,20 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       const modal = btn.closest('.modal');
       if(modal && modal.id === 'adminModal') return;
       requestCloseModal(modal);
+    });
+  });
+  document.querySelectorAll('.modal .move-left').forEach(btn=>{
+    btn.addEventListener('click', e=>{
+      e.stopPropagation();
+      const modal = btn.closest('.modal');
+      moveModalToEdge(modal, 'left');
+    });
+  });
+  document.querySelectorAll('.modal .move-right').forEach(btn=>{
+    btn.addEventListener('click', e=>{
+      e.stopPropagation();
+      const modal = btn.closest('.modal');
+      moveModalToEdge(modal, 'right');
     });
   });
 


### PR DESCRIPTION
## Summary
- Center logo and geocoder, remove left gutter
- Add arrow buttons to modal headers to snap modals left or right
- Prevent hidden overlay from blocking the map

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad856cf84c83319479f79f0fb17026