### PR TITLE
Fix date range display and restore Litepicker hover colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,6 +401,10 @@ select option:hover{
   color: var(--ink);
   border: none;
 }
+#filterModal .litepicker [role="button"],
+#filterModal .litepicker [role="button"]:hover{
+  color: initial;
+}
 #memberModal #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
 #memberModal input[type=color]{
   border-radius:4px;
@@ -3024,9 +3028,12 @@ function makePosts(){
           if(start && end){
             const sIso = start.format('YYYY-MM-DD');
             const eIso = end.format('YYYY-MM-DD');
-            const sDisp = start.format('ddd D MMM');
-            const eDisp = end.format('ddd D MMM');
-            input.value = `${sDisp} to ${eDisp}`;
+            const fmt = d => d.toDate().toLocaleDateString('en-GB', {
+              weekday: 'short', day: 'numeric', month: 'short'
+            }).replace(/,/g, '');
+            const sDisp = fmt(start);
+            const eDisp = fmt(end);
+            input.value = `${sDisp} - ${eDisp}`;
             input.dataset.range = `${sIso} to ${eIso}`;
             todayWasOn = todayToggle && todayToggle.checked;
             $('#todayToggle').checked = false;


### PR DESCRIPTION
## Summary
- Format filter date range as "Thu 7 Aug - Sat 30 Aug" with weekday labels
- Remove theme hover color from Litepicker in filter modal to use default text colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae89a2d9e48331a8aa3afe5f68920f