### PR TITLE
Refine admin controls and balloon tool styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,34 +263,14 @@ select option:hover{
 }
   #spinType{
     display:flex;
-    gap:6px;
+    gap:10px;
     margin-top:6px;
   }
   #spinType label{
-    flex:1;
-    border-radius:6px;
-    overflow:hidden;
-  }
-  #spinType input{
-    display:none;
-  }
-  #spinType span{
-    display:block;
-    padding:6px 10px;
-    background:var(--btn);
-    color:var(--button-text);
+    display:flex;
+    align-items:center;
+    gap:4px;
     font-weight:600;
-    cursor:pointer;
-    text-align:center;
-    transition:background .2s,border-color .2s,color .2s;
-    border:1px solid var(--btn);
-    border-radius:6px;
-    white-space:nowrap;
-  }
-  #spinType input:checked + span{
-    background:var(--btn-hover);
-    border-color:var(--btn-hover);
-    color:var(--button-hover-text);
   }
 
 .auth{
@@ -2383,14 +2363,20 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
                 </div>
               </div>
             <div class="modal-field">
-              <label><input type="checkbox" id="spinLoadStart" /> Start on load</label>
+              <div class="control-row">
+                <label for="spinLoadStart">Spin on Load</label>
+                <input type="checkbox" id="spinLoadStart" />
+              </div>
               <div id="spinType">
-                <label><input type="radio" name="spinType" value="all" /> <span>Everyone</span></label>
-                <label><input type="radio" name="spinType" value="new" /> <span>New Users</span></label>
+                <label for="spinTypeAll"><input type="radio" id="spinTypeAll" name="spinType" value="all" /> Everyone</label>
+                <label for="spinTypeNew"><input type="radio" id="spinTypeNew" name="spinType" value="new" /> New Users</label>
               </div>
             </div>
             <div class="modal-field">
-              <label><input type="checkbox" id="spinLogoClick" checked /> Start on logo click</label>
+              <div class="control-row">
+                <label for="spinLogoClick">Spin on Logo</label>
+                <input type="checkbox" id="spinLogoClick" checked />
+              </div>
             </div>
             <div class="modal-field">
               <label for="mapRestore">Restore Backup</label>
@@ -2400,12 +2386,13 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
             <div class="modal-field">
               <div id="balloonTool">
                 <style>
-                  #balloonTool { padding: 10px; width:100%; height:100%; }
+                  #balloonTool { padding: 10px; width:auto; height:auto; max-width:100%; max-height:100%; }
                   #balloonTool .admin-fieldset{ width:100%; }
                   #balloonTool .shape-buttons { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
-                  #balloonTool .shape-button { display: flex; align-items: center; gap: 4px; padding: 4px; border: 1px solid #000; background: #fff; box-shadow: 2px 2px 0 rgba(0,0,0,0.2); cursor: pointer; }
+                  #balloonTool .shape-button { display: flex; align-items: center; gap: 4px; padding: 4px; border: 1px solid var(--secondary); background: var(--secondary); color: var(--button-text); cursor: pointer; border-radius:6px; transition: background .2s,border-color .2s,color .2s; }
+                  #balloonTool .shape-button:hover { background: var(--accent); border-color: var(--accent); color: var(--button-hover-text); }
                   #balloonTool .shape-button svg { width: 24px; height: 24px; }
-                  #balloonTool .shape-button.active { outline: 2px solid #000; }
+                  #balloonTool .shape-button.active { outline: 2px solid var(--accent); }
                   #balloonTool .size-control { margin-bottom: 8px; }
                   #balloonTool .svg-output { display:flex; gap:8px; margin-bottom:8px; }
                   #balloonTool .svg-output textarea{ flex:1; }
@@ -4681,8 +4668,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
       btn.setAttribute('aria-selected','true');
       const panel = document.getElementById(`tab-${btn.dataset.tab}`);
       panel && panel.classList.add('active');
+      localStorage.setItem('adminLastTab', btn.dataset.tab);
     });
   });
+  const initialTab = localStorage.getItem('adminLastTab');
+  const initBtn = initialTab ? document.querySelector(`#adminModal .tab-bar button[data-tab="${initialTab}"]`) : adminTabs[0];
+  initBtn && initBtn.click();
 
   const colorAreas = [
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},


### PR DESCRIPTION
## Summary
- Rename map spin options and reposition checkboxes
- Replace spin audience toggles with standard radios
- Style balloon icon generator with theme colors and responsive sizing
- Persist last-open admin tab between sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec8a123a883318fcbee85de6c11e5