### PR TITLE
fix: clip overflow for open posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1199,7 +1199,7 @@ body.hide-results .closed-posts{
   border:1px solid var(--border);
   border-radius:18px;
   margin:0 0 12px 0;
-  overflow:visible;
+  overflow:clip;
 }
 
 .open-posts .detail-header{
@@ -2090,7 +2090,7 @@ body.hide-results .closed-posts{left:0;}
 .closed-posts .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
 .closed-posts button{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
 .closed-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;}
+.open-posts{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;overflow:clip;}
 .open-posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
 .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;margin:8px 0 4px;}


### PR DESCRIPTION
## Summary
- clip the `.open-posts` container so its body is hidden beneath the header while scrolling
- ensure theme-specific styles also set `overflow: clip` for `.open-posts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af1e621edc83318a8187907d57e42a