### PR TITLE
fix: enable post interactions and scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,6 +692,8 @@ select option:hover{
   display: flex;
   flex-direction: column;
   min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 .left-tools{
@@ -3331,7 +3333,7 @@ function makePosts(){
       document.body.classList.add('mode-'+m);
       const panel = document.querySelector('.post-panel');
       if(panel){
-        panel.style.pointerEvents = m === 'posts' ? 'auto' : 'none';
+        panel.style.pointerEvents = m === 'map' ? 'auto' : 'none';
       }
       $('#tab-posts').setAttribute('aria-current', m==='posts'?'page':'');
       $('#main-tab-map').setAttribute('aria-current', m==='map'?'page':'');


### PR DESCRIPTION
## Summary
- Ensure filters panel scrolls by making the column flexible and scrollable
- Allow posts to open and scroll by disabling map overlay interactions in posts mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af40d59850833191506ad39ae9eeb5