### PR TITLE
Fix admin modal tab management

### DIFF
--- a/index.html
+++ b/index.html
@@ -6101,7 +6101,7 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     const saveBtn = document.getElementById('saveNow');
     const discardBtn = document.getElementById('discardChanges');
     const adminClose = document.querySelector('#adminModal .close-modal');
-    const tabPanels = ['theme','map','settings'];
+    const tabPanels = ['theme','map','forms','settings'];
     const savedData = {};
 
     function toHex(val){


### PR DESCRIPTION
## Summary
- Include "forms" in admin modal's tab list so its settings are saved alongside other tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af4c77a7d08331a503ead074f1c21c