### PR TITLE
fix: ensure default theme remains active

### DIFF
--- a/index.html
+++ b/index.html
@@ -6105,9 +6105,12 @@ document.addEventListener('keydown', e=>{ if(e.key==='Escape') handleEsc(); });
     }
 
   function applyPreset(p){
-    document.querySelectorAll('[id^="theme-"]').forEach(el=>{ el.disabled = true; });
-    if(!p) return;
+    const themes = document.querySelectorAll('[id^="theme-"]');
+    themes.forEach(el=>{ el.disabled = true; });
+    const enableBase = ()=>{ const base=document.getElementById('theme-default'); if(base) base.disabled=false; };
+    if(!p){ enableBase(); return; }
     if(p.data){
+      enableBase();
       storage.removeItem('selectedCssTheme');
       applyPresetData(p.data);
     } else if(p.css){


### PR DESCRIPTION
## Summary
- keep base theme enabled when no preset is chosen
- preserve theme-default when applying custom data presets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b01023e1a48331aacee4ea6338eda1