### PR TITLE
Allow closed posts panel to scroll to end

### DIFF
--- a/index.html
+++ b/index.html
@@ -3686,14 +3686,6 @@ function makePosts(){
     const postsWideEl = $('#postsWide');
     const postsModeEl = $('.closed-posts');
 
-    postsModeEl.addEventListener('scroll', () => {
-      const last = postsWideEl.lastElementChild;
-      if(!last) return;
-      const limit = postsModeEl.getBoundingClientRect().top + 12;
-      const lastTop = last.getBoundingClientRect().top;
-      if(lastTop < limit){ postsModeEl.scrollTop -= (limit - lastTop); }
-    });
-
     function renderLists(list){
       if(spinning) return;
       const sort = currentSort;


### PR DESCRIPTION
## Summary
- remove scroll clamp listener from `.closed-posts` so the panel can scroll freely to the final card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b022bcdc748331a8c360f1f17f5dc9