### PR TITLE
Remove top padding from closed posts panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1091,7 +1091,7 @@ body.hide-results .results-col{
   left: var(--results-w);
   right: 0;
   overflow:auto;
-  padding:12px 6px 12px 0;
+  padding:0 6px 12px 0;
   color:#000;
   background:rgba(0,0,0,0.7);
 }
@@ -1968,7 +1968,7 @@ body{background-color:rgba(41,41,41,1);}
 .results-col{position:fixed;top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);left:0;width:var(--results-w);display:flex;flex-direction:column;padding:0;transition:width .3s ease, padding .3s ease;z-index:2;pointer-events:auto;}
 body.hide-results .results-col{width:0;padding:0;overflow:hidden;}
 .map-overlay{position:absolute;top:0;bottom:0;left:0;right:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none;}
-.closed-posts{position:fixed;top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);left:var(--results-w);right:0;display:none;overflow:auto;padding:12px 6px 12px 0;}
+.closed-posts{position:fixed;top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);left:var(--results-w);right:0;display:none;overflow:auto;padding:0 6px 12px 0;}
 body.hide-results .closed-posts{left:0;}
 .mode-posts .closed-posts{display:block;z-index:1;pointer-events:auto;}
 
@@ -2058,7 +2058,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberModal button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
 .res-list .thumb{width:80px;height:80px;}
-.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
+.closed-posts .res-list{padding-top:0;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
 .closed-posts .thumb{width:70px;height:70px;}
 
 


### PR DESCRIPTION
## Summary
- Remove top padding on `.closed-posts` container
- Eliminate extra top padding on `.closed-posts .res-list` so posts align with top

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03c3de18483319bb5c5745ea24b33