### PR TITLE
Refine header spacing and mobile panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/litepicker/dist/css/litepicker.css" />
   <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/bundle.js"></script>
   <style>:root{
-  --header-h: 75px;
-  --subheader-h: 75px;
+  --header-h: 35px;
+  --subheader-h: 35px;
   --panel-w: 260px;
   --results-w: 520px;
   --gap: 12px;
@@ -61,7 +61,7 @@
       --keyword-bg: rgba(74,74,74,0.9);
       --date-range-bg: rgba(74,74,74,0.9);
       --date-range-text: rgba(255,255,255,1);
-      --control-h: 40px;
+      --control-h: 35px;
 }
 
 *{
@@ -220,7 +220,7 @@ select option:hover{
   }
 
 .logo img{
-  height: 48px;
+  height: 30px;
   display: block;
 }
 
@@ -248,9 +248,10 @@ select option:hover{
 .view-toggle button,
 .auth button,
 .subheader button,
-.options-menu button{
-  height:40px;
-  line-height:40px;
+.options-menu button,
+.header a{
+  height:35px;
+  line-height:35px;
 }
 
 .results-arrow{
@@ -274,7 +275,7 @@ button[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg);}
 
 #smallLogo{
   display:none;
-  height:48px;
+  height:30px;
 }
 
 
@@ -1128,10 +1129,10 @@ body.filters-active #filterBtn{
 .geocoder .mapboxgl-ctrl-geocoder{flex:1;position:relative;height:var(--control-h);display:flex;align-items:center;min-width:240px !important;background:#fff;border:1px solid #ccc;}
 .geocoder .mapboxgl-ctrl-geocoder--suggestions,
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
-.geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 30px;background:#fff;color:#000;}
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{display:grid;place-items:center;background:#fff;border:1px solid #ccc;color:#000;padding:0;margin:0;}
+.geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h);background:#fff;color:#000;}
+.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{position:absolute;right:0;top:0;bottom:0;width:var(--control-h);height:var(--control-h);display:flex;align-items:center;justify-content:center;background:#fff;border-left:1px solid #ccc;color:#000;padding:0;margin:0;}
 .mapboxgl-ctrl-group button,
-.mapboxgl-ctrl button{width:var(--control-h);height:var(--control-h);background:#fff;border:1px solid #ccc;color:#000;display:grid;place-items:center;padding:0;border-radius:4px;}
+.mapboxgl-ctrl button{width:var(--control-h);height:var(--control-h);background:#fff;border:1px solid #ccc;color:#000;display:flex;align-items:center;justify-content:center;padding:0;border-radius:4px;}
 .mapboxgl-ctrl button svg,
 .mapboxgl-ctrl button span{display:block;}
 
@@ -1140,6 +1141,18 @@ body.filters-active #filterBtn{
 }
 @media (max-width:649px){
   .geocoder{width:100%;margin-left:0;}
+  #filterPanel,
+  #adminPanel,
+  #memberPanel{top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);}
+  #filterPanel .panel-content,
+  #adminPanel .panel-content,
+  #memberPanel .panel-content{top:0;left:0;right:0;bottom:0;width:100%;max-width:none;max-height:none;height:100%;border-radius:0;}
+  #filterPanel .panel-content .resizer,
+  #adminPanel .panel-content .resizer,
+  #memberPanel .panel-content .resizer,
+  #filterPanel .move-left,#filterPanel .move-right,
+  #adminPanel .move-left,#adminPanel .move-right,
+  #memberPanel .move-left,#memberPanel .move-right{display:none;}
 }
 
 
@@ -2203,12 +2216,15 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
       <div class="panel-body">
         <section class="filters-col" aria-label="Filters">
           <div>
-            <h3>Keywords</h3>
-            <div class="field">
-              <div class="input"><input id="kwInput" type="text" placeholder="Search keywords" aria-label="Keywords" />
-                <div class="x" role="button" aria-label="Clear keywords">X</div>
-              </div>
+          <h3>Keywords</h3>
+          <div class="field">
+            <div class="input"><input id="kwInput" type="text" placeholder="Search keywords" aria-label="Keywords" />
+              <div class="x" role="button" aria-label="Clear keywords">X</div>
             </div>
+          </div>
+
+          <h3 id="addressTitle">Address</h3>
+          <div class="field" id="addressField"></div>
 
           <h3>Date Range</h3>
           <div class="field">
@@ -2220,9 +2236,6 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
             <label class="t">Today Onwards <input id="todayToggle" type="checkbox" checked /></label>
           </div>
           <div id="datePicker"></div>
-
-          <h3 id="addressTitle">Address</h3>
-          <div class="field" id="addressField"></div>
 
           <h3>Categories</h3>
           <div class="cats" id="cats"></div>


### PR DESCRIPTION
## Summary
- Shrink header and subheader heights to 35px and scale related buttons and logos.
- Ensure Mapbox controls remain square with centered icons and a right-aligned clear button.
- Move address search between keyword and date filters and make panels full-width on small screens.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04c941590833181de29197702a24d