### PR TITLE
Fix geocoder visibility on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -3350,8 +3350,8 @@ function makePosts(){
         if(!geoWrap || !addressTitle || !addressField) return;
         const w = window.innerWidth;
         if(w < 650){
-          addressTitle.style.display = '';
-          addressField.style.display = '';
+          addressTitle.style.display = 'block';
+          addressField.style.display = 'block';
           addressField.appendChild(geoWrap);
           geoWrap.style.position = 'static';
           geoWrap.style.transform = 'none';


### PR DESCRIPTION
## Summary
- show geocoder and address title on narrow viewports by explicitly using `display: block`

## Testing
- `npm test`
- `node - <<'NODE'` (simulates placeGeocoder at 640px)


------
https://chatgpt.com/codex/tasks/task_e_68b054ba20a88331bef1bf068a50fdd5