### PR TITLE
Refine admin panel layout and add welcome WYSIWYG

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,8 +640,9 @@ button[aria-expanded="true"] .dropdown-arrow{
   margin:8px 0;
   display:flex;
   flex-direction:column;
+  gap:8px;
 }
-#adminPanel .panel-field{margin:0;max-width:320px;}
+#adminPanel .panel-field{margin:8px 0;max-width:none;}
 #baseColorRow{
   flex-direction:row;
   align-items:center;
@@ -652,6 +653,31 @@ button[aria-expanded="true"] .dropdown-arrow{
   display:flex;
   align-items:center;
   gap:6px;
+}
+.option-label{
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+.option-group{
+  display:flex;
+  gap:10px;
+}
+.wysiwyg{
+  border:1px solid #ccc;
+  min-height:80px;
+  padding:8px;
+}
+.wysiwyg:empty:before{
+  content:attr(data-placeholder);
+  color:#999;
+}
+.wysiwyg-toolbar{
+  display:flex;
+  gap:4px;
+}
+.wysiwyg-toolbar button{
+  padding:4px 6px;
 }
 .panel-field input,
 .panel-field textarea,
@@ -2376,7 +2402,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
           <div id="tab-map" class="tab-panel">
             <div class="panel-field">
               <label for="mapTheme">Theme</label>
-              <select id="mapTheme" style="width:250px">
+              <select id="mapTheme">
                 <option value="mapbox://styles/mapbox/outdoors-v12">Outdoors</option>
                 <option value="mapbox://styles/mapbox/streets-v12">Streets</option>
                 <option value="mapbox://styles/mapbox/light-v11">Light</option>
@@ -2401,7 +2427,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
             </div>
             <div class="panel-field">
               <label for="skyTheme">Sky</label>
-              <select id="skyTheme" style="width:250px">
+              <select id="skyTheme">
                 <option value="default">Default</option>
                 <option value="sunset">Sunset</option>
                 <option value="night">Night</option>
@@ -2438,18 +2464,18 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
                 </div>
               </div>
             <div class="panel-field">
-              <label><input type="checkbox" id="spinLoadStart" /> Start on load</label>
-              <div id="spinType">
-                <label><input type="radio" name="spinType" value="all" /> <span>Everyone</span></label>
-                <label><input type="radio" name="spinType" value="new" /> <span>New Users</span></label>
+              <label class="option-label">Spin on Load <input type="checkbox" id="spinLoadStart" /></label>
+              <div id="spinType" class="option-group">
+                <label class="option-label"><span>Everyone</span><input type="radio" name="spinType" value="all" /></label>
+                <label class="option-label"><span>New Users</span><input type="radio" name="spinType" value="new" /></label>
               </div>
             </div>
             <div class="panel-field">
-              <label><input type="checkbox" id="spinLogoClick" checked /> Start on logo click</label>
+              <label class="option-label">Spin on Logo <input type="checkbox" id="spinLogoClick" checked /></label>
             </div>
             <div class="panel-field">
               <label for="mapRestore">Restore Backup</label>
-              <select id="mapRestore" style="width:250px"></select>
+              <select id="mapRestore"></select>
               <button type="button" data-restore="map">Restore</button>
             </div>
             <div class="panel-field">
@@ -2493,8 +2519,14 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
             <input type="color" id="aColor" data-mode="hex" value="#000000" />
           </div>
           <div class="panel-field">
-            <label for="welcomeMessage">Welcome Message</label>
-            <textarea id="welcomeMessage" rows="4" placeholder="<p>Welcome!</p>"></textarea>
+            <label for="welcomeMessageEditor">Welcome Message</label>
+            <div class="wysiwyg-toolbar">
+              <button type="button" data-command="bold"><b>B</b></button>
+              <button type="button" data-command="italic"><i>I</i></button>
+              <button type="button" data-command="underline"><u>U</u></button>
+            </div>
+            <div id="welcomeMessageEditor" class="wysiwyg" contenteditable="true" data-placeholder="<p>Welcome!</p>"></div>
+            <textarea id="welcomeMessage" hidden></textarea>
           </div>
           <h3>Subcategory Form Builder</h3>
           <div class="palette" id="fieldPalette">
@@ -6602,6 +6634,25 @@ document.addEventListener('keydown', e=>{
     document.getElementById('formsCategories').appendChild(cat);
   });
 })();
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const editor = document.getElementById('welcomeMessageEditor');
+  const hidden = document.getElementById('welcomeMessage');
+  if(editor && hidden){
+    const placeholder = editor.getAttribute('data-placeholder') || '';
+    hidden.value = hidden.value || placeholder;
+    editor.innerHTML = hidden.value;
+    editor.addEventListener('input', () => hidden.value = editor.innerHTML);
+    document.querySelectorAll('.wysiwyg-toolbar button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.execCommand(btn.dataset.command, false, null);
+        editor.focus();
+      });
+    });
+  }
+});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Allow admin map tab controls to flow naturally by removing width caps and adding spacing.
- Rename map spin options and place their checkboxes to the right of the labels for clarity.
- Replace the welcome message textarea with a simple WYSIWYG editor and syncing script.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b05775c2dc8331a9e76315469a66cc