### PR TITLE
Enable overlay clicks to close panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,14 +382,17 @@ button[aria-expanded="true"] .dropdown-arrow{
   position:fixed;
   top:0;
   left:0;
-  width:100%;
-  height:100%;
+  width:100vw;
+  height:100vh;
   background:transparent;
   display:none;
   z-index:2000;
   pointer-events:none;
 }
-.panel.show{display:block;}
+.panel.show{
+  display:block;
+  pointer-events:auto;
+}
 .panel-content{
   position:absolute;
   border-radius:8px;


### PR DESCRIPTION
## Summary
- Ensure modal overlay stretches across the viewport and accepts pointer events when visible
- Allow clicking outside panel content to close the welcome panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b116f668bc833186c52b0ad5c5fc4e