### PR TITLE
Hide navigation bars while scrolling posts on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,6 +1022,7 @@ body.hide-results .results-col{
   right: 0;
   z-index: 3;
   pointer-events: auto;
+  transition: transform .3s ease;
 }
 
 #filterBtn{
@@ -1700,6 +1701,20 @@ footer{
   left: 0;
   right: 0;
   z-index: 10;
+  transition: transform .3s ease;
+}
+
+@media (max-width: 649px){
+  body.mode-posts.hide-posts-ui .subheader{
+    transform: translateY(-100%);
+  }
+  body.mode-posts.hide-posts-ui footer{
+    transform: translateY(100%);
+  }
+  body.mode-posts.hide-posts-ui .closed-posts{
+    top: var(--header-h);
+    bottom: 0;
+  }
 }
 
 .foot-row{
@@ -3444,7 +3459,7 @@ function makePosts(){
 
       function setMode(m){
         mode = m;
-      document.body.classList.remove('mode-map','mode-posts');
+      document.body.classList.remove('mode-map','mode-posts','hide-posts-ui');
       document.body.classList.add('mode-'+m);
       const panel = document.querySelector('.post-panel');
       if(panel){
@@ -6682,6 +6697,30 @@ document.addEventListener('click', e=>{
     document.getElementById('formsCategories').appendChild(cat);
   });
 })();
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const posts = document.querySelector('.closed-posts');
+  if(!posts) return;
+  let last = 0;
+  posts.addEventListener('scroll', () => {
+    if(window.innerWidth >= 650) return;
+    if(!document.body.classList.contains('mode-posts')) return;
+    const current = posts.scrollTop;
+    if(current > last + 5){
+      document.body.classList.add('hide-posts-ui');
+    } else if(current < last - 5 || current <= 0){
+      document.body.classList.remove('hide-posts-ui');
+    }
+    last = current;
+  });
+  window.addEventListener('resize', () => {
+    if(window.innerWidth >= 650) {
+      document.body.classList.remove('hide-posts-ui');
+    }
+  });
+});
 </script>
 
 <script>


### PR DESCRIPTION
## Summary
- Slide subheader and footer off-screen on devices under 650px while scrolling posts
- Reset hidden bars when changing modes
- Add scroll listener to toggle visibility on posts view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b122c01b508331aa7ef6d68ab21f7f