### PR TITLE
Adjust post map and calendar sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1367,12 +1367,12 @@ body.hide-results .closed-posts{
   display:flex;
   flex-direction:column;
   gap:4px;
-  width:100%;
+  width:auto;
 }
 
 .open-posts .post-map{
-  width:100%;
-  height:300px;
+  width:400px;
+  height:250px;
   border:1px solid var(--border);
   border-radius:8px;
 }
@@ -1516,12 +1516,13 @@ body.hide-results .closed-posts{
   display:flex;
   flex-direction:column;
   gap:4px;
-  width:100%;
+  width:auto;
 }
 
 
 .open-posts .post-calendar{
-  height:300px;
+  width:auto;
+  height:250px;
   overflow-y:auto;
   overflow-x:hidden;
   position:relative;
@@ -4375,8 +4376,8 @@ function makePosts(){
           });
           const lp = calendarEl.querySelector('.litepicker');
           if(lp){
-            const w = lp.offsetWidth + 'px';
-            calendarEl.style.width = w;
+            const w = '400px';
+            calendarEl.style.width = 'auto';
             if(sessDropdown) sessDropdown.style.width = w;
             if(sessMenu) sessMenu.style.width = w;
             if(mapEl) mapEl.style.width = w;


### PR DESCRIPTION
## Summary
- Set each post's map to 400×250px and allow its container to size to content
- Allow post calendar to auto-width with 250px height
- Ensure JavaScript sets map width to 400px and keeps calendar width flexible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1239fd5488331bf841d273580f84c