### PR TITLE
Align session menu text left and improve mobile post layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1412,6 +1412,7 @@ body.hide-results .closed-posts{
   color:var(--button-text);
   display:flex;
   align-items:center;
+  justify-content:flex-start;
 }
 
 
@@ -1488,6 +1489,7 @@ body.hide-results .closed-posts{
   color:var(--button-text);
   display:flex;
   align-items:center;
+  justify-content:flex-start;
 }
 
 
@@ -1687,6 +1689,25 @@ body.hide-results .closed-posts{
   .open-posts .venue-dropdown,
   .open-posts .session-dropdown{
     display:block;
+  }
+}
+
+@media (max-width:450px){
+  .closed-posts,
+  .closed-posts .card,
+  .open-posts,
+  .open-posts .img-box{
+    width:100%;
+    max-width:100%;
+    border:none;
+    border-radius:0;
+  }
+  .closed-posts{
+    left:0;
+    right:0;
+  }
+  .open-posts .img-box{
+    height:auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- Left-align "Select Session" text within session dropdown and menu for improved readability
- Optimize mobile layout under 450px: remove borders and stretch posts and images to full width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1273ba2a48331a7c1b824be28b96f