### PR TITLE
Reduce subheader height and remove mobile post margins

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/bundle.js"></script>
   <style>:root{
   --header-h: 75px;
-  --subheader-h: 75px;
+  --subheader-h: 55px;
   --panel-w: 260px;
   --results-w: 520px;
   --gap: 12px;
@@ -2156,12 +2156,16 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   }
   .closed-posts .card{
     width:100%;
-    margin:0 0 12px;
+    margin:0;
     border-radius:0;
+  }
+  .closed-posts .open-posts{
+    margin:0;
   }
   .open-posts{
     width:100%;
     border-radius:0;
+    margin:0;
   }
   .open-posts .img-area{
     flex:0 0 100%;


### PR DESCRIPTION
## Summary
- shrink subheader height to 55px
- remove margins around closed and open posts on screens under 450px for edge-to-edge display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b129820608833195b956416b7b6df6