### PR TITLE
Fix closed posts padding for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2287,7 +2287,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
 .res-list .thumb{width:80px;height:80px;}
-.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:0px;margin-bottom:0px;padding-left:12px;margin-left:0px;}
+@media (min-width:450px){.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:0px;margin-bottom:0px;padding-left:12px;margin-left:0px;}}
 .closed-posts .thumb{width:80px;height:80px;}
 
 


### PR DESCRIPTION
## Summary
- Restrict closed-posts result list padding to screens wider than 450px so small screens keep zero padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12b6b107c8331935170a0322c6401