### PR TITLE
Ensure closed posts vertical scrollbar is always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,9 @@ body.filters-active #filterBtn{
   bottom: var(--footer-h);
   left: var(--results-w);
   right: 0;
-  overflow:auto;
+  overflow-y:scroll;
+  overflow-x:hidden;
+  scrollbar-gutter:stable;
   padding:0;
   color:#000;
   background:rgba(0,0,0,0.7);
@@ -2197,7 +2199,7 @@ body{background-color:rgba(41,41,41,1);}
 .results-col{position:fixed;top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);left:0;width:var(--results-w);display:flex;flex-direction:column;padding:0;transition:width .3s ease, padding .3s ease;z-index:2;pointer-events:auto;}
 body.hide-results .results-col{width:0;padding:0;overflow:hidden;}
 .map-overlay{position:absolute;top:0;bottom:0;left:0;right:0;display:grid;place-items:center;color:#fff;font-weight:700;letter-spacing:.5px;opacity:.15;pointer-events:none;}
-.closed-posts{position:fixed;top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);left:var(--results-w);right:0;display:none;overflow:auto;padding:0;}
+.closed-posts{position:fixed;top:calc(var(--header-h) + var(--subheader-h));bottom:var(--footer-h);left:var(--results-w);right:0;display:none;overflow-y:scroll;overflow-x:hidden;scrollbar-gutter:stable;padding:0;}
 body.hide-results .closed-posts{left:0;}
 .mode-posts .closed-posts{display:block;z-index:1;pointer-events:auto;}
 


### PR DESCRIPTION
## Summary
- Keep a stable vertical scrollbar in closed posts by replacing `overflow:auto` with explicit `overflow-y:scroll`
- Hide horizontal overflow and reserve scrollbar space with `overflow-x:hidden` and `scrollbar-gutter: stable`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12d2662388331b919b9aba5e31e46