### PR TITLE
Fix mobile post image alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1338,8 +1338,7 @@ body.hide-results .closed-posts{
   }
   .open-posts .img-box{
     width:100%;
-    margin-left:-14px;
-    margin-right:-14px;
+    margin:0;
     border-radius:0;
   }
 }


### PR DESCRIPTION
## Summary
- remove negative margins from mobile post images to prevent left offset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1425bcff483318b14b02d9617635f