### PR TITLE
Prevent logo clicks from halting map spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -3788,7 +3788,9 @@ function makePosts(){
     applyFilters();
   }
 
-    function haltSpin(){
+    function haltSpin(e){
+      const target = (e && e.originalEvent && e.originalEvent.target) || (e && e.target);
+      if(target && logoEls.some(el=>el.contains(target))) return;
       if(spinEnabled || spinning){
         spinEnabled = false;
         localStorage.setItem('spinGlobe','false');


### PR DESCRIPTION
## Summary
- Ensure clicks on any logo do not stop the map's spin animation by ignoring those events in `haltSpin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1515316888331a2e7769eca1283a4