### PR TITLE
Adjust thumbnail padding in open and closed posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1321,6 +1321,7 @@ body.hide-results .closed-posts{
   height:auto;
   overflow-x:auto;
   gap:4px;
+  padding:0 12px;
 }
 
 .open-posts .thumb-column img{
@@ -1733,10 +1734,6 @@ body.hide-results .closed-posts{
     margin-left:0;
     margin-right:0;
   }
-  .card .thumb,
-  .open-posts .thumb-column img{
-    padding-right:12px;
-  }
   .open-posts .body{
     padding:14px 0;
     gap:8px;
@@ -1851,6 +1848,7 @@ footer .foot-row .foot-item[aria-selected="true"],
   flex-basis: 70px;
   width: 70px;
   height: 70px;
+  padding:0;
 }
 
 .card .meta{
@@ -2320,7 +2318,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
 .res-list .thumb{width:80px;height:80px;}
 @media (min-width:450px){.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:0px;margin-bottom:0px;padding-left:12px;margin-left:0px;}}
-.closed-posts .thumb{width:80px;height:80px;}
+.closed-posts .thumb{width:80px;height:80px;padding:0;}
 
 
 


### PR DESCRIPTION
## Summary
- remove padding from closed post thumbnails
- add 12px horizontal padding to open post thumbnail slider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b153ca1d3483318c79adb6ce4a8979