### PR TITLE
Restore text padding on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1738,6 +1738,10 @@ body.hide-results .closed-posts{
     padding:14px 0;
     gap:8px;
   }
+  .open-posts .text{
+    padding-left:12px;
+    padding-right:12px;
+  }
 }
 
 footer{


### PR DESCRIPTION
## Summary
- ensure open post text has side padding on screens under 450px while keeping images full width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b155c16cb08331ad32bd2478d76cee