### PR TITLE
Limit image height on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1724,13 +1724,16 @@ body.hide-results .closed-posts{
   }
   .open-posts .img-box{
     height:auto;
+    max-height:100vw;
     margin-left:0;
     margin-right:0;
     padding-left:0;
     padding-right:0;
   }
   .open-posts .img-box img{
-    height:auto;
+    width:100%;
+    height:100%;
+    object-fit:cover;
     margin-left:0;
     margin-right:0;
   }


### PR DESCRIPTION
## Summary
- Limit open post image height to viewport width on screens under 450px
- Use `object-fit: cover` so images fill the box without layout shifts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15787fe048331a942b259e3647252