### PR TITLE
Adjust default header and theme opacities

### DIFF
--- a/index.html
+++ b/index.html
@@ -2217,7 +2217,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 <style id="theme-dark-transparency">
 :root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:rgba(74,74,74,0.9);--btn-hover:rgba(0,0,0,1);--btn-active:rgba(0,0,0,1);--panel-bg:rgba(0,0,0,0.62);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:#d1d1d1;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);--session-available:#0000ff;--session-selected:#008000;}
 .open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}
-.header{background-color:rgba(41,41,41,1);}
+.header{background-color:#2c3e50;}
 .header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
 .header .gear{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
@@ -2225,7 +2225,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 .header button{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header .gear{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header a{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.subheader{background-color:rgba(0,0,0,0);}
+.subheader{background-color:rgba(0,0,0,0);opacity:0.5;}
 .subheader{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .subheader button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
 .subheader button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
@@ -2273,9 +2273,9 @@ body.hide-results .closed-posts{left:0;}
 .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;margin:8px 0 4px;}
 .open-posts button{background-color:#22343f;border-color:#22343f;box-shadow:0 0 0px #000000;}
 .open-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .detail-header{background-color:#000000;}
+.open-posts .detail-header{background-color:#000000;opacity:1;}
 .open-posts .img-box{background-color:#000000;}
-footer{background-color:rgba(0,0,0,0);}
+footer{background-color:rgba(0,0,0,0);opacity:0.5;}
 footer .foot-row .foot-item{background-color:rgba(0,0,0,0.32);box-shadow:0 0 0px #000000;}
 footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
   .map-area{background-color:rgba(0,0,0,1);}
@@ -2333,6 +2333,11 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 
 </style>
 <link id="theme-readable" rel="stylesheet" href="themes/readable.css" disabled>
+<style>
+  .header { background-color: #2c3e50; }
+  .subheader, footer { opacity: 0.5; }
+  .open-posts .detail-header { opacity: 1; }
+</style>
 </head>
 <body class="mode-map" style="padding-bottom:var(--footer-h);">
   <header class="header" role="banner">


### PR DESCRIPTION
## Summary
- Set site header background to dark grey-blue
- Default subheader and footer opacity to 0.5 and post headers to full opacity
- Add global style override so all themes use new defaults

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b158ec651883319ba00df927a1c8e7