### PR TITLE
Replace member and admin header text with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2346,8 +2346,17 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
       <button id="main-tab-map" role="tab" aria-selected="true" aria-current="page">Map</button>
     </nav>
     <div class="auth">
-      <button id="memberBtn" aria-label="Open members area">Members</button>
-      <button id="adminBtn" aria-label="Open admin area">Admin</button>
+      <button id="memberBtn" aria-label="Open members area">
+        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A6 6 0 0112 15a6 6 0 016.879 2.804M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+      </button>
+      <button id="adminBtn" aria-label="Open admin area">
+        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0a1.724 1.724 0 002.693.949 1.724 1.724 0 012.45 2.45 1.724 1.724 0 00.949 2.693c.921.3.921 1.603 0 1.902a1.724 1.724 0 00-.949 2.693 1.724 1.724 0 01-2.45 2.45 1.724 1.724 0 00-2.693.949c-.3.921-1.603.921-1.902 0a1.724 1.724 0 00-2.693-.949 1.724 1.724 0 01-2.45-2.45 1.724 1.724 0 00-.949-2.693c-.921-.3-.921-1.603 0-1.902a1.724 1.724 0 00.949-2.693 1.724 1.724 0 012.45-2.45 1.724 1.724 0 002.693-.949z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+      </button>
     </div>
   </header>
   <div class="subheader">


### PR DESCRIPTION
## Summary
- swap member and admin header buttons to SVG icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15f26223883319ea48d775171b7e2