### PR TITLE
Fix logo click handler to toggle welcome popup correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2798,7 +2798,8 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
       }
 
       logoEls.forEach(el=>{
-        el.addEventListener('click', () => {
+        el.addEventListener('click', (e) => {
+          e.stopPropagation();
           if(spinning){
             openWelcome();
             return;


### PR DESCRIPTION
## Summary
- prevent the logo click from bubbling so welcome popup toggles instead of firing twice

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1649aa79c8331bf208cd1f0f13747