### PR TITLE
fix: restore header layout and update welcome message

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,8 +196,7 @@ select option:hover{
     max-height: var(--header-h);
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 20px;
+    justify-content: flex-end;
     padding: 0 20px;
     position: fixed;
     top: 0;
@@ -207,6 +206,10 @@ select option:hover{
   }
 
   .logo{
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -222,9 +225,12 @@ select option:hover{
 }
 
   .view-toggle{
-    display: flex;
-    gap: 8px;
-    align-items: center;
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 8px;
   }
 
 .view-toggle button{
@@ -2670,7 +2676,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
               <button type="button" data-command="italic"><i>I</i></button>
               <button type="button" data-command="underline"><u>U</u></button>
             </div>
-            <div id="welcomeMessageEditor" class="wysiwyg" contenteditable="true" data-placeholder="<p>Welcome!</p>"></div>
+            <div id="welcomeMessageEditor" class="wysiwyg" contenteditable="true" data-placeholder="<p>Welcome to Funmap!</p><p>Choose an area on the map to search for events and listings.</p><p>Click the Filters button to refine your search.</p>"></div>
             <textarea id="welcomeMessage" hidden></textarea>
           </div>
           <h3>Subcategory Form Builder</h3>
@@ -2717,7 +2723,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 
     let mode = 'map';
     const DEFAULT_SPIN_SPEED = 0.3;
-    const DEFAULT_WELCOME = '<p>Welcome!</p>';
+    const DEFAULT_WELCOME = '<p>Welcome to Funmap!</p><p>Choose an area on the map to search for events and listings.</p><p>Click the Filters button to refine your search.</p>';
     const firstVisit = !localStorage.getItem('hasVisited');
     localStorage.setItem('hasVisited','1');
     const savedView = JSON.parse(localStorage.getItem('mapView') || 'null');


### PR DESCRIPTION
## Summary
- fix header elements layout, centering logo and aligning controls
- set default welcome text to Funmap instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b165dd0cd48331a9df630f24a11a86