### PR TITLE
Constrain post calendar scroll width to 400px

### DIFF
--- a/index.html
+++ b/index.html
@@ -1557,7 +1557,7 @@ body.hide-results .closed-posts{
 
 
 .open-posts .post-calendar{
-  width:auto;
+  width:400px;
   height:250px;
   overflow-x:auto;
   overflow-y:hidden;


### PR DESCRIPTION
## Summary
- Set post calendar width to 400px to keep scroll area within fixed bounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20285ea6883319823726e23bd96dd