### PR TITLE
Align closed posts padding with results list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1219,7 +1219,7 @@ body.filters-active #filterBtn{
   color:#000;
   background:rgba(0,0,0,0.7);
 }
-.closed-posts .res-list{overflow:visible;padding:12px 12px 0;margin-bottom:0;}
+.closed-posts .res-list{overflow:visible;padding:12px;margin-bottom:0;}
 .closed-posts{color:#000;padding:0;}
 .closed-posts .card{background:rgba(0,0,0,0.37);}
 .closed-posts button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
@@ -2265,7 +2265,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     right:0;
   }
   .closed-posts .res-list{
-    padding:0;
+    padding:12px;
   }
   .closed-posts .card{
     width:100%;
@@ -2404,7 +2404,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
 .res-list .thumb{width:80px;height:80px;}
-@media (min-width:450px){.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:0px;margin-bottom:0px;padding-left:12px;margin-left:0px;}}
+@media (min-width:450px){.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:0px;padding-left:12px;margin-left:0px;}}
 .closed-posts .thumb{width:80px;height:80px;padding:0;}
 
 


### PR DESCRIPTION
## Summary
- Match closed posts list padding to results list cards across breakpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26237a5b88331978885cfec4f810b