### PR TITLE
Fix button layout and closed post spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,9 +128,8 @@ button,
   color: var(--button-text);
   padding: 6px 10px;
   border-radius: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: inline-block;
+  text-align: center;
   cursor: pointer;
   transition: background .2s,border-color .2s,color .2s,transform .05s;
 }
@@ -936,9 +935,7 @@ button[aria-expanded="true"] .dropdown-arrow{
 
 .sub .chip{
   height: 28px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+  display: inline-block;
   padding: 0 10px;
   border-radius: 999px;
   background: var(--btn);
@@ -947,6 +944,12 @@ button[aria-expanded="true"] .dropdown-arrow{
   color: var(--ink-d);
   width: max-content;
   cursor: pointer;
+  line-height: 28px;
+}
+.sub .chip .badge{
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 8px;
 }
 
 
@@ -1224,7 +1227,7 @@ body.filters-active #filterBtn{
   color:#000;
   background:rgba(0,0,0,0.7);
 }
-.closed-posts .res-list{overflow:visible;padding:12px;margin-bottom:0;}
+.closed-posts .res-list{overflow:visible;padding:12px 12px 0;margin-bottom:0;}
 .closed-posts{color:#000;padding:0;}
 .closed-posts .card{background:rgba(0,0,0,0.37);}
 .closed-posts button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
@@ -1561,10 +1564,11 @@ body.hide-results .closed-posts{
 
 .open-posts .location-section .calendar-container{
   display:flex;
-  flex-direction:column;
+  flex-direction:row;
   gap:4px;
   width:auto;
   position:relative;
+  align-items:flex-start;
 }
 
 .hide-map-calendar .open-posts .map-container,
@@ -1596,9 +1600,8 @@ body.hide-results .closed-posts{
   width:24px;
   height:24px;
   padding:0;
-  display:flex;
-  align-items:center;
-  justify-content:center;
+  line-height:24px;
+  text-align:center;
   background:var(--btn);
   border:1px solid var(--btn);
   color:var(--button-text);
@@ -2270,7 +2273,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     right:0;
   }
   .closed-posts .res-list{
-    padding:12px;
+    padding:0;
   }
   .closed-posts .card{
     width:100%;
@@ -2431,7 +2434,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:12px;padding-left:12px;margin-left:0px;}
 .res-list .thumb{width:80px;height:80px;}
-@media (min-width:450px){.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:0px;padding-left:12px;margin-left:0px;}}
+@media (min-width:450px){.closed-posts .res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:0px;margin-bottom:0px;padding-left:12px;margin-left:0px;}}
 .closed-posts .thumb{width:80px;height:80px;padding:0;}
 
 
@@ -2727,8 +2730,8 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
                 <style>
                   #balloonTool { padding: 10px; }
                   #balloonTool .shape-buttons { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
-                  #balloonTool .shape-button { display: flex; align-items: center; gap: 4px; padding: 4px; border: 1px solid #000; background: #fff; box-shadow: 2px 2px 0 rgba(0,0,0,0.2); cursor: pointer; }
-                  #balloonTool .shape-button svg { width: 24px; height: 24px; }
+                  #balloonTool .shape-button { display: inline-block; padding: 4px; border: 1px solid #000; background: #fff; box-shadow: 2px 2px 0 rgba(0,0,0,0.2); cursor: pointer; }
+                  #balloonTool .shape-button svg { width: 24px; height: 24px; vertical-align: middle; margin-right: 4px; }
                   #balloonTool .shape-button.active { outline: 2px solid #000; }
                   #balloonTool .size-control { margin-bottom: 8px; }
                   #balloonTool .svg-output { display:flex; gap:8px; margin-bottom:8px; }
@@ -4261,7 +4264,7 @@ function makePosts(){
       const el = document.createElement('article');
       el.className = 'card';
       el.dataset.id = p.id;
-      if(wide) el.style.gridTemplateColumns='70px 1fr 36px';
+      if(wide) el.style.gridTemplateColumns='80px 1fr 36px';
       el.innerHTML = `
         <img class="thumb" src="${imgThumb(p)}" alt="" loading="lazy" referrerpolicy="no-referrer" />
         <div class="meta">


### PR DESCRIPTION
## Summary
- restore original closed post padding and thumbnail spacing
- remove flex from button styles to re-center map controls icons
- display post calendar and session selector side by side

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2681443408331a2827666904de3d9