### PR TITLE
Align admin tab buttons with theme colors and refine theme builder toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,14 +434,39 @@ button[aria-expanded="true"] .dropdown-arrow{
   padding:10px;
   width:250px;
 }
-.admin-fieldset legend{cursor:pointer;display:flex;align-items:center;justify-content:space-between;}
-.admin-fieldset legend .fs-toggle{margin-left:8px;padding:2px 6px;font-size:12px;}
-.admin-fieldset.collapsed > *:not(legend):not(.fieldset-actions){display:none;}
+.admin-fieldset legend{
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+.admin-fieldset legend .fs-toggle{
+  margin:0;
+  width:20px;
+  height:20px;
+  padding:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+.admin-fieldset.collapsed{
+  padding:4px 8px;
+  width:max-content;
+  min-width:0;
+  max-width:100%;
+}
+.admin-fieldset.collapsed > *:not(legend){display:none;}
 #adminPanel #styleControls{display:flex;flex-wrap:wrap;gap:10px;align-items:flex-start;}
 #adminPanel .admin-fieldset{
   flex:0 0 250px;
   min-width:250px;
   max-width:250px;
+}
+#adminPanel .admin-fieldset.collapsed{
+  flex:0 0 auto;
+  min-width:0;
+  max-width:none;
+  width:auto;
 }
   #adminPanel .panel-content,
   #memberPanel .panel-content{
@@ -528,7 +553,7 @@ button[aria-expanded="true"] .dropdown-arrow{
     max-height:95%;
   }
 }
-#adminPanel legend{font-weight:600;padding:0 6px;display:flex;align-items:center;justify-content:flex-start;cursor:pointer;user-select:none;}
+#adminPanel legend{font-weight:600;padding:0 6px;display:flex;align-items:center;gap:6px;justify-content:flex-start;cursor:pointer;user-select:none;}
 #adminPanel .fieldset-actions{display:flex;gap:4px;margin:4px 6px;}
 #adminPanel .fieldset-actions .same-btn{flex:1 1 0;padding:6px;}
 #adminPanel .control-row{display:flex;align-items:center;gap:6px;margin-bottom:6px;}
@@ -645,6 +670,15 @@ button[aria-expanded="true"] .dropdown-arrow{
   border:1px solid var(--btn);
   color:var(--button-text);
   cursor:pointer;
+}
+#adminPanel .tab-bar button:hover{
+  background:var(--btn-hover);
+  border-color:var(--btn-hover);
+  color:var(--button-hover-text);
+}
+#adminPanel .tab-bar button:active{
+  background:var(--btn-active);
+  border-color:var(--btn-active);
 }
 #adminPanel .tab-bar button[aria-selected="true"]{
   background:var(--btn-hover);
@@ -5677,7 +5711,6 @@ document.addEventListener('click', e=>{
       fs.addEventListener('click',()=>{ lastFieldsetKey = area.key; });
       fs.addEventListener('input',()=>{ lastFieldsetKey = area.key; });
       const lg = document.createElement('legend');
-      lg.textContent = area.label;
       lg.addEventListener('click',()=>{ lastFieldsetKey = area.key; });
       const toggleBtn = document.createElement('button');
       toggleBtn.type = 'button';
@@ -5690,6 +5723,7 @@ document.addEventListener('click', e=>{
         toggleBtn.textContent = fs.classList.contains('collapsed') ? '+' : '−';
       });
       lg.appendChild(toggleBtn);
+      lg.appendChild(document.createTextNode(area.label));
       fs.appendChild(lg);
       const btnRow = document.createElement('div');
       btnRow.className = 'fieldset-actions';
@@ -5934,7 +5968,6 @@ document.addEventListener('click', e=>{
     const misc = document.createElement('fieldset');
     misc.className = 'admin-fieldset collapsed';
     const miscLg = document.createElement('legend');
-    miscLg.textContent = 'Miscellaneous';
     const miscToggle = document.createElement('button');
     miscToggle.type = 'button';
     miscToggle.className = 'fs-toggle';
@@ -5945,6 +5978,7 @@ document.addEventListener('click', e=>{
       miscToggle.textContent = misc.classList.contains('collapsed') ? '+' : '−';
     });
     miscLg.appendChild(miscToggle);
+    miscLg.appendChild(document.createTextNode('Miscellaneous'));
     misc.appendChild(miscLg);
     const miscColors = [
       {id:'btn', label:'Button Base'},
@@ -5972,7 +6006,6 @@ document.addEventListener('click', e=>{
     const dropdown = document.createElement('fieldset');
     dropdown.className = 'admin-fieldset collapsed';
     const ddLg = document.createElement('legend');
-    ddLg.textContent = 'Dropdown Boxes';
     const ddToggle = document.createElement('button');
     ddToggle.type = 'button';
     ddToggle.className = 'fs-toggle';
@@ -5983,6 +6016,7 @@ document.addEventListener('click', e=>{
       ddToggle.textContent = dropdown.classList.contains('collapsed') ? '+' : '−';
     });
     ddLg.appendChild(ddToggle);
+    ddLg.appendChild(document.createTextNode('Dropdown Boxes'));
     dropdown.appendChild(ddLg);
     const ddColors = [
       {id:'dropdownTitle', label:'Title'},


### PR DESCRIPTION
## Summary
- Update admin panel tab buttons to use theme-specific button colors and active states.
- Rework theme builder fieldsets so square +/- toggles sit to the left, collapsing to title-only by default.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b290af03ac8331ba8b0ad938cd2c74