### PR TITLE
Fix calendar nav alignment in filter panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,6 +520,7 @@ button[aria-expanded="true"] .dropdown-arrow{
 }
 #filterPanel .calendar-container{
   background: var(--dropdown-bg);
+  position:relative;
 }
 #filterPanel .calendar-scroll{
   background: var(--dropdown-bg);


### PR DESCRIPTION
## Summary
- position filter panel calendar container relative so nav arrows align at top corners

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cdca5cc48331843d153679d727a4