### PR TITLE
fix: disable initial calendar selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -4956,13 +4956,13 @@ function makePosts(){
           inlineMode: true,
           selectMode: 'single',
           highlightedDates: dateStrings,
-          startDate: firstDate,
           minDate: firstDate,
           maxDate: lastDate,
           numberOfMonths: monthsCount,
           numberOfColumns: monthsCount,
           lockDaysFilter: (date)=> !allowedSet.has(date.format('YYYY-MM-DD'))
         });
+          picker.clearSelection();
           calendarEl.addEventListener('click', e=> e.stopPropagation());
           calendarEl.addEventListener('mousedown', e=>{
             const day = e.target.closest('.litepicker-day');


### PR DESCRIPTION
## Summary
- ensure Litepicker doesn't select the first available date automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ce843a2c8331a4f57ba32e61810d