### PR TITLE
Fix collapsed fieldset visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,9 @@ button[aria-expanded="true"] .dropdown-arrow{
   justify-content:center;
 }
 .admin-fieldset.collapsed{
-  padding:4px 8px;
+  border:none;
+  padding:0;
+  display:inline-block;
   width:max-content;
   min-width:0;
   max-width:100%;
@@ -486,7 +488,7 @@ button[aria-expanded="true"] .dropdown-arrow{
   flex:0 0 auto;
   min-width:0;
   max-width:none;
-  width:auto;
+  width:max-content;
 }
   #adminPanel .panel-content,
   #memberPanel .panel-content{


### PR DESCRIPTION
## Summary
- Ensure collapsed admin fieldsets hide their container border and padding
- Narrow collapsed admin panel fieldsets to legend width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d712cf408331ad427220a75f0079