### PR TITLE
Fix fieldset collapse behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,6 +472,7 @@ button[aria-expanded="true"] .dropdown-arrow{
 .admin-fieldset.collapsed{
   border:none;
   padding:0;
+  margin:0;
   display:inline-block;
   width:max-content;
   min-width:0;
@@ -7496,11 +7497,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const handler = e => {
       e.stopPropagation();
       fs.classList.toggle('collapsed');
+      const collapsed = fs.classList.contains('collapsed');
+      Array.from(fs.children).forEach(child => {
+        if (child !== legend) child.hidden = collapsed;
+      });
       update();
     };
     legend.addEventListener('click', handler);
     toggle.addEventListener('click', handler);
     fs.classList.add('collapsed');
+    Array.from(fs.children).forEach(child => {
+      if (child !== legend) child.hidden = true;
+    });
     update();
     toggle.dataset.bound = '1';
   });


### PR DESCRIPTION
## Summary
- Hide non-legend content when collapsing Theme Builder fieldsets
- Remove extra margin from collapsed fieldsets to avoid blank gaps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2db910a508331b40df9db30f97778