### PR TITLE
Fix date picker initialization and today toggle handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3863,6 +3863,9 @@ function makePosts(){
     const minPickerStr = minPickerDate.toISOString().split('T')[0];
     const maxPickerStr = maxPickerDate.toISOString().split('T')[0];
 
+    const todayToggle = $('#todayToggle');
+    todayWasOn = todayToggle && todayToggle.checked;
+
 datePicker = flatpickr($('#datePicker'), {
   inline: true,
   mode: 'range',
@@ -3870,7 +3873,7 @@ datePicker = flatpickr($('#datePicker'), {
   minDate: minPickerStr,
   maxDate: maxPickerStr,
   showMonths: pickerMonths,
-  defaultDate: minPickerStr,
+  defaultDate: minPickerDate,
   onChange: (selectedDates, dateStr, instance) => {
     const input = $('#dateInput');
     if (selectedDates.length === 2) {
@@ -3928,9 +3931,6 @@ datePicker = flatpickr($('#datePicker'), {
         updateClearButtons();
       }
     }));
-
-    const todayToggle = $('#todayToggle');
-    todayWasOn = todayToggle && todayToggle.checked;
     if(todayToggle){
       todayToggle.addEventListener('change', ()=>{
         const input = $('#dateInput');


### PR DESCRIPTION
## Summary
- Initialize date picker with a valid Date object to prevent Flatpickr invalid date errors
- Declare `todayToggle` before date picker creation and keep event listener to avoid reference errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fbf468b48331a9c2ea2ee4f48d16