### PR TITLE
Prevent theme override of core colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
       --button-text: #ffffff;
       --button-hover-text: #000000;
       --btn: rgba(74,74,74,0.9);
-      --btn-hover: rgba(0,0,0,1);
-      --btn-active: rgba(0,0,0,1);
+      --btn-hover: var(--accent);
+      --btn-active: var(--accent);
       --btn-2: var(--btn-hover);
       --panel-bg: rgba(0,0,0,0.62);
       --panel-text: #000000;
@@ -493,7 +493,7 @@ button[aria-expanded="true"] .dropdown-arrow{
 }
 .admin-fieldset{
   margin:10px 0;
-  border:1px solid var(--btn);
+  border:0;
   border-radius:8px;
   padding:10px;
   width:300px;
@@ -1475,7 +1475,21 @@ body.filters-active #filterBtn{
   justify-content:center;
   flex:none;
 }
-#map .mapboxgl-ctrl-group{border-radius:12px;overflow:hidden;}
+#map .mapboxgl-ctrl button{
+  width:var(--control-h);
+  height:var(--control-h);
+  background:#fff !important;
+  border:0 !important;
+  color:#000;
+  padding:0;
+  box-shadow:none;
+}
+#map .mapboxgl-ctrl-group{
+  background:#fff !important;
+  border:1px solid #ccc !important;
+  border-radius:12px;
+  overflow:hidden;
+}
 
 @media (max-width:999px){
   .geocoder{position:static;transform:none;margin-left:auto;}
@@ -2608,7 +2622,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 
 </style>
 <style id="theme-default">
-:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:rgba(74,74,74,0.9);--btn-hover:rgba(0,0,0,1);--btn-active:rgba(0,0,0,1);--panel-bg:rgba(0,0,0,0.62);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:#d1d1d1;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);--session-available:#808080;--session-selected:#008000;}
+:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:rgba(74,74,74,0.9);--btn-hover:var(--accent);--btn-active:var(--accent);--panel-bg:rgba(0,0,0,0.62);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:#d1d1d1;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);--session-available:#808080;--session-selected:#008000;}
 .header{background-color:#1d2744;}
 .header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
@@ -5798,7 +5812,7 @@ document.addEventListener('click', e=>{
         });
       });
     });
-    const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',today:'--today'};
+    const varMap = {today:'--today'};
     Object.entries(varMap).forEach(([id,varName])=>{
       const el = document.getElementById(id);
       if(el){
@@ -5990,10 +6004,6 @@ document.addEventListener('click', e=>{
     if(hb) hb.value = theme.accent;
     const ab = document.getElementById('body-activeBorder-c');
     if(ab) ab.value = theme.accent;
-    ['primary','secondary','accent'].forEach(id=>{
-      const inp = document.getElementById(id);
-      if(inp && theme[id]) inp.value = theme[id];
-    });
     applyAdmin();
   }
 
@@ -6151,7 +6161,7 @@ document.addEventListener('click', e=>{
       ['text','title','btnText'].forEach(t=> updateTextPicker(area.key, t));
     });
     ['panelText','placeholder','filterPlaceholder','dropdownSelectedText','dropdownText','dropdownHoverText','dropdownVenueText','dateRangeText'].forEach(id=> updateTextPicker(id,'text'));
-    const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',btn:'--btn',btnHover:'--btn-hover',btnActive:'--btn-active',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',today:'--today'};
+    const varMap = {btn:'--btn',btnHover:'--btn-hover',btnActive:'--btn-active',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',today:'--today'};
     Object.entries(varMap).forEach(([id,varName])=>{
       const cInput = document.getElementById(`${id}-c`) || document.getElementById(`${id}-text-c`) || document.getElementById(id);
       const oInput = document.getElementById(`${id}-o`);
@@ -6257,24 +6267,6 @@ document.addEventListener('click', e=>{
       btnRow.appendChild(colBtn);
       btnRow.appendChild(txtBtn);
       fs.appendChild(btnRow);
-      if(area.key === 'body'){
-        const palette = [
-          {id:'primary', label:'Primary'},
-          {id:'secondary', label:'Secondary'},
-          {id:'accent', label:'Accent'}
-        ];
-        palette.forEach(p=>{
-          const row = document.createElement('div');
-          row.className = 'control-row';
-          row.innerHTML = `
-              <label>${p.label}</label>
-              <div class="color-group">
-                <input id="${p.id}" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              </div>
-            `;
-          fs.appendChild(row);
-        });
-      }
       const types = [];
       if(area.selectors.bg) types.push('bg');
       if(area.selectors.card) types.push('card');
@@ -6470,6 +6462,7 @@ document.addEventListener('click', e=>{
     misc.className = 'admin-fieldset collapsed';
     const miscLg = document.createElement('legend');
     miscLg.textContent = 'Miscellaneous';
+    miscLg.addEventListener('click', (e)=>{ e.preventDefault(); misc.classList.toggle('collapsed'); });
     misc.appendChild(miscLg);
     const miscColors = [
       {id:'btn', label:'Button Base'},
@@ -6504,6 +6497,7 @@ document.addEventListener('click', e=>{
     dropdown.className = 'admin-fieldset collapsed';
     const ddLg = document.createElement('legend');
     ddLg.textContent = 'Dropdown Boxes';
+    ddLg.addEventListener('click', (e)=>{ e.preventDefault(); dropdown.classList.toggle('collapsed'); });
     dropdown.appendChild(ddLg);
     const ddColors = [
       {id:'dropdownTitle', label:'Title'},
@@ -6592,7 +6586,7 @@ document.addEventListener('click', e=>{
       const col = adjust(baseColor, parseInt(activeAdj.value,10)||0);
       document.documentElement.style.setProperty('--border-active', hexToRgba(col, baseOpacity));
     }
-    const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',btn:'--btn',btnHover:'--btn-hover',btnActive:'--btn-active',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',today:'--today'};
+    const varMap = {btn:'--btn',btnHover:'--btn-hover',btnActive:'--btn-active',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',today:'--today'};
     Object.entries(varMap).forEach(([id,varName])=>{
       const c = document.getElementById(`${id}-c`) || document.getElementById(`${id}-text-c`) || document.getElementById(id);
       const o = document.getElementById(`${id}-o`);
@@ -6710,9 +6704,14 @@ document.addEventListener('click', e=>{
     const stickyImages = document.getElementById('open-posts-sticky-images');
     if(stickyImages){ data['open-posts-sticky-images'] = { value: stickyImages.checked ? '1' : '0' }; }
     ['primary','secondary','accent'].forEach(id=>{
-      const input = document.getElementById(id);
-      if(input){
-        data[id] = { color: input.value };
+      const val = getComputedStyle(document.documentElement).getPropertyValue(`--${id}`).trim();
+      if(val){
+        const match = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
+        if(match){
+          data[id] = { color: rgbToHex(parseInt(match[1],10),parseInt(match[2],10),parseInt(match[3],10)) };
+        } else {
+          data[id] = { color: val };
+        }
       }
     });
     ['btn','btnHover','btnActive','panelBg','scrollbarTrack','scrollbarThumb','scrollbarThumbHover','listBackground','closedCardBg','dropdownBg','dropdownSelectedBg','dropdownHoverBg','keywordBg','dateRangeBg'].forEach(id=>{
@@ -7331,9 +7330,6 @@ document.addEventListener('click', e=>{
   });
 
     const fieldBindings = {
-      primary: '--primary',
-      secondary: '--secondary',
-      accent: '--accent',
       btn: '--btn',
       panelBg: '--panel-bg',
       panelText: '--panel-text',


### PR DESCRIPTION
## Summary
- Mapbox geolocate and compass controls keep white backgrounds and drop extra borders so they match any theme
- Remove manual primary, secondary, and accent inputs; colors now come from the active theme
- Use theme accent for button hover/active states so selected header and admin buttons reflect the loaded theme

## Testing
- ✅ `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b34effdf948331b6a005aae9c256d4