### PR TITLE
Fix logo toggle for welcome popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5554,6 +5554,7 @@ document.addEventListener('keydown', e=>{
 });
 
 document.addEventListener('click', e=>{
+  if(logoEls.some(el => el.contains(e.target))) return;
   const welcome = document.getElementById('welcomePopup');
   if(welcome && welcome.classList.contains('show')){
     const content = welcome.querySelector('.panel-content');


### PR DESCRIPTION
## Summary
- Prevent document click handler from closing the welcome popup when clicking the logo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35e5ea68c833186c49a3c9973b3ec