### PR TITLE
Fix skinny flatpickr calendars

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@ button[aria-expanded="true"] .dropdown-arrow{
   background: var(--dropdown-bg);
 }
 #filterPanel #datePicker .flatpickr-calendar{
-  width:300px;
+  width:max-content;
   height:300px;
 }
 #filterPanel #datePicker .flatpickr-months{
@@ -1819,7 +1819,7 @@ body.hide-results .closed-posts{
   margin:0;
   box-sizing:border-box;
   display:block;
-  width:400px;
+  width:max-content;
   height:300px;
 }
 .open-posts .calendar-container .calendar-scroll{


### PR DESCRIPTION
## Summary
- Avoid compressing date-range filter calendar by letting Flatpickr expand to its content width
- Do the same for post calendars so days render at full size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b35ead61048331b614eb1d6ec171fc