### PR TITLE
style: unify address bar controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1375,7 +1375,7 @@ body.filters-active #filterBtn{
 .geocoder .mapboxgl-ctrl-geocoder{position:relative;height:var(--control-h);min-width:240px !important;background:#fff !important;border:1px solid #ccc !important;width:100%;flex:1;border-radius:12px;overflow:visible;}
 .geocoder .mapboxgl-ctrl-geocoder--suggestions,
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
-.geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 30px;background:#fff !important;color:#000;font-size:16px;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
+.geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 10px;background:#fff !important;color:#000;font-size:inherit;font-family:inherit;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   position:absolute;
   top:50%;
@@ -1383,7 +1383,8 @@ body.filters-active #filterBtn{
   width:var(--control-h);
   height:var(--control-h);
   background:#fff !important;
-  border:1px solid #ccc !important;
+  border:0;
+  border-left:1px solid #ccc;
   color:#000;
   padding:0;
   margin:0;
@@ -1392,13 +1393,13 @@ body.filters-active #filterBtn{
   transform:translateY(-50%);
   border-radius:0 12px 12px 0;
 }
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{position:absolute;left:8px;top:50%;transform:translateY(-50%);}
+.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{display:none;}
 .geocoder .mapboxgl-ctrl-group button,
 .geocoder .mapboxgl-ctrl button{
   width:var(--control-h);
   height:var(--control-h);
   background:#fff !important;
-  border:1px solid #ccc !important;
+  border:0;
   color:#000;
   padding:0;
   border-radius:12px;
@@ -1409,6 +1410,7 @@ body.filters-active #filterBtn{
   justify-content:center;
   flex:none;
 }
+.geocoder .mapboxgl-ctrl-group button + button{border-left:1px solid #ccc;}
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
 .geocoder .mapboxgl-ctrl button svg,
 .geocoder .mapboxgl-ctrl button span{


### PR DESCRIPTION
## Summary
- remove geocoder search icon and align text with keyword input styling
- collapse double borders around address bar, geolocate and compass buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35feab74c833182390d062605aab2