### PR TITLE
Limit cluster click zoom level

### DIFF
--- a/index.html
+++ b/index.html
@@ -4524,7 +4524,7 @@ datePicker = flatpickr($('#datePicker'), {
         const leaves = await getClusterLeavesAll('posts', clusterId);
         if(!leaves.length) return;
         const bounds = leaves.reduce((b,f)=> b.extend(f.geometry.coordinates), new mapboxgl.LngLatBounds(leaves[0].geometry.coordinates, leaves[0].geometry.coordinates));
-        map.fitBounds(bounds, { padding: 40, pitch: 45, essential: true });
+        map.fitBounds(bounds, { padding: 40, pitch: 45, maxZoom: 20, essential: true });
       });
       
       map.on('click','unclustered', (e)=>{


### PR DESCRIPTION
## Summary
- prevent zooming in beyond level 20 when clicking a marker cluster

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3697ecb448331ba999b2e20d9e9f7