### PR TITLE
Limit calendar width and scale to fit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1833,14 +1833,18 @@ body.hide-results .closed-posts{
   height:200px;
 }
 .open-posts .calendar-container .calendar-scroll{
-  width:400px;
+  width:200px;
   height:200px;
-  overflow-x:auto;
-  overflow-y:hidden;
+  overflow:hidden;
   touch-action:pan-x;
   scroll-snap-type:x mandatory;
   padding-bottom:20px;
   box-sizing:content-box;
+}
+
+.open-posts .calendar-container .calendar-scroll .flatpickr-calendar{
+  transform:scale(0.5);
+  transform-origin:top left;
 }
 
 .open-posts .post-calendar .flatpickr-months{


### PR DESCRIPTION
## Summary
- Restrict open post calendar scroll area to 200px square
- Scale Flatpickr calendar to fit within constrained box and hide overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b377f32c1c83319dbea55efb8cf779