### PR TITLE
Limit map height to 200px with updated fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1359,8 +1359,7 @@ body.filters-active #filterBtn{
 
 
 #map{
-  position: absolute;
-  inset: 0;
+  height:200px;
 }
 
 .map-overlay{
@@ -1498,12 +1497,7 @@ body.hide-results .closed-posts{
   display: none;
 }
 .map-area{
-  position: fixed;
-  top: var(--header-h);
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 0;
+  height:200px;
 }
 
 
@@ -5347,7 +5341,7 @@ datePicker = flatpickr($('#datePicker'), {
             });
         setTimeout(()=>{
           const calHeight = calendarEl.offsetHeight;
-          mapEl.style.height = (calHeight || 300) + 'px';
+          mapEl.style.height = (calHeight || 200) + 'px';
           if(map && typeof map.resize === 'function') map.resize();
         },0);
           if(sessMenu){


### PR DESCRIPTION
## Summary
- Set the main map and its container to a fixed 200px height instead of full-screen
- Adjust map height calculation to default to 200px when no calendar height is available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3780907f48331b40139a921d0c3de