### PR TITLE
Fix fieldset collapse height and AutoTheme layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,9 +474,10 @@ button[aria-expanded="true"] .dropdown-arrow{
   width:300px;
 }
 #adminPanel .admin-fieldset{
-  flex:0 0 300px;
-  min-width:300px;
-  max-width:300px;
+  width:300px;
+}
+#adminPanel .admin-fieldset.collapsed{
+  padding:0;
 }
   #adminPanel .panel-content,
   #memberPanel .panel-content{
@@ -624,6 +625,22 @@ button[aria-expanded="true"] .dropdown-arrow{
   align-items:stretch;
   position:relative;
   margin-left:auto;
+}
+#autoTheme-row{
+  flex-direction:row;
+  align-items:center;
+  gap:8px;
+  margin-left:0;
+  width:300px;
+  max-width:300px;
+}
+#autoTheme-row button{
+  flex:1 1 auto;
+}
+#autoTheme-row input[type=color]{
+  flex:0 0 35px;
+  width:35px;
+  padding:0;
 }
 #adminPanel .shadow-group{
   flex:1 1 220px;


### PR DESCRIPTION
## Summary
- Ensure collapsed fieldsets in Theme Builder shrink to legend height instead of 300px
- Keep AutoTheme controls on a single line within Theme Builder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40d0f78c08331a38ac70c78da69bf