### PR TITLE
Refine theme builder controls and search clear button

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,12 @@
   border-color: var(--border) !important;
 }
 
+fieldset{
+  margin:0;
+  padding:0;
+  border:0 !important;
+}
+
 *:active,
 *[aria-pressed="true"],
 *[aria-current="page"],
@@ -637,10 +643,12 @@ button[aria-expanded="true"] .dropdown-arrow{
 #autoTheme-row button{
   flex:0 0 auto;
   height:35px;
+  padding:0 8px;
+  min-width:0;
 }
 #autoTheme-row input[type=color]{
-  flex:0 0 200px;
-  width:200px;
+  flex:0 0 35px;
+  width:35px;
   height:35px;
   padding:0;
 }
@@ -981,17 +989,16 @@ button[aria-expanded="true"] .dropdown-arrow{
   width: 35px;
   height: 35px;
   border-radius: 8px;
-  background: var(--btn);
+  background: none;
   cursor: pointer;
-  border: 1px solid var(--btn);
+  border: 0;
   margin-left: 6px;
   line-height: 35px;
   text-align: center;
+  color: var(--text);
 }
 .input .x.active{
-  background: red;
-  border-color: red;
-  color: #fff;
+  color: var(--accent);
 }
 
 #filterPanel .field label.t{


### PR DESCRIPTION
## Summary
- Remove default fieldset margins and borders to keep theme builder controls flush
- Align AutoTheme button and color picker side by side with compact sizing
- Hide background and border of search box clear button for a cleaner look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4144e55948331bc3a0ac1259accd5