### PR TITLE
Fix session and venue menu sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,7 +1658,7 @@ body.hide-results .closed-posts{
 .open-posts .venue-dropdown,
 .open-posts .session-dropdown{
   position:relative;
-  width:100%;
+  width:400px;
 }
 
 .open-posts .calendar-container .session-dropdown{
@@ -1668,7 +1668,8 @@ body.hide-results .closed-posts{
 
 
 .open-posts .venue-dropdown > button{
-  width:auto;
+  width:400px;
+  height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
   border-radius:var(--dropdown-radius);
@@ -1682,7 +1683,8 @@ body.hide-results .closed-posts{
 }
 
 .open-posts .session-dropdown > button{
-  width:auto;
+  width:400px;
+  height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
   border-radius:var(--dropdown-radius);
@@ -1736,16 +1738,14 @@ body.hide-results .closed-posts{
   gap:6px;
   box-shadow:0 2px 6px rgba(0,0,0,0.2);
   z-index:30;
+  width:400px;
 }
-
-.open-posts .venue-menu{width:100%;}
-.open-posts .session-menu{width:100%;}
 
 .open-posts .venue-menu[hidden],
 .open-posts .session-menu[hidden]{display:none;}
 
 .open-posts .venue-menu button{
-  width:100%;
+  width:400px;
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -1760,7 +1760,7 @@ body.hide-results .closed-posts{
 }
 
 .open-posts .session-menu button{
-  width:100%;
+  width:400px;
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);


### PR DESCRIPTION
## Summary
- Set venue and session dropdowns to fixed 400px width and 50px height
- Ensure date range filter and session calendars remain functional

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4171610fc83318cd16301e217127a