### PR TITLE
Hide Mapbox Geocoder loading spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1414,7 +1414,7 @@ body.filters-active #filterBtn{
   align-items:center;
   justify-content:center;
 }
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{display:block;}
+.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{display:none;}
 .geocoder .mapboxgl-ctrl-group button,
 .geocoder .mapboxgl-ctrl button{
   width:var(--control-h);


### PR DESCRIPTION
## Summary
- hide Mapbox Geocoder loading spinner by setting display to none

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42b7a274883318d342e0f75dc0008