### PR TITLE
Hide Mapbox geocoder icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1414,7 +1414,8 @@ body.filters-active #filterBtn{
   align-items:center;
   justify-content:center;
 }
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{display:none;}
+.mapboxgl-ctrl-geocoder--icon,
+.mapboxgl-ctrl-geocoder--icon-search{display:none;}
 .geocoder .mapboxgl-ctrl-group button,
 .geocoder .mapboxgl-ctrl button{
   width:var(--control-h);


### PR DESCRIPTION
## Summary
- hide Mapbox geocoder icons to remove search glyph

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42ddd24a88331a509934ecfa671a6