### PR TITLE
Hide geocoder magnifier and resize placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1394,7 +1394,7 @@ body.filters-active #filterBtn{
 .geocoder .mapboxgl-ctrl-geocoder--suggestions,
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
 .geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 10px;background:#fff !important;color:#000;font-family:inherit;font-size:16px;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
-#geocoder input::placeholder{font-family:Verdana,sans-serif;font-size:10px;}
+#geocoder input::placeholder{font-family:Verdana,sans-serif;font-size:16px;color:grey;}
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   position:absolute;
   top:0;
@@ -1414,8 +1414,8 @@ body.filters-active #filterBtn{
   align-items:center;
   justify-content:center;
 }
-.mapboxgl-ctrl-geocoder--icon,
-.mapboxgl-ctrl-geocoder--icon-search{display:none;}
+#geocoder .mapboxgl-ctrl-geocoder--icon,
+#geocoder .mapboxgl-ctrl-geocoder--icon-search{display:none !important;}
 .geocoder .mapboxgl-ctrl-group button,
 .geocoder .mapboxgl-ctrl button{
   width:var(--control-h);


### PR DESCRIPTION
## Summary
- Hide magnifying glass icon in address geocoder
- Set geocoder placeholder to 16px grey Verdana

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b431922b108331b7ea141bad6cff37