### PR TITLE
Clear geocoder input and fix manifest icon paths

### DIFF
--- a/assets/favicons/site.webmanifest
+++ b/assets/favicons/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"","short_name":"","icons":[{"src":"android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/index.html
+++ b/index.html
@@ -1397,10 +1397,11 @@ body.filters-active #filterBtn{
 #geocoder input::placeholder{font-family:Verdana,sans-serif;font-size:16px;color:grey;}
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   position:absolute;
-  top:0;
-  bottom:0;
   right:0;
+  top:50%;
+  transform:translateY(-50%);
   width:var(--control-h);
+  height:var(--control-h);
   background:transparent!important;
   border:0;
   border-left:1px solid #ccc;
@@ -4260,7 +4261,11 @@ function makePosts(){
           spinEnabled = false;
           localStorage.setItem('spinGlobe','false');
           stopSpin();
-          if(map) map.once('moveend', () => { applyFilters(); updatePostPanel(); });
+          if(map) map.once('moveend', () => {
+            applyFilters();
+            updatePostPanel();
+            geocoder.clear();
+          });
         });
         const gc = document.getElementById('geocoder');
         if(gc){


### PR DESCRIPTION
## Summary
- Clear search box after map moves to selected destination
- Absolutely position geocoder clear button within address field
- Correct manifest icon paths to prevent 404 errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4337183888331a04d2c893465fef4