### PR TITLE
Adjust AutoTheme color picker size and fieldset spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,7 +476,7 @@ button[aria-expanded="true"] .dropdown-arrow{
   margin:0;
   border:0;
   border-radius:8px;
-  padding:10px;
+  padding:0;
   width:300px;
   box-sizing:border-box;
 }
@@ -520,6 +520,7 @@ button[aria-expanded="true"] .dropdown-arrow{
   line-height:35px;
 }
 #adminPanel input[type="color"]{
+  width:35px;
   height:35px;
 }
 #filterPanel input[type="text"]{


### PR DESCRIPTION
## Summary
- Ensure AutoTheme color picker renders as a 35x35 square
- Remove default padding from admin fieldsets for a tighter layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43808a68483318199730397d570f1