### PR TITLE
Refine session and venue dropdown styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,14 +330,17 @@ body.hide-results .results-arrow{transform:rotate(-45deg);}
   padding-right:30px;
 }
 
-.open-posts .options-dropdown .dropdown-arrow{
+.open-posts .options-dropdown .dropdown-arrow,
+.open-posts .options-dropdown .results-arrow{
   position:absolute;
   top:50%;
   right:10px;
   transform:translateY(-50%) rotate(135deg);
+  margin-right:0;
 }
 
-button[aria-expanded="true"] .dropdown-arrow{
+button[aria-expanded="true"] .dropdown-arrow,
+button[aria-expanded="true"] .results-arrow{
   transform:translateY(-50%) rotate(-45deg);
 }
 
@@ -1684,7 +1687,8 @@ body.hide-results .closed-posts{
 .open-posts .venue-dropdown,
 .open-posts .session-dropdown{
   position:relative;
-  width:400px;
+  width:100%;
+  max-width:400px;
 }
 
 .open-posts .calendar-container .session-dropdown{
@@ -1694,7 +1698,7 @@ body.hide-results .closed-posts{
 
 
 .open-posts .venue-dropdown > button{
-  width:400px;
+  width:100%;
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -1709,7 +1713,7 @@ body.hide-results .closed-posts{
 }
 
 .open-posts .session-dropdown > button{
-  width:400px;
+  width:100%;
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -1753,7 +1757,7 @@ body.hide-results .closed-posts{
   position:absolute;
   top:calc(100% + 4px);
   left:0;
-  max-height:400px;
+  max-height:250px;
   overflow-y:auto;
   background:var(--dropdown-bg);
   border:1px solid var(--border);
@@ -1764,14 +1768,15 @@ body.hide-results .closed-posts{
   gap:6px;
   box-shadow:0 2px 6px rgba(0,0,0,0.2);
   z-index:30;
-  width:400px;
+  width:100%;
+  max-width:400px;
 }
 
 .open-posts .venue-menu[hidden],
 .open-posts .session-menu[hidden]{display:none;}
 
 .open-posts .venue-menu button{
-  width:400px;
+  width:100%;
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -1786,7 +1791,7 @@ body.hide-results .closed-posts{
 }
 
 .open-posts .session-menu button{
-  width:400px;
+  width:100%;
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -4946,13 +4951,13 @@ function makePosts(){
             <div class="location-section">
               <div class="map-container">
                 <div id="map-${p.id}" class="post-map"></div>
-                <div id="venue-${p.id}" class="venue-dropdown options-dropdown"><button class="venue-btn" aria-haspopup="true" aria-expanded="false"><span class="venue-name">${p.locations[0].venue}</span><span class="venue-address">${p.locations[0].address}</span>${p.locations.length>1?'<span class="dropdown-arrow" aria-hidden="true"></span>':''}</button><div class="venue-menu options-menu" hidden>${p.locations.map((loc,i)=>`<button data-index="${i}"><span class="venue-name">${loc.venue}</span><span class="venue-address">${loc.address}</span></button>`).join('')}</div></div>
+                <div id="venue-${p.id}" class="venue-dropdown options-dropdown"><button class="venue-btn" aria-haspopup="true" aria-expanded="false"><span class="venue-name">${p.locations[0].venue}</span><span class="venue-address">${p.locations[0].address}</span>${p.locations.length>1?'<span class="results-arrow" aria-hidden="true"></span>':''}</button><div class="venue-menu options-menu" hidden>${p.locations.map((loc,i)=>`<button data-index="${i}"><span class="venue-name">${loc.venue}</span><span class="venue-address">${loc.address}</span></button>`).join('')}</div></div>
               </div>
               <div class="calendar-container">
                 <div class="calendar-scroll">
                   <div id="cal-${p.id}" class="post-calendar"></div>
                 </div>
-                <div id="sess-${p.id}" class="session-dropdown options-dropdown"><button class="sess-btn" aria-haspopup="true" aria-expanded="false">Select Session<span class="dropdown-arrow" aria-hidden="true"></span></button><div class="session-menu options-menu" hidden></div></div>
+                <div id="sess-${p.id}" class="session-dropdown options-dropdown"><button class="sess-btn" aria-haspopup="true" aria-expanded="false">Select Session<span class="results-arrow" aria-hidden="true"></span></button><div class="session-menu options-menu" hidden></div></div>
               </div>
             </div>
             <h2 class="title">${p.title}</h2>
@@ -5229,7 +5234,7 @@ function makePosts(){
           return y !== currentYear ? `${d.date}, ${y}` : d.date;
         };
         if(venueInfo) venueInfo.innerHTML = `<strong>${loc.venue}</strong><br>${loc.address}`;
-        if(venueBtn) venueBtn.innerHTML = `<span class="venue-name">${loc.venue}</span><span class="venue-address">${loc.address}</span>${p.locations.length>1?'<span class="dropdown-arrow" aria-hidden="true"></span>':''}`;
+        if(venueBtn) venueBtn.innerHTML = `<span class="venue-name">${loc.venue}</span><span class="venue-address">${loc.address}</span>${p.locations.length>1?'<span class="results-arrow" aria-hidden="true"></span>':''}`;
         sessionHasMultiple = loc.dates.length > 1;
         if(!map){
           map = new mapboxgl.Map({
@@ -5279,14 +5284,14 @@ function makePosts(){
             const dt = loc.dates[i];
             if(dt){
               sessionInfo.innerHTML = `<div><strong>${formatDate(dt)} ${dt.time}</strong></div><div>Adults $20, Kids $10, Pensioners $15</div><div>🎫 Buy at venue | ♿ Accessible | 👶 Kid-friendly</div>`;
-              if(sessBtn) sessBtn.innerHTML = `<span class="session-date">${formatDate(dt)}</span><span class="session-time">${dt.time}</span>${sessionHasMultiple?'<span class="dropdown-arrow" aria-hidden="true"></span>':''}`;
+              if(sessBtn) sessBtn.innerHTML = `<span class="session-date">${formatDate(dt)}</span><span class="session-time">${dt.time}</span>${sessionHasMultiple?'<span class="results-arrow" aria-hidden="true"></span>':''}`;
               ignoreSelect = true;
               const selectedDateObj = parseDate(dt.full);
               picker.setDate(selectedDateObj);
               ignoreSelect = false;
             } else {
               sessionInfo.innerHTML = '<div class="placeholder">💲 Price range | 📅 Date range</div>';
-              if(sessBtn) sessBtn.innerHTML = sessionHasMultiple ? 'Select Session<span class="dropdown-arrow" aria-hidden="true"></span>' : 'Select Session';
+              if(sessBtn) sessBtn.innerHTML = sessionHasMultiple ? 'Select Session<span class="results-arrow" aria-hidden="true"></span>' : 'Select Session';
               picker.clear();
             }
             sessMenu.hidden = true;
@@ -5332,7 +5337,7 @@ function makePosts(){
             sessMenu.scrollTop = 0;
             if(sessionHasMultiple){
               sessionInfo.innerHTML = '<div class="placeholder">💲 Price range | 📅 Date range</div>';
-              if(sessBtn){ sessBtn.innerHTML = 'Select Session<span class="dropdown-arrow" aria-hidden="true"></span>'; sessBtn.setAttribute('aria-expanded','false'); }
+              if(sessBtn){ sessBtn.innerHTML = 'Select Session<span class="results-arrow" aria-hidden="true"></span>'; sessBtn.setAttribute('aria-expanded','false'); }
             } else {
               if(loc.dates.length){
                 selectSession(0);


### PR DESCRIPTION
## Summary
- Use results list chevron for venue and session dropdown arrows
- Limit venue and session menu height to 250px
- Make dropdowns and menu items full-width for better fit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45d4b77788331b9a45801c4d6241e