### PR TITLE
Ensure fullscreen button works on all screen sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7768,6 +7768,17 @@ document.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('resize', updateViewport);
   window.addEventListener('orientationchange', updateViewport);
 
+  const fsBtn = document.getElementById('fullscreenBtn');
+  if(fsBtn){
+    fsBtn.addEventListener('click', () => {
+      if(!document.fullscreenElement){
+        document.documentElement.requestFullscreen().catch(()=>{});
+      } else {
+        document.exitFullscreen();
+      }
+    });
+  }
+
   if (window.innerWidth >= 650) return;
 
   const posts = document.querySelector('.closed-posts');
@@ -7816,17 +7827,6 @@ document.addEventListener('DOMContentLoaded', () => {
     overlay.appendChild(big);
     overlay.addEventListener('click', () => overlay.remove());
     document.body.appendChild(overlay);
-  }
-
-  const fsBtn = document.getElementById('fullscreenBtn');
-  if(fsBtn){
-    fsBtn.addEventListener('click', () => {
-      if(!document.fullscreenElement){
-        document.documentElement.requestFullscreen().catch(()=>{});
-      } else {
-        document.exitFullscreen();
-      }
-    });
   }
 
   posts.querySelectorAll('img').forEach(img => {


### PR DESCRIPTION
## Summary
- Bind fullscreen button handler before screen-width check to enable toggling on desktop and mobile.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b460656aa08331a971fea5ea75f5ca