### PR TITLE
Ensure open post info text inherits default styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1576,6 +1576,12 @@ body.hide-results .closed-posts{
   flex:1 1 300px;
 }
 
+.open-posts .text .info{
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+}
+
 .open-posts .img-area{
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- make open post `info` section inherit color, size, and font settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4736952988331a0feb38877ab70f6