### PR TITLE
Prevent filter panel from closing when filter button clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -5664,6 +5664,7 @@ document.addEventListener('keydown', e=>{
 function handleDocInteract(e){
   if(e.target.closest('.img-popup')) return;
   if(logoEls.some(el => el.contains(e.target))) return;
+  if(e.target.closest('#filterBtn')) return;
   const welcome = document.getElementById('welcomePopup');
   if(welcome && welcome.classList.contains('show')){
     const content = welcome.querySelector('.panel-content');


### PR DESCRIPTION
## Summary
- add guard in `handleDocInteract` to ignore clicks on the filter button

## Testing
- `npm test`
- `node - <<'NODE'\nlet closed=false;\nconst logoEls = [];\nfunction closePanel(){closed=true}\nfunction handleDocInteract(e){\n  if(e.target.closest('.img-popup')) return;\n  if(logoEls.some(el => el.contains(e.target))) return;\n  if(e.target.closest('#filterBtn')) return;\n  const filterPanel = {classList:{contains:(cls)=>cls==='show'}, querySelector:()=>({contains:()=>false})};\n  if(filterPanel && filterPanel.classList.contains('show')){\n    const content = filterPanel.querySelector('.panel-content');\n    if(content && !content.contains(e.target)){\n      closePanel(filterPanel);\n    }\n  }\n  document.querySelectorAll('.img-popup').forEach(()=>{});\n}\nconst filterBtn={closest: sel => sel === '#filterBtn' ? filterBtn : null};\nconst document={querySelectorAll: () => []};\nglobal.document=document;\nhandleDocInteract({target:filterBtn});\nconsole.log('closed:', closed);\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68b47a9fc7508331b591f726a57b5552