### PR TITLE
Adjust autotheme color row dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,6 +725,7 @@ button[aria-expanded="true"] .results-arrow{
 }
 .autotheme-row{
   width:300px;
+  height:35px;
 }
 .autotheme-row button,
 .autotheme-row input[type=color]{


### PR DESCRIPTION
## Summary
- Set `.autotheme-row` height to 35px and keep width at 300px to ensure proper row layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47c2ed1a083319605b5c89375c45d