### PR TITLE
Fix ad panel toggle loop on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -8089,7 +8089,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const postsPanel = document.querySelector('.closed-posts');
   window.updateAdVisibility = function(){
     if(!adPanel || !postsPanel) return;
-    const width = postsPanel.getBoundingClientRect().width;
+    const gap = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--gap')) || 0;
+    const width = postsPanel.getBoundingClientRect().width + (adPanel.classList.contains('show') ? adPanel.getBoundingClientRect().width + gap : 0);
     const hasPosts = !!postsPanel.querySelector('.card');
     const shouldShow = document.body.classList.contains('mode-posts') && width >= 1200 && hasPosts;
     const isShown = adPanel.classList.contains('show');


### PR DESCRIPTION
## Summary
- Adjust ad panel visibility check to account for reserved ad width, preventing repeated slide-in/out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b496db51a483319f60d4ba9a4fd8de