### PR TITLE
Use CSS variable for image popup background

### DIFF
--- a/index.html
+++ b/index.html
@@ -6881,6 +6881,13 @@ document.addEventListener('pointerdown', handleDocInteract);
         const font = f ? f.value : null;
         const size = s ? s.value : null;
         const weight = w ? w.value : null;
+        if(area.key==='imagePanel' && type==='bg'){
+          if(color){
+            document.documentElement.style.setProperty('--image-panel-bg', hexToRgba(color, opacity));
+            document.querySelectorAll('.img-popup').forEach(el=>el.style.removeProperty('background-color'));
+          }
+          return;
+        }
         const targets = area.selectors[type] || [];
         targets.forEach(sel=>{
           document.querySelectorAll(sel).forEach(el=>{


### PR DESCRIPTION
## Summary
- Update theme builder to set the global `--image-panel-bg` variable instead of applying inline styles to `.img-popup`
- Clear existing popup inline backgrounds so new and existing popups share the selected color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4976ee6508331bfd11728c0b22efc