### PR TITLE
Allow open posts calendars to expand

### DIFF
--- a/index.html
+++ b/index.html
@@ -1900,14 +1900,12 @@ body.hide-results .closed-posts{
   display:block;
   width:auto;
   height:auto;
-  transform:scale(var(--calendar-scale));
-  transform-origin:top center;
 }
 .open-posts .calendar-container .calendar-scroll{
   width:100%;
-  height:var(--media-h);
+  height:auto;
   overflow-x:auto;
-  overflow-y:hidden;
+  overflow-y:auto;
   padding-bottom:20px;
   box-sizing:border-box;
 }


### PR DESCRIPTION
## Summary
- Let open posts calendars grow with content by removing fixed height and enabling vertical scrolling
- Drop transform scaling from open posts calendar for natural sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a0e599a48331b687bcfcd798b587