### PR TITLE
Fix Duet date picker CDN path

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@2/dist/duet/themes/default.css" />
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@2/dist/duet/duet.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@2/dist/duet/duet.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1/dist/duet/themes/default.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1/dist/duet/duet.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1/dist/duet/duet.js"></script>
   <style>:root{
   --header-h: 75px;
   --subheader-h: 55px;


### PR DESCRIPTION
## Summary
- update Duet Date Picker CDN links to valid version to prevent 404 errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9f371788331858eb4d321bbb9e8