### PR TITLE
Fix calendar component and post mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1/dist/duet/themes/default.css" />
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1/dist/duet/duet.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1/dist/duet/duet.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@2/dist/duet/themes/default.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@2/dist/duet/duet.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@2/dist/duet/duet.js"></script>
   <style>:root{
   --header-h: 75px;
   --subheader-h: 55px;
@@ -4319,6 +4319,7 @@ function makePosts(){
       applyFilters();
       if(window.updateAdVisibility) updateAdVisibility();
     }
+    window.setMode = setMode;
     $('#tab-posts').addEventListener('click',()=> setMode('posts'));
     $('#main-tab-map').addEventListener('click',()=> setMode('map'));
 
@@ -8067,12 +8068,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const postPanel = document.querySelector('.post-panel');
   if(postPanel){
     postPanel.addEventListener('click', e => {
-      if(e.target === postPanel) setMode('map');
+      if(e.target === postPanel) window.setMode('map');
     });
   }
   if(adPanel){
     adPanel.addEventListener('click', e => {
-      if(e.target === adPanel) setMode('map');
+      if(e.target === adPanel) window.setMode('map');
     });
   }
   window.updateAdVisibility = function(){


### PR DESCRIPTION
## Summary
- Update Duet date-picker CDN to version 2 so calendar loads correctly
- Expose `setMode` globally and reference it in panels to avoid console error and unresponsive posts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5dc1412e483318e5630e0d218e17e