### PR TITLE
fix setMode not defined console error

### DIFF
--- a/index.html
+++ b/index.html
@@ -4423,6 +4423,7 @@ function makePosts(){
       applyFilters();
       if(window.updateAdVisibility) updateAdVisibility();
     }
+    window.setMode = setMode;
     $('#tab-posts').addEventListener('click',()=> setMode('posts'));
     $('#main-tab-map').addEventListener('click',()=> setMode('map'));
 


### PR DESCRIPTION
## Summary
- expose `setMode` on `window` so later scripts can close panels without errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5eb8c3b2883319fbac7cb22fff92c