### PR TITLE
Fix date range picker header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
         --dropdown-radius: 6px;
         --calendar-width: 210px;
         --calendar-cell: calc(var(--calendar-width) / 7);
+        --calendar-header-h: 30px;
         --calendar-past-bg: #d3d3d3;
         --calendar-future-bg: #ffffff;
         --session-available: #add8e6;
@@ -571,13 +572,15 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filterPanel .calendar .grid{
   width:var(--calendar-width);
-  height:calc(var(--calendar-width) + var(--calendar-cell));
+  height:calc(var(--calendar-header-h)*2 + var(--calendar-cell)*6);
   display:grid;
   grid-template-columns:repeat(7,1fr);
-  grid-template-rows:repeat(8,1fr);
+  grid-template-rows:var(--calendar-header-h) var(--calendar-header-h) repeat(6,var(--calendar-cell));
 }
 #filterPanel .calendar .header{
   grid-column:1 / span 7;
+  grid-row:1;
+  height:var(--calendar-header-h);
   display:flex;
   align-items:center;
   justify-content:center;


### PR DESCRIPTION
## Summary
- enforce 30px month headers in date range picker
- ensure header occupies top row above weekdays and days grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b600fd5adc8331a6fd6f3fe9e7647b