### PR TITLE
Fix calendar header size and positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
         --dropdown-radius: 6px;
         --calendar-width: 210px;
         --calendar-cell: calc(var(--calendar-width) / 7);
+        --calendar-header-h: 30px;
         --calendar-past-bg: #d3d3d3;
         --calendar-future-bg: #ffffff;
         --session-available: #add8e6;
@@ -571,13 +572,19 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filterPanel .calendar .grid{
   width:var(--calendar-width);
-  height:calc(var(--calendar-width) + var(--calendar-cell));
+  height:calc(var(--calendar-header-h)*2 + var(--calendar-cell)*6);
   display:grid;
   grid-template-columns:repeat(7,1fr);
-  grid-template-rows:repeat(8,1fr);
+  grid-template-rows:var(--calendar-header-h) var(--calendar-header-h) repeat(6,var(--calendar-cell));
 }
-#filterPanel .calendar .header{
+#filterPanel .calendar .cal-header{
   grid-column:1 / span 7;
+  grid-row:1;
+  width:var(--calendar-width);
+  height:var(--calendar-header-h);
+  min-height:var(--calendar-header-h);
+  max-height:var(--calendar-header-h);
+  padding:0;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -585,6 +592,11 @@ button[aria-expanded="true"] .results-arrow{
   font-family:inherit;
   font-size:inherit;
   color:inherit;
+  position:static;
+  top:auto;
+  left:auto;
+  right:auto;
+  z-index:auto;
 }
 #filterPanel .calendar .weekday,
 #filterPanel .calendar .day{
@@ -1969,10 +1981,22 @@ body.hide-results .closed-posts{
   display:flex;
   flex-direction:column;
 }
-.open-posts .post-calendar .header{
+.open-posts .post-calendar .cal-header{
+  height:var(--calendar-header-h);
+  min-height:var(--calendar-header-h);
+  max-height:var(--calendar-header-h);
+  padding:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
   text-align:center;
   font-weight:bold;
   margin-bottom:4px;
+  position:static;
+  top:auto;
+  left:auto;
+  right:auto;
+  z-index:auto;
 }
 .open-posts .post-calendar .grid{
   display:grid;
@@ -4200,7 +4224,7 @@ function makePosts(){
         grid.className='grid';
 
         const header = document.createElement('div');
-        header.className='header';
+        header.className='cal-header';
         header.textContent=current.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
         grid.appendChild(header);
 
@@ -5610,7 +5634,7 @@ function makePosts(){
           const monthEl=document.createElement('div');
           monthEl.className='month';
           const header=document.createElement('div');
-          header.className='header';
+          header.className='cal-header';
           header.textContent=monthStart.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
           const grid=document.createElement('div');
           grid.className='grid';
@@ -6175,7 +6199,7 @@ document.addEventListener('pointerdown', handleDocInteract);
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['.map-area'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], text:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
     {key:'filter', label:'Filter Panel', selectors:{bg:['#filterPanel .panel-content'], text:['#filterPanel .panel-content'], title:['#filterPanel .panel-content .t','#filterPanel .panel-content .title'], btn:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn'], btnText:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn']}},
-    {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], title:['.calendar .header']}},
+    {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], title:['.calendar .cal-header']}},
   {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},
   {key:'welcomePopup', label:'Welcome Popup', selectors:{bg:['#welcomePopup .panel-content'], text:['#welcomePopup .panel-content'], title:['#welcomePopup .panel-content .t','#welcomePopup .panel-content .title'], btn:['#welcomePopup button'], btnText:['#welcomePopup button']}},
   {key:'memberPanel', label:'Member Panel', selectors:{bg:['#memberPanel .panel-content'], text:['#memberPanel .panel-content'], title:['#memberPanel .panel-content .t','#memberPanel .panel-content .title'], btn:['#memberPanel button'], btnText:['#memberPanel button']}},


### PR DESCRIPTION
## Summary
- rename calendar headers to avoid global header styles
- force each calendar month header to 30px height and full calendar width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b600fd5adc8331a6fd6f3fe9e7647b