### PR TITLE
Revamp calendar styles and fix datepicker selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@
         --calendar-header-h: 30px;
         --calendar-past-bg: #d3d3d3;
         --calendar-future-bg: #ffffff;
-        --session-available: #add8e6;
-        --session-selected: #00008b;
+        --session-available: #92D0F7;
+        --session-selected: #009FFF;
         --today: #ff0000;
         --ad-panel-bg: rgba(0,0,0,0.5);
         --image-panel-bg: rgba(0,0,0,0.7);
@@ -564,6 +564,7 @@ button[aria-expanded="true"] .results-arrow{
   border-radius:50%;
   background:var(--today);
   cursor:pointer;
+  transform:translateX(-50%);
 }
 #filterPanel #datePicker{
   width:max-content;
@@ -576,18 +577,21 @@ button[aria-expanded="true"] .results-arrow{
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
 }
-#filterPanel .calendar .month{
+.calendar .month{
   flex:0 0 auto;
   width:var(--calendar-width);
 }
-#filterPanel .calendar .grid{
+.calendar .month:not(:first-child){
+  border-left:1px solid var(--border);
+}
+.calendar .grid{
   width:var(--calendar-width);
   height:calc(var(--calendar-header-h)*2 + var(--calendar-cell)*6);
   display:grid;
   grid-template-columns:repeat(7,1fr);
   grid-template-rows:var(--calendar-header-h) var(--calendar-header-h) repeat(6,var(--calendar-cell));
 }
-#filterPanel .calendar .calendar-header{
+.calendar .calendar-header{
   grid-column:1 / span 7;
   grid-row:1;
   height:var(--calendar-header-h);
@@ -599,22 +603,22 @@ button[aria-expanded="true"] .results-arrow{
   font-size:inherit;
   color:inherit;
 }
-#filterPanel .calendar .weekday,
-#filterPanel .calendar .day{
+.calendar .weekday,
+.calendar .day{
   display:flex;
   align-items:center;
   justify-content:center;
   font-family:inherit;
   font-size:inherit;
 }
-#filterPanel .calendar .weekday{font-weight:bold;}
-#filterPanel .calendar .day{cursor:pointer;}
-#filterPanel .calendar .day.empty{cursor:default;background:var(--calendar-future-bg);}
-#filterPanel .calendar .day.past{background:var(--calendar-past-bg);}
-#filterPanel .calendar .day.future{background:var(--calendar-future-bg);}
-#filterPanel .calendar .day.today{color:var(--today);font-weight:bold;}
-#filterPanel .calendar .day.in-range{background:var(--session-available);}
-#filterPanel .calendar .day.selected{background:var(--session-selected);color:#fff;}
+.calendar .weekday{font-weight:bold;}
+.calendar .day{cursor:pointer;}
+.calendar .day.empty{cursor:default;background:var(--calendar-future-bg);}
+.calendar .day.past{background:var(--calendar-past-bg);}
+.calendar .day.future{background:var(--calendar-future-bg);}
+.calendar .day.today{color:var(--today);font-weight:bold;}
+.calendar .day.in-range{background:var(--session-available);}
+.calendar .day.selected{background:var(--session-selected);color:#fff;}
 #memberPanel #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
 #memberPanel input[type=color]{
   border-radius:4px;
@@ -1974,24 +1978,28 @@ body.hide-results .closed-posts{
   transform:scale(var(--calendar-scale));
   transform-origin:top left;
   background:var(--dropdown-bg);
+  color:var(--dropdown-text);
 }
 .open-posts .post-calendar .month{
-  width:300px;
-  height:300px;
   flex:0 0 auto;
-  display:flex;
-  flex-direction:column;
-}
-.open-posts .post-calendar .calendar-header{
-  text-align:center;
-  font-weight:bold;
-  margin-bottom:4px;
+  width:var(--calendar-width);
 }
 .open-posts .post-calendar .grid{
+  width:var(--calendar-width);
+  height:calc(var(--calendar-header-h)*2 + var(--calendar-cell)*6);
   display:grid;
   grid-template-columns:repeat(7,1fr);
-  grid-auto-rows:1fr;
-  flex:1;
+  grid-template-rows:var(--calendar-header-h) var(--calendar-header-h) repeat(6,var(--calendar-cell));
+}
+.open-posts .post-calendar .calendar-header{
+  grid-column:1 / span 7;
+  grid-row:1;
+  height:var(--calendar-header-h);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  font-weight:bold;
 }
 .open-posts .post-calendar .day{
   display:flex;
@@ -2008,7 +2016,7 @@ body.hide-results .closed-posts{
 }
 .open-posts .post-calendar .day.available-day.selected{
   background:var(--session-selected);
-  color:var(--button-text);
+  color:#fff;
 }
 .open-posts .post-calendar .day.today{color:var(--today);}
 
@@ -4215,7 +4223,8 @@ function makePosts(){
       $('#datePicker').querySelectorAll('.day').forEach(day=>{
         const iso = day.dataset.iso;
         if(!iso) return;
-        const d = new Date(iso);
+        const [yy, mm, dd] = iso.split('-').map(Number);
+        const d = new Date(yy, mm - 1, dd);
         day.classList.remove('selected','in-range');
         if(start && sameDay(d, start)) day.classList.add('selected');
         if(end && sameDay(d, end)) day.classList.add('selected');
@@ -4310,7 +4319,7 @@ function makePosts(){
         const monthWidth = cal.querySelector('.month').offsetWidth;
         calendarScroll.scrollLeft = monthWidth * currentMonthIndex;
         const maxScroll = calendarScroll.scrollWidth - calendarScroll.clientWidth;
-        const pos = maxScroll ? (monthWidth * currentMonthIndex) / maxScroll * (calendarScroll.clientWidth - 8) : 0;
+        const pos = maxScroll ? (monthWidth * currentMonthIndex) / maxScroll * calendarScroll.clientWidth : 0;
         calendarScroll.querySelector('.today-marker')?.remove();
         const marker = document.createElement('div');
         marker.className = 'today-marker';
@@ -5667,47 +5676,66 @@ function makePosts(){
         }
         const dateStrings = Array.from(new Set(loc.dates.map(d=>d.full)));
         const allowedSet = new Set(dateStrings);
-        const months = Array.from(new Set(dateStrings.map(ds=> ds.slice(0,7))));
+        const minDate = parseDate(dateStrings[0]);
+        const maxDate = parseDate(dateStrings[dateStrings.length-1]);
         calendarEl.innerHTML='';
         const cal = document.createElement('div');
         cal.className='calendar';
-        months.forEach(m=>{
-          const [yy,mm] = m.split('-').map(Number);
-          const monthStart = new Date(yy, mm-1,1);
-          const daysInMonth = new Date(yy, mm,0).getDate();
-          const monthEl=document.createElement('div');
+        let current = new Date(minDate.getFullYear(), minDate.getMonth(),1);
+        const end = new Date(maxDate.getFullYear(), maxDate.getMonth(),1);
+        while(current <= end){
+          const monthEl = document.createElement('div');
           monthEl.className='month';
-          const header=document.createElement('div');
-          header.className='calendar-header';
-          header.textContent=monthStart.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
-          const grid=document.createElement('div');
+          const grid = document.createElement('div');
           grid.className='grid';
-          let startDow=(monthStart.getDay()+6)%7;
-          for(let i=0;i<startDow;i++){ const empty=document.createElement('div'); empty.className='day empty'; grid.appendChild(empty); }
-          for(let d=1; d<=daysInMonth; d++){
-            const dateObj=new Date(yy, mm-1, d);
-            const iso=dateObj.toISOString().slice(0,10);
+
+          const header = document.createElement('div');
+          header.className='calendar-header';
+          header.textContent = current.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
+          grid.appendChild(header);
+
+          const weekdays=['S','M','T','W','T','F','S'];
+          weekdays.forEach(wd=>{
+            const w=document.createElement('div');
+            w.className='weekday';
+            w.textContent=wd;
+            grid.appendChild(w);
+          });
+
+          const firstDay = new Date(current.getFullYear(), current.getMonth(),1);
+          const startDow = firstDay.getDay();
+          const daysInMonth = new Date(current.getFullYear(), current.getMonth()+1,0).getDate();
+          const totalCells = 42;
+          for(let i=0;i<totalCells;i++){
             const cell=document.createElement('div');
             cell.className='day';
-            cell.textContent=d;
-            if(allowedSet.has(iso)){
-              cell.classList.add('available-day');
-              cell.dataset.iso = iso;
-              cell.addEventListener('mousedown',()=>{ lastClickedCell = cell; });
-              cell.addEventListener('click',()=>{
-                const matches = loc.dates.map((dd,i)=>({i,d:dd})).filter(o=> o.d.full===iso);
-                if(matches.length===1){ selectSession(matches[0].i); }
-                else if(matches.length>1){ showTimePopup(matches); }
-              });
-            } else {
+            const dayNum=i-startDow+1;
+            if(i<startDow || dayNum>daysInMonth){
               cell.classList.add('empty');
+            }else{
+              cell.textContent=dayNum;
+              const dateObj=new Date(current.getFullYear(), current.getMonth(), dayNum);
+              const iso=dateObj.toISOString().slice(0,10);
+              cell.dataset.iso = iso;
+              if(allowedSet.has(iso)){
+                cell.classList.add('available-day');
+                cell.addEventListener('mousedown',()=>{ lastClickedCell = cell; });
+                cell.addEventListener('click',()=>{
+                  const matches = loc.dates.map((dd,i)=>({i,d:dd})).filter(o=> o.d.full===iso);
+                  if(matches.length===1){ selectSession(matches[0].i); }
+                  else if(matches.length>1){ showTimePopup(matches); }
+                });
+              } else {
+                cell.classList.add('empty');
+              }
+              if(isToday(dateObj)) cell.classList.add('today');
             }
-            if(isToday(dateObj)) cell.classList.add('today');
             grid.appendChild(cell);
           }
-          monthEl.append(header,grid);
+          monthEl.appendChild(grid);
           cal.appendChild(monthEl);
-        });
+          current.setMonth(current.getMonth()+1);
+        }
         calendarEl.appendChild(cal);
         if(calScroll) calScroll.scrollLeft = 0;
         let selectedIndex = null;


### PR DESCRIPTION
## Summary
- ensure selected and available dates use new blue palette and calendar months are separated by vertical lines
- fix timezone-related datepicker misselection and center the today scroll marker
- rebuild post calendars using filter panel layout with weekday headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60ea854c88331921e42e9526338a2