### PR TITLE
Refine calendar layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       --dropdown-hover-text: #000000;
         --dropdown-venue-text: #000000;
         --dropdown-radius: 6px;
-        --calendar-width: 210px;
+        --calendar-width: 300px;
         --calendar-cell: calc(var(--calendar-width) / 7);
         --calendar-header-h: 30px;
         --calendar-past-bg: #f0f0f0;
@@ -560,7 +560,7 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filterPanel .calendar-container .today-marker{
   position:absolute;
-  bottom:4px;
+  bottom:0;
   width:8px;
   height:8px;
   border-radius:50%;
@@ -597,6 +597,7 @@ button[aria-expanded="true"] .results-arrow{
   grid-column:1 / span 7;
   grid-row:1;
   height:var(--calendar-header-h);
+  line-height:var(--calendar-header-h);
   display:flex;
   align-items:center;
   justify-content:center;
@@ -621,8 +622,9 @@ button[aria-expanded="true"] .results-arrow{
 .calendar .day.today{color:var(--today);font-weight:bold;}
 .calendar .day.in-range{background:var(--session-available);border-radius:0;}
 .calendar .day.selected{background:var(--session-selected);color:#fff;}
-.calendar .day.range-start,
-.calendar .day.range-end{border-radius:50%;}
+.calendar .day.range-start{border-radius:8px 0 0 8px;}
+.calendar .day.range-end{border-radius:0 8px 8px 0;}
+.calendar .day.range-start.range-end{border-radius:8px;}
 #memberPanel #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
 #memberPanel input[type=color]{
   border-radius:4px;
@@ -4376,7 +4378,7 @@ function makePosts(){
         header.textContent=current.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
         grid.appendChild(header);
 
-        const weekdays=['S','M','T','W','T','F','S'];
+        const weekdays=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
         weekdays.forEach(wd=>{
           const w=document.createElement('div');
           w.className='weekday';
@@ -5797,7 +5799,7 @@ function makePosts(){
           header.textContent = current.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
           grid.appendChild(header);
 
-          const weekdays=['S','M','T','W','T','F','S'];
+          const weekdays=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
           weekdays.forEach(wd=>{
             const w=document.createElement('div');
             w.className='weekday';
@@ -6372,7 +6374,7 @@ document.addEventListener('pointerdown', handleDocInteract);
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{bg:['.map-area'], card:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], text:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
     {key:'filter', label:'Filter Panel', selectors:{bg:['#filterPanel .panel-content'], text:['#filterPanel .panel-content'], title:['#filterPanel .panel-content .t','#filterPanel .panel-content .title'], btn:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn'], btnText:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn']}},
-    {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar'], title:['.calendar .calendar-header']}},
+    {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar .day'], weekday:['.calendar .weekday'], title:['.calendar .calendar-header']}},
   {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},
   {key:'welcomePopup', label:'Welcome Popup', selectors:{bg:['#welcomePopup .panel-content'], text:['#welcomePopup .panel-content'], title:['#welcomePopup .panel-content .t','#welcomePopup .panel-content .title'], btn:['#welcomePopup button'], btnText:['#welcomePopup button']}},
   {key:'memberPanel', label:'Member Panel', selectors:{bg:['#memberPanel .panel-content'], text:['#memberPanel .panel-content'], title:['#memberPanel .panel-content .t','#memberPanel .panel-content .title'], btn:['#memberPanel button'], btnText:['#memberPanel button']}},
@@ -6426,7 +6428,7 @@ document.addEventListener('pointerdown', handleDocInteract);
   const COLOR_PICKER_MODE = 'hex';
   const FONT_OPTIONS = ['Verdana','Inter','Roboto','Montserrat','Arial','Helvetica','Georgia','Times New Roman','Courier New','Trebuchet MS','Tahoma','Comic Sans MS'];
   const FONT_SIZE_OPTIONS = ['10','12','14','16','18','20','24','32'];
-  const TEXT_BG_MAP = {text:'bg', title:'card', btnText:'btn'};
+  const TEXT_BG_MAP = {text:'bg', weekday:'bg', title:'card', btnText:'btn'};
 
   function updateTextPicker(areaKey, type){
     const picker = document.getElementById(`${areaKey}-${type}-picker`);
@@ -6575,6 +6577,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       };
       set('bg', theme.background);
       set('text', theme.text);
+      set('weekday', theme.text);
       set('card', theme.secondary);
       set('btn', theme.primary);
       set('btnText', theme.buttonText);
@@ -6623,7 +6626,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       if(svgInput) svgInput.value = clusterSvg;
       if(svgRow) svgRow.style.display = clusterIconType === 'svg' ? 'flex' : 'none';
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText','border','hoverBorder','activeBorder','header','image','optionsMenu','menu'].forEach(type=>{
+      ['bg','card','text','weekday','title','btn','btnText','border','hoverBorder','activeBorder','header','image','optionsMenu','menu'].forEach(type=>{
         const cInput = document.getElementById(`${area.key}-${type}-c`);
         const oInput = document.getElementById(`${area.key}-${type}-o`);
         const fontSel = document.getElementById(`${area.key}-${type}-font`);
@@ -6685,14 +6688,14 @@ document.addEventListener('pointerdown', handleDocInteract);
           const cs = getComputedStyle(el);
           if(cInput){
             if(type === 'bg' || type === 'btn' || type === 'card' || type === 'header' || type === 'image' || type === 'optionsMenu') col = cs.backgroundColor;
-            else if(type === 'text' || type === 'btnText' || type === 'title') col = cs.color;
+            else if(type === 'text' || type === 'btnText' || type === 'title' || type === 'weekday') col = cs.color;
             else if(type === 'border' || type === 'hoverBorder' || type === 'activeBorder') col = cs.borderColor;
           }
           if(fontSel) font = cs.fontFamily.split(',')[0].replace(/"/g,'').trim();
           if(sizeSel) size = parseInt(cs.fontSize,10);
           if(weightSel) weight = cs.fontWeight;
           if(shColor){
-            if(type==='text' || type==='title' || type==='btnText') shadow = cs.textShadow;
+            if(type==='text' || type==='title' || type==='btnText' || type==='weekday') shadow = cs.textShadow;
             else if(type==='card' || type==='btn') shadow = cs.boxShadow;
           }
           return true;
@@ -6718,7 +6721,7 @@ document.addEventListener('pointerdown', handleDocInteract);
           weightSel.value = parseInt(weight,10) >= 600 ? 'bold' : 'normal';
         }
         if(shColor && shadow && shadow !== 'none'){
-          if(type==='text' || type==='title' || type==='btnText'){
+          if(type==='text' || type==='title' || type==='btnText' || type==='weekday'){
             const m = shadow.match(/(-?\d+)px\s+(-?\d+)px\s+(-?\d+)px\s+rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
             if(m){
               shX.value = m[1];
@@ -6741,7 +6744,7 @@ document.addEventListener('pointerdown', handleDocInteract);
           v.value = currentState[`${area.key}-${type}`].value;
         }
       });
-      ['text','title','btnText'].forEach(t=> updateTextPicker(area.key, t));
+      ['text','title','btnText','weekday'].forEach(t=> updateTextPicker(area.key, t));
     });
     ['panelText','placeholder','filterPlaceholder','dropdownSelectedText','dropdownText','dropdownHoverText','dropdownVenueText','dateRangeText'].forEach(id=> updateTextPicker(id,'text'));
     const varMap = {btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today'};
@@ -6827,7 +6830,7 @@ document.addEventListener('pointerdown', handleDocInteract);
           const toV = document.getElementById(`${area.key}-${type}`);
           if(fromV && toV){ toV.value = fromV.value; }
         });
-        ['text','title','btnText'].forEach(t=> updateTextPicker(area.key, t));
+        ['text','title','btnText','weekday'].forEach(t=> updateTextPicker(area.key, t));
         applyAdmin();
       });
       const txtBtn = document.createElement('button');
@@ -6837,7 +6840,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       txtBtn.addEventListener('click', (e)=>{
         e.stopPropagation();
         if(!lastFieldsetKey || lastFieldsetKey === area.key) return;
-        ['text','title','btnText'].forEach(type=>{
+        ['text','title','btnText','weekday'].forEach(type=>{
           const fields = ['c','font','size','weight','shadow-color','shadow-x','shadow-y','shadow-blur'];
           fields.forEach(suf=>{
             const from = document.getElementById(`${lastFieldsetKey}-${type}-${suf}`);
@@ -6855,6 +6858,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       if(area.selectors.bg) types.push('bg');
       if(area.selectors.card) types.push('card');
       if(area.selectors.text) types.push('text');
+      if(area.selectors.weekday) types.push('weekday');
       if(area.selectors.title) types.push('title');
       if(area.selectors.btn) types.push('btn','btnText');
       if(area.selectors.border) types.push('border');
@@ -6869,6 +6873,7 @@ document.addEventListener('pointerdown', handleDocInteract);
             bg: 'Background',
             card: 'Card',
             text: 'Text',
+            weekday: 'Weekday Text',
             title: 'Title',
             btn: 'Button',
             btnText: 'Button Text',
@@ -6882,8 +6887,9 @@ document.addEventListener('pointerdown', handleDocInteract);
             optionsMenu: 'Options Menu',
             menu: 'Menu Background'
           };
-          const label = labelMap[type] || type;
-        if(type === 'text' || type === 'title' || type === 'btnText'){
+          let label = labelMap[type] || type;
+          if(area.key === 'calendar' && type === 'text') label = 'Date Text';
+        if(type === 'text' || type === 'title' || type === 'btnText' || type === 'weekday'){
           const row = document.createElement('div');
           row.className = 'control-row';
           const labelEl = document.createElement('label');
@@ -7207,7 +7213,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       }
     });
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText','header','image','optionsMenu','menu'].forEach(type=>{
+      ['bg','card','text','weekday','title','btn','btnText','header','image','optionsMenu','menu'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         const f = document.getElementById(`${area.key}-${type}-font`);
@@ -7240,7 +7246,7 @@ document.addEventListener('pointerdown', handleDocInteract);
                 const blur = sb ? sb.value : 0;
                 if(shadowColor) el.style.boxShadow = `0 0 ${blur}px ${shadowColor}`;
               }
-            } else if(type==='text' || type==='btnText' || type==='title'){
+            } else if(type==='text' || type==='btnText' || type==='title' || type==='weekday'){
               if(color) el.style.color = color;
               if(font) el.style.fontFamily = font;
               if(size) el.style.fontSize = `${size}px`;
@@ -7281,7 +7287,7 @@ document.addEventListener('pointerdown', handleDocInteract);
   function collectThemeValues(){
     const data = {};
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText','border','hoverBorder','activeBorder','hoverAdjust','activeAdjust','header','image','optionsMenu','menu'].forEach(type=>{
+      ['bg','card','text','weekday','title','btn','btnText','border','hoverBorder','activeBorder','hoverAdjust','activeAdjust','header','image','optionsMenu','menu'].forEach(type=>{
         const c = document.getElementById(`${area.key}-${type}-c`);
         const o = document.getElementById(`${area.key}-${type}-o`);
         const f = document.getElementById(`${area.key}-${type}-font`);
@@ -7389,7 +7395,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       css += '.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}\n';
     }
     colorAreas.forEach(area=>{
-      ['bg','card','text','title','btn','btnText','header','image','optionsMenu','menu'].forEach(type=>{
+      ['bg','card','text','weekday','title','btn','btnText','header','image','optionsMenu','menu'].forEach(type=>{
         const entry = data[`${area.key}-${type}`];
         if(!entry) return;
         const selectors = area.selectors[type] || [];
@@ -7404,7 +7410,7 @@ document.addEventListener('pointerdown', handleDocInteract);
             const s = entry.shadow; const blur = s.blur || 0;
             rules.push(`box-shadow:0 0 ${blur}px ${s.color};`);
           }
-        } else if(type==='text' || type==='title' || type==='btnText'){
+        } else if(type==='text' || type==='title' || type==='btnText' || type==='weekday'){
           if(entry.color) rules.push(`color:${entry.color};`);
           if(entry.font) rules.push(`font-family:${entry.font};`);
           if(entry.size) rules.push(`font-size:${entry.size}px;`);


### PR DESCRIPTION
## Summary
- Set calendar months to 300px with 30px headers showing only month and year
- Display weekday labels in "Sun Mon" format and add separate Date Text and Weekday Text styling controls
- Adjust range selection and today marker for improved alignment and clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b671ba2ff883318e560648e5124e16