### PR TITLE
Fix calendar calendar container height

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,9 +552,8 @@ button[aria-expanded="true"] .results-arrow{
   position:relative;
   overflow-x:auto;
   overflow-y:hidden;
-  padding-bottom:20px;
   box-sizing:content-box;
-  height:auto;
+  height:250px;
   border:1px solid var(--border);
   border-radius:8px;
 }
@@ -2003,10 +2002,9 @@ body.hide-results .closed-posts{
 
 .open-posts .calendar-container .calendar-scroll{
   width:100%;
-  height:auto;
   overflow-x:auto;
   overflow-y:auto;
-  padding-bottom:20px;
+  height:250px;
   box-sizing:border-box;
   background:var(--dropdown-bg);
   border:1px solid var(--border);


### PR DESCRIPTION
## Summary
- Remove extra bottom padding from calendar displays
- Set calendar container and scroll areas to fixed 250px height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6841d9fb48331945332a012913238