### PR TITLE
fix: ignore missing custom theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -7658,12 +7658,16 @@ document.addEventListener('pointerdown', handleDocInteract);
   function loadSavedTheme(){
     const cssTheme = localStorage.getItem('selectedCssTheme');
     if(cssTheme){
-      const idx = presets.findIndex(p=>p.css===cssTheme);
-      if(idx !== -1){
-        const sel = document.getElementById('themePreset');
-        if(sel) sel.value = idx;
-        applyPreset(presets[idx]);
-        return;
+      if(!document.getElementById(cssTheme)){
+        localStorage.removeItem('selectedCssTheme');
+      } else {
+        const idx = presets.findIndex(p=>p.css===cssTheme);
+        if(idx !== -1){
+          const sel = document.getElementById('themePreset');
+          if(sel) sel.value = idx;
+          applyPreset(presets[idx]);
+          return;
+        }
       }
     }
     const saved = JSON.parse(localStorage.getItem('currentTheme')||'null');


### PR DESCRIPTION
## Summary
- Prevent missing CSS theme entries from overriding the default style by clearing invalid `selectedCssTheme` values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e5008c088331b999e293812b0729