### PR TITLE
Refine map control styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1504,22 +1504,7 @@ body.filters-active #filterBtn{
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg{opacity:1;}
 .geocoder .mapboxgl-ctrl-geocoder--icon,
 .geocoder .mapboxgl-ctrl-geocoder--icon-search{display:none !important;}
-.geocoder .mapboxgl-ctrl-group button,
-.geocoder .mapboxgl-ctrl button{
-  width:var(--control-h);
-  height:var(--control-h);
-  background:var(--control-text-bg) !important;
-  border:0;
-  color:#000;
-  padding:0;
-  border-radius:12px;
-  line-height:var(--control-h);
-  text-align:center;
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  flex:none;
-}
+
 .geocoder .mapboxgl-ctrl-group button + button{border-left:1px solid #ccc;}
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
 .geocoder .mapboxgl-ctrl button svg,
@@ -1533,7 +1518,7 @@ body.filters-active #filterBtn{
   width:20px;
   height:20px;
 }
-.geocoder .mapboxgl-ctrl-group{background:var(--control-text-bg) !important;border:1px solid #ccc !important;border-radius:12px;overflow:hidden;}
+.geocoder .mapboxgl-ctrl-group{border-radius:12px;overflow:hidden;}
 .mapboxgl-ctrl button{
   line-height:var(--control-h);
   text-align:center;
@@ -1553,17 +1538,13 @@ body.filters-active #filterBtn{
   width:var(--control-h);
   height:var(--control-h);
   overflow:hidden;
-}
-.mapboxgl-ctrl-geolocate button,
-.mapboxgl-ctrl-compass button{
-  width:100%;
-  height:100%;
   display:flex;
   align-items:center;
   justify-content:center;
+  border:none !important;
 }
-.mapboxgl-ctrl-geolocate button{background:var(--control-geolocate-bg) !important;}
-.mapboxgl-ctrl-compass button{background:var(--control-compass-bg) !important;}
+.mapboxgl-ctrl-geolocate{background:var(--control-geolocate-bg) !important;}
+.mapboxgl-ctrl-compass{background:var(--control-compass-bg) !important;}
 .mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon,
 .mapboxgl-ctrl-compass .mapboxgl-ctrl-icon,
 .mapboxgl-ctrl-compass .mapboxgl-ctrl-compass-arrow{


### PR DESCRIPTION
## Summary
- remove global geocoder button background to avoid overriding map controls
- style geolocate and compass containers directly with custom backgrounds
- drop default background/border from geocoder control groups to prevent stacked appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e909d2188331ba9ab729e1570064