### PR TITLE
Relocate sort controls and map toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,6 +783,9 @@ button[aria-expanded="true"] .results-arrow{
 .autotheme-row{
   width:300px;
   height:35px;
+  display:flex;
+  align-items:center;
+  gap:4px;
 }
 .autotheme-row button,
 .autotheme-row input[type=color]{
@@ -3098,7 +3101,6 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
         <span id="resultCount" aria-live="polite"><strong>0</strong> Results</span>
       </button>
       <img id="smallLogo" src="assets/funmap logo 2011-09-30h.png" alt="FunMap.com logo" />
-      <button id="mapPostsToggle" aria-pressed="false">Show Posts</button>
     </nav>
     <div class="auth">
       <button id="memberBtn" aria-label="Open members area">
@@ -3120,17 +3122,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
     <button id="resultsToggle" aria-pressed="true" aria-label="Toggle results list">
       <span class="results-arrow" aria-hidden="true"></span> List
     </button>
-    <div class="options-dropdown">
-      <button id="optionsBtn" aria-haspopup="true" aria-expanded="false">Title A - Z</button>
-      <div id="optionsMenu" class="options-menu" hidden>
-        <button id="favToggle" aria-pressed="false">Favourites on top<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 17.3 6.2 21l1.6-6.7L2 9.3l6.9-.6L12 2l3.1 6.7 6.9.6-5.8 4.9L17.8 21 12 17.3z"/></svg></button>
-        <div class="sort-options" role="group" aria-label="Sort order" style="display:flex; flex-direction:column; gap:6px;">
-          <button class="sort-option" data-sort="az" aria-pressed="true">Title A - Z</button>
-          <button class="sort-option" data-sort="nearest" aria-pressed="false">Closest</button>
-          <button class="sort-option" data-sort="soon" aria-pressed="false">Soonest</button>
-        </div>
-      </div>
-    </div>
+    <button id="mapPostsToggle" aria-pressed="false">Show Posts</button>
     <div id="geocoder" class="geocoder"></div>
   </div>
 
@@ -3168,6 +3160,17 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
       </div>
       <div class="panel-body">
         <section class="filters-col" aria-label="Filters">
+          <div class="options-dropdown">
+            <button id="optionsBtn" aria-haspopup="true" aria-expanded="false">Title A - Z</button>
+            <div id="optionsMenu" class="options-menu" hidden>
+              <button id="favToggle" aria-pressed="false">Favourites on top<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 17.3 6.2 21l1.6-6.7L2 9.3l6.9-.6L12 2l3.1 6.7 6.9.6-5.8 4.9L17.8 21 12 17.3z"/></svg></button>
+              <div class="sort-options" role="group" aria-label="Sort order" style="display:flex; flex-direction:column; gap:6px;">
+                <button class="sort-option" data-sort="az" aria-pressed="true">Title A - Z</button>
+                <button class="sort-option" data-sort="nearest" aria-pressed="false">Closest</button>
+                <button class="sort-option" data-sort="soon" aria-pressed="false">Soonest</button>
+              </div>
+            </div>
+          </div>
           <div>
             <h3>Keywords</h3>
             <div class="field">
@@ -4141,7 +4144,7 @@ function makePosts(){
 }
 
 
-    posts = makePosts();
+    posts = makePosts().filter(p => Number.isFinite(p.lng) && Number.isFinite(p.lat));
 
     const resultsEl = $('#results');
     const postsWideEl = $('#postsWide');
@@ -4683,18 +4686,18 @@ function makePosts(){
       }
 
       injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css');
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.css',
-        'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.1/dist/mapbox-gl-geocoder.css');
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css',
+        'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
 
       const s = document.createElement('script');
       s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = ()=>{
         const g = document.createElement('script');
-        g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.min.js';
+        g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         g.onload = cb;
         g.onerror = ()=>{
           const gf = document.createElement('script');
-          gf.src='https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.1/dist/mapbox-gl-geocoder.min.js';
+          gf.src='https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.min.js';
           gf.onload = cb;
           gf.onerror = cb;
           document.head.appendChild(gf);
@@ -4736,7 +4739,7 @@ function makePosts(){
         }
       } else {
         const script = document.createElement('script');
-        script.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.1/mapbox-gl-geocoder.min.js';
+        script.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         script.onload = addGeocoder;
         script.onerror = ()=> console.error('Mapbox Geocoder failed to load');
         document.head.appendChild(script);
@@ -4949,7 +4952,7 @@ function makePosts(){
       return {
         type:'FeatureCollection',
         features: list
-          .filter(p => typeof p.lng === 'number' && typeof p.lat === 'number')
+          .filter(p => Number.isFinite(p.lng) && Number.isFinite(p.lat))
           .map(p => ({
             type:'Feature',
             properties:{id:p.id, title:p.title, city:p.city, cat:p.category},


### PR DESCRIPTION
## Summary
- Move sort options into filter panel and put map/posts toggle in subheader
- Align autotheme color picker row
- Fix Mapbox Geocoder CDN paths and guard against invalid post coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f148b7b08331bd7eed233f20e0e8