### PR TITLE
Improve geocoder placeholder styling and map control icon alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
       --filter-placeholder-text: var(--placeholder-text);
       --control-text-bg: #ffffff;
       --control-placeholder-text: var(--placeholder-text);
+      --control-placeholder-font: Verdana, sans-serif;
+      --control-placeholder-size: 16px;
       --control-geolocate-bg: #ffffff;
       --control-compass-bg: #ffffff;
       --control-clear-bg: rgba(0,0,0,0);
@@ -1482,12 +1484,13 @@ body.filters-active #filterBtn{
 .geocoder .mapboxgl-ctrl-geocoder--suggestions,
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
 .geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 10px;background:var(--control-text-bg) !important;color:#000;font-family:inherit;font-size:16px;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
-.geocoder input::placeholder{font-family:Verdana,sans-serif;font-size:16px;color:var(--control-placeholder-text);}
+.geocoder .mapboxgl-ctrl-geocoder input::placeholder{font-family:var(--control-placeholder-font) !important;font-size:var(--control-placeholder-size) !important;color:var(--control-placeholder-text);}
 .geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   position:absolute;
   right:0;
-  top:50%;
-  transform:translateY(-50%);
+  top:0;
+  bottom:0;
+  margin:auto;
   width:var(--control-h);
   height:var(--control-h);
   background:var(--control-clear-bg) !important;
@@ -1495,7 +1498,6 @@ body.filters-active #filterBtn{
   border-left:1px solid #ccc;
   color:#000;
   padding:0;
-  margin:0;
   line-height:var(--control-h);
   text-align:center;
   border-radius:0 12px 12px 0;
@@ -1504,20 +1506,19 @@ body.filters-active #filterBtn{
   justify-content:center;
   opacity:1;
 }
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg{opacity:1;}
+.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg{opacity:1;fill:#000;}
 .geocoder .mapboxgl-ctrl-geocoder--icon,
 .geocoder .mapboxgl-ctrl-geocoder--icon-search{display:none !important;}
 
 .geocoder .mapboxgl-ctrl-group button + button{border-left:1px solid #ccc;}
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
-.geocoder .mapboxgl-ctrl button svg,
-.geocoder .mapboxgl-ctrl button span{
-  display:inline-block;
-  vertical-align:middle;
+.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
+.mapboxgl-ctrl button svg,
+.mapboxgl-ctrl button span{
+  display:block;
   margin:0;
 }
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
-.geocoder .mapboxgl-ctrl button svg{
+.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
+.mapboxgl-ctrl button svg{
   width:20px;
   height:20px;
 }


### PR DESCRIPTION
## Summary
- Allow customizing geocoder placeholder font and size via new CSS variables
- Center map control icons and make geocoder clear button fully opaque black

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f2f16390833192234ee55964a950