### PR TITLE
Rotate dropdown arrows to point down initially

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,11 +379,11 @@ input[type="checkbox"]{
 
 .results-arrow{
   margin-right:8px;
-  transform:rotate(135deg);
+  transform:rotate(45deg);
   transition:transform .3s;
   vertical-align:middle;
 }
-body.hide-results #resultsToggle .results-arrow{transform:rotate(-45deg);}
+body.hide-results #resultsToggle .results-arrow{transform:rotate(-135deg);}
 
 .options-dropdown > button{
   position:relative;
@@ -395,13 +395,13 @@ body.hide-results #resultsToggle .results-arrow{transform:rotate(-45deg);}
   position:absolute;
   top:50%;
   right:10px;
-  transform:translateY(-50%) rotate(135deg);
+  transform:translateY(-50%) rotate(45deg);
   margin-right:0;
 }
 
 button[aria-expanded="true"] .dropdown-arrow,
 button[aria-expanded="true"] .results-arrow{
-  transform:translateY(-50%) rotate(-45deg);
+  transform:translateY(-50%) rotate(-135deg);
 }
 
 


### PR DESCRIPTION
## Summary
- Adjust dropdown and results arrow CSS so sort, venue, and session menus start pointing downward and rotate up when expanded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7048594b883318cf7f65c02261e03