### PR TITLE
Adjust ad panel offset to ignore subheader height

### DIFF
--- a/index.html
+++ b/index.html
@@ -2715,7 +2715,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 
 .ad-panel{
   position:fixed;
-  top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top));
+  top: calc(var(--header-h) + var(--safe-top));
   bottom: var(--footer-h);
   width:400px;
   right: var(--gap);


### PR DESCRIPTION
## Summary
- eliminate subheader height from ad panel top offset so panel begins directly below header
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b706c3af888331aedfd81ec421bbd4