### PR TITLE
Fix map control styling and placeholder font

### DIFF
--- a/index.html
+++ b/index.html
@@ -1586,8 +1586,8 @@ body.filters-active #filterBtn{
   justify-content:center;
   border:none !important;
 }
-.mapboxgl-ctrl-geolocate{background:var(--control-geolocate-bg) !important;}
-.mapboxgl-ctrl-compass{background:var(--control-compass-bg) !important;}
+#map .mapboxgl-ctrl-geolocate{background:var(--control-geolocate-bg) !important;}
+#map .mapboxgl-ctrl-compass{background:var(--control-compass-bg) !important;}
 .mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon,
 .mapboxgl-ctrl-compass .mapboxgl-ctrl-icon,
 .mapboxgl-ctrl-compass .mapboxgl-ctrl-compass-arrow{
@@ -1598,11 +1598,13 @@ body.filters-active #filterBtn{
 #map .mapboxgl-ctrl button{
   width:var(--control-h);
   height:var(--control-h);
-  background:var(--control-text-bg) !important;
   border:0 !important;
   color:#000;
   padding:0 !important;
   box-shadow:none;
+}
+#map .mapboxgl-ctrl button:not(.mapboxgl-ctrl-geolocate):not(.mapboxgl-ctrl-compass){
+  background:var(--control-text-bg) !important;
 }
 #map .mapboxgl-ctrl button svg{
   width:20px;
@@ -4765,7 +4767,14 @@ function makePosts(){
       }
     }
 
+    function ensureControlSizes(){
+      const style = document.createElement('style');
+      style.textContent = '.mapboxgl-ctrl button,.mapboxgl-ctrl-geolocate,.mapboxgl-ctrl-compass{width:var(--control-h)!important;height:var(--control-h)!important;}';
+      document.head.appendChild(style);
+    }
+
     function initMap(){
+      ensureControlSizes();
       if(typeof mapboxgl === 'undefined'){
         console.error('Mapbox GL failed to load');
         return;
@@ -6368,7 +6377,7 @@ document.addEventListener('pointerdown', handleDocInteract);
     {key:'closed-posts', label:'Closed Posts', selectors:{bg:['.closed-posts'], text:['.closed-posts','.closed-posts .posts'], title:['.closed-posts .card .t','.closed-posts .card .title','.closed-posts .open-posts .t','.closed-posts .open-posts .title'], btn:['.closed-posts button'], btnText:['.closed-posts button'], card:['.closed-posts .card','.closed-posts .open-posts']}},
     {key:'open-posts', label:'Open Posts', selectors:{text:['.open-posts','.open-posts .venue-info','.open-posts .session-info'], title:['.open-posts .t','.open-posts .title'], btn:['.open-posts button'], btnText:['.open-posts button'], card:['.open-posts'], header:['.open-posts .detail-header'], image:['.open-posts .img-box'], menu:['.open-posts .venue-menu button','.open-posts .session-menu button']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
-    {key:'map', label:'Map', selectors:{bg:['.map-area'], popupBg:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], popupText:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
+    {key:'map', label:'Map', selectors:{popupBg:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], popupText:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
     {key:'filter', label:'Filter Panel', selectors:{bg:['#filterPanel .panel-content'], text:['#filterPanel .panel-content'], title:['#filterPanel .panel-content .t','#filterPanel .panel-content .title'], btn:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn'], btnText:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn']}},
     {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar .day'], weekday:['.calendar .weekday'], title:['.calendar .calendar-header'], header:['.calendar .calendar-header']}},
   {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},
@@ -6752,6 +6761,16 @@ document.addEventListener('pointerdown', handleDocInteract);
       });
       ['text','title','btnText','weekday','popupText'].forEach(t=> updateTextPicker(area.key, t));
     });
+    const cpFont = document.getElementById('controlPlaceholder-text-font');
+    const cpSize = document.getElementById('controlPlaceholder-text-size');
+    if(cpFont){
+      const val = getComputedStyle(document.documentElement).getPropertyValue('--control-placeholder-font').trim().replace(/"/g,'');
+      cpFont.value = FONT_OPTIONS.includes(val) ? val : FONT_OPTIONS[0];
+    }
+    if(cpSize){
+      const val = getComputedStyle(document.documentElement).getPropertyValue('--control-placeholder-size').trim();
+      cpSize.value = parseInt(val) || cpSize.value;
+    }
     ['panelText','placeholder','filterPlaceholder','dropdownSelectedText','dropdownText','dropdownHoverText','dropdownVenueText','dateRangeText','controlPlaceholder'].forEach(id=> updateTextPicker(id,'text'));
     const varMap = {btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg'};
     Object.entries(varMap).forEach(([id,varName])=>{
@@ -7263,8 +7282,18 @@ document.addEventListener('pointerdown', handleDocInteract);
       const col = adjust(baseColor, parseInt(activeAdj.value,10)||0);
       document.documentElement.style.setProperty('--border-active', hexToRgba(col, baseOpacity));
     }
-    const varMap = {btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg'};
+    const varMap = {btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg',controlPlaceholderFont:'--control-placeholder-font',controlPlaceholderSize:'--control-placeholder-size'};
     Object.entries(varMap).forEach(([id,varName])=>{
+      if(id==='controlPlaceholderFont'){
+        const f = document.getElementById('controlPlaceholder-text-font');
+        if(f) document.documentElement.style.setProperty(varName, f.value);
+        return;
+      }
+      if(id==='controlPlaceholderSize'){
+        const s = document.getElementById('controlPlaceholder-text-size');
+        if(s) document.documentElement.style.setProperty(varName, s.value + 'px');
+        return;
+      }
       const c = document.getElementById(`${id}-c`) || document.getElementById(`${id}-text-c`) || document.getElementById(id);
       const o = document.getElementById(`${id}-o`);
       if(c){
@@ -7412,8 +7441,13 @@ document.addEventListener('pointerdown', handleDocInteract);
     });
     ['dropdownTitle','panelText','placeholder','filterPlaceholder','dropdownSelectedText','dropdownText','dropdownHoverText','dropdownVenueText','dateRangeText','controlPlaceholder'].forEach(id=>{
       const c = document.getElementById(`${id}-text-c`) || document.getElementById(`${id}-c`);
-      if(c){
-        data[id] = { color: c.value };
+      const f = document.getElementById(`${id}-text-font`);
+      const s = document.getElementById(`${id}-text-size`);
+      if(c || f || s){
+        data[id] = {};
+        if(c && c.value) data[id].color = c.value;
+        if(f && f.value) data[id].font = f.value;
+        if(s && s.value) data[id].size = s.value;
       }
     });
     const calWidth = document.getElementById('calendar-width');
@@ -7461,6 +7495,11 @@ document.addEventListener('pointerdown', handleDocInteract);
     if(calW && calW.value){ rootVars.push(`--calendar-width:${calW.value}px;`); }
     const calH = data['calendar-height'];
     if(calH && calH.value){ rootVars.push(`--calendar-height:${calH.value}px;`); }
+    const cp = data.controlPlaceholder;
+    if(cp){
+      if(cp.font) rootVars.push(`--control-placeholder-font:${cp.font};`);
+      if(cp.size) rootVars.push(`--control-placeholder-size:${cp.size}px;`);
+    }
     if(rootVars.length){
       css += `:root{${rootVars.join('')}}\n`;
     }
@@ -7553,14 +7592,22 @@ document.addEventListener('pointerdown', handleDocInteract);
         const areaKey = parts.shift();
         const type = parts.join('-');
         if(!type){
-          const colorInput = document.getElementById(`${key}-c`) || document.getElementById(key);
+          const colorInput = document.getElementById(`${key}-c`) || document.getElementById(`${key}-text-c`) || document.getElementById(key);
           const opacityInput = document.getElementById(`${key}-o`);
+          const fontInput = document.getElementById(`${key}-text-font`);
+          const sizeInput = document.getElementById(`${key}-text-size`);
           if(colorInput && val.color){ colorInput.value = val.color; }
           if(opacityInput && val.opacity!==undefined){ opacityInput.value = val.opacity; }
-        const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg'};
+          if(fontInput && val.font){ fontInput.value = val.font; }
+          if(sizeInput && val.size){ sizeInput.value = val.size; }
+          const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg'};
           if(varMap[key]){
             const color = val.opacity!==undefined ? hexToRgba(val.color, val.opacity) : val.color;
             document.documentElement.style.setProperty(varMap[key], color);
+          }
+          if(key==='controlPlaceholder'){
+            if(val.font) document.documentElement.style.setProperty('--control-placeholder-font', val.font);
+            if(val.size) document.documentElement.style.setProperty('--control-placeholder-size', val.size + 'px');
           }
           return;
         }


### PR DESCRIPTION
## Summary
- Let geolocate and compass buttons use their own theme colors
- Maintain custom 35px control size even after Mapbox CSS loads
- Enable theme builder to change control placeholder font and size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70353179c83319b4139d5cf8ad001