### PR TITLE
Fix sticky header offset when scrolling to posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5585,12 +5585,21 @@ function makePosts(){
         updateStickyImages();
       }
 
+      await nextFrame();
+      const header = detail.querySelector('.detail-header');
+      const stickyHeaderActive = document.documentElement.classList.contains('open-posts-sticky-header');
+      if(stickyHeaderActive && header){
+        const h = header.offsetHeight;
+        header.style.scrollMarginTop = h + 'px';
+      }
+
       if(container){
-        const top = detail.offsetTop - parseInt(getComputedStyle(container).paddingTop,10) - 12;
+        const headerHeight = (stickyHeaderActive && header) ? header.offsetHeight : 0;
+        const top = detail.offsetTop - parseInt(getComputedStyle(container).paddingTop,10) - 12 - headerHeight;
         container.scrollTo({top: Math.max(top, 0), behavior:'smooth'});
         ensureGap(container, detail);
       } else if(window.innerWidth > 450) {
-        detail.scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
+        (header || detail).scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
 
 


### PR DESCRIPTION
## Summary
- Adjust openPost scroll behavior to account for sticky header and apply scroll-margin-top

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b711ff99fc8331b7b5e45c48787a30