### PR TITLE
refine thumbnails and corner styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       --dropdown-hover-bg: rgba(224,224,224,1);
       --dropdown-hover-text: #000000;
         --dropdown-venue-text: #000000;
-        --dropdown-radius: 6px;
+        --dropdown-radius: 8px;
         --calendar-width: 300px;
         --calendar-height: 250px;
         --calendar-cell-w: calc(var(--calendar-width) / 7);
@@ -136,7 +136,7 @@ html,body{
 }
 *::-webkit-scrollbar-thumb{
   background:var(--scrollbar-thumb);
-  border-radius:4px;
+  border-radius:8px;
 }
 *::-webkit-scrollbar-thumb:hover{
   background:var(--scrollbar-thumb-hover);
@@ -172,8 +172,8 @@ button:not([class^="mapboxgl-ctrl"]),
   color: var(--button-text);
   padding: 0 10px;
   height: var(--control-h);
-  min-width: var(--control-h);
-  border-radius: 12px;
+  min-width: 35px;
+  border-radius: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -290,12 +290,12 @@ input[type="url"],
 textarea,
 select{
   height: var(--control-h);
-  border-radius: 12px;
+  border-radius: 8px;
 }
 input[type="checkbox"]{
   width: var(--control-h);
   height: var(--control-h);
-  border-radius: 12px;
+  border-radius: 8px;
 }
 
   .header{
@@ -344,7 +344,7 @@ input[type="checkbox"]{
 
 .view-toggle button{
   border: 1px solid var(--btn);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 0 14px;
   background: var(--btn);
   color: var(--button-text);
@@ -359,7 +359,7 @@ input[type="checkbox"]{
 .auth button,
 .options-menu button{
   height:35px;
-  border-radius:12px;
+  border-radius:8px;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -368,7 +368,7 @@ input[type="checkbox"]{
 }
 .header .gear,
 .header a{
-  border-radius:12px;
+  border-radius:8px;
 }
 
 
@@ -436,7 +436,7 @@ button[aria-expanded="true"] .results-arrow{
   }
   #spinType label{
     flex:1;
-    border-radius:6px;
+    border-radius:8px;
     overflow:hidden;
   }
   #spinType input{
@@ -454,7 +454,7 @@ button[aria-expanded="true"] .results-arrow{
     text-align:center;
     transition:background .2s,border-color .2s,color .2s;
     border:1px solid var(--btn);
-    border-radius:6px;
+    border-radius:8px;
   }
 
 .auth{
@@ -477,7 +477,7 @@ button[aria-expanded="true"] .results-arrow{
 .gear{
   width: 36px;
   height: 36px;
-  border-radius: 10px;
+  border-radius: 8px;
   background: rgba(255,255,255,0.2);
   display: grid;
   place-items: center;
@@ -683,7 +683,7 @@ button[aria-expanded="true"] .results-arrow{
 .calendar .day.range-start.range-end{border-radius:8px;}
 #memberPanel #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
 #memberPanel input[type=color]{
-  border-radius:4px;
+  border-radius:8px;
   padding:0;
   height:40px;
   display:block;
@@ -766,7 +766,7 @@ button[aria-expanded="true"] .results-arrow{
   width:40px;
   height:40px;
   padding:0;
-  border-radius:4px;
+  border-radius:8px;
 }
 #adminPanel .shadow-group input[type=number]{
   flex:1 1 0;
@@ -854,7 +854,7 @@ button[aria-expanded="true"] .results-arrow{
   width:100%;
 }
 #adminPanel .color-group input[type=color]{
-  border-radius:4px;
+  border-radius:8px;
   padding:0;
   height:35px;
   display:block;
@@ -879,7 +879,7 @@ button[aria-expanded="true"] .results-arrow{
 #adminPanel .tab-bar button{
   flex:1;
   padding:6px 10px;
-  border-radius:6px;
+  border-radius:8px;
   background:var(--btn);
   border:1px solid var(--btn);
   color:var(--button-text);
@@ -895,7 +895,7 @@ button[aria-expanded="true"] .results-arrow{
 #adminPanel .marker-set svg.outline *{stroke:#000;stroke-width:1;}
 #adminPanel input[type=range]{width:100%;}
 #adminPanel .preset-actions{display:flex;gap:6px;margin:0;}
-#adminPanel .preset-actions input{flex:1;padding:6px;border-radius:4px;}
+#adminPanel .preset-actions input{flex:1;padding:6px;border-radius:8px;}
 #adminPanel .preset-actions button{padding:6px 10px;}
 .panel-field{
   margin:8px 0;
@@ -989,7 +989,7 @@ button[aria-expanded="true"] .results-arrow{
 .field-instance{
   padding:6px 10px;
   border:1px solid #ccc;
-  border-radius:4px;
+  border-radius:8px;
   background:#f9f9f9;
   cursor:move;
 }
@@ -1073,7 +1073,7 @@ button[aria-expanded="true"] .results-arrow{
   align-items: center;
 }
 .input input{
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--btn);
   color: var(--ink);
 }
@@ -1185,7 +1185,7 @@ button[aria-expanded="true"] .results-arrow{
   place-items: center;
   width: 38px;
   height: 40px;
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--btn);
   cursor: pointer;
   border: 1px solid var(--btn);
@@ -1211,7 +1211,7 @@ button[aria-expanded="true"] .results-arrow{
 
 .cat .bar{
   height: 36px;
-  border-radius: 12px;
+  border-radius: 8px;
   padding-left: 12px;
   display: flex;
   align-items: center;
@@ -1241,7 +1241,7 @@ button[aria-expanded="true"] .results-arrow{
   place-items: center;
   width: 38px;
   height: 36px;
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--btn);
   border: 1px solid var(--btn);
   cursor: pointer;
@@ -1311,7 +1311,7 @@ button[aria-expanded="true"] .results-arrow{
   place-items: center;
   width: 38px;
   height: 36px;
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--btn);
   border: 1px solid var(--btn);
 }
@@ -1339,7 +1339,7 @@ body.hide-results .results-col{
 
 
 #filterBtn{
-  border-radius:12px;
+  border-radius:8px;
   gap:4px;
 }
 .icon-search{
@@ -1374,7 +1374,7 @@ body.filters-active #filterBtn{
   align-items: flex-start;
   background: var(--list-background);
   border: none;
-  border-radius:16px;
+  border-radius:8px;
   padding:12px;
   margin-bottom:12px;
   cursor:pointer;
@@ -1383,7 +1383,7 @@ body.filters-active #filterBtn{
 .thumb{
   width: 90px;
   height: 70px;
-  border-radius: 12px;
+  border-radius: 8px;
   object-fit: cover;
   display: block;
   background: var(--panel-bg);
@@ -1391,7 +1391,7 @@ body.filters-active #filterBtn{
 }
 
 .thumb.lqip{
-  filter: blur(10px);
+  filter: none;
 }
 
 .meta{
@@ -1441,6 +1441,12 @@ body.filters-active #filterBtn{
   gap: 4px;
 }
 
+.closed-posts .info > div{
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .badge{
   width: 18px;
   height: 18px;
@@ -1455,7 +1461,7 @@ body.filters-active #filterBtn{
 .fav{
   width: 36px;
   height: 36px;
-  border-radius: 12px;
+  border-radius: 8px;
   display: grid;
   place-items: center;
   background: var(--btn);
@@ -1526,7 +1532,7 @@ body.filters-active #filterBtn{
   width:100%;
   margin-bottom:var(--gap);
 }
-.geocoder .mapboxgl-ctrl-geocoder{position:relative;height:var(--control-h);min-width:240px !important;background:var(--control-text-bg) !important;border:1px solid #ccc !important;width:100%;flex:1;border-radius:12px;overflow:visible;font-size:16px;}
+.geocoder .mapboxgl-ctrl-geocoder{position:relative;height:var(--control-h);min-width:240px !important;background:var(--control-text-bg) !important;border:1px solid #ccc !important;width:100%;flex:1;border-radius:8px;overflow:visible;font-size:16px;}
 .geocoder .mapboxgl-ctrl-geocoder--suggestions,
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
 .geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 10px;background:var(--control-text-bg) !important;color:#000;font-family:inherit;font-size:16px;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
@@ -1546,7 +1552,7 @@ body.filters-active #filterBtn{
   padding:0;
   line-height:var(--control-h);
   text-align:center;
-  border-radius:0 12px 12px 0;
+  border-radius:0 8px 8px 0;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -1568,11 +1574,11 @@ body.filters-active #filterBtn{
   width:20px;
   height:20px;
 }
-.geocoder .mapboxgl-ctrl-group{border-radius:12px;overflow:hidden;}
+.geocoder .mapboxgl-ctrl-group{border-radius:8px;overflow:hidden;}
 .mapboxgl-ctrl button{
   line-height:var(--control-h);
   text-align:center;
-  border-radius:12px;
+  border-radius:8px;
   display:inline-flex;
   align-items:center;
   justify-content:center;
@@ -1592,7 +1598,7 @@ body.filters-active #filterBtn{
   align-items:center;
   justify-content:center;
   border:none !important;
-  border-radius:12px;
+  border-radius:8px;
 }
 #map .mapboxgl-ctrl-geolocate{background:var(--control-geolocate-bg) !important;}
 #map .mapboxgl-ctrl-compass{background:var(--control-compass-bg) !important;}
@@ -1623,7 +1629,7 @@ body.filters-active #filterBtn{
 #map .mapboxgl-ctrl-group{
   background:var(--control-text-bg) !important;
   border:1px solid #ccc !important;
-  border-radius:12px;
+  border-radius:8px;
   overflow:hidden;
 }
 .mapboxgl-ctrl-top-left,
@@ -1683,7 +1689,7 @@ body.hide-results .closed-posts{
 
 .open-posts{
   border:none;
-  border-radius:18px;
+  border-radius:8px;
   margin:0 0 12px 0;
   overflow:visible;
   color:#fff;
@@ -2157,7 +2163,7 @@ body.hide-results .closed-posts{
 .open-posts .post-calendar .selected-month-name{
   background:var(--accent);
   color:var(--button-hover-text);
-  border-radius:4px;
+  border-radius:8px;
   padding:0 4px;
 }
 
@@ -2170,7 +2176,7 @@ body.hide-results .closed-posts{
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
   padding:8px;
-  border-radius:4px;
+  border-radius:8px;
   display:flex;
   flex-direction:column;
   gap:4px;
@@ -2181,7 +2187,7 @@ body.hide-results .closed-posts{
   background:var(--btn);
   border:1px solid var(--btn);
   color:var(--button-text);
-  border-radius:4px;
+  border-radius:8px;
   padding:6px 10px;
   cursor:pointer;
 }
@@ -2226,7 +2232,7 @@ body.hide-results .closed-posts{
 .close{
   border: 0;
   background: #16283f;
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 8px 12px;
   cursor: pointer;
 }
@@ -2395,7 +2401,7 @@ footer{
   align-items: center;
   gap: 8px;
   background: var(--btn);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 6px 10px;
   font-size: 12px;
   white-space: nowrap;
@@ -2412,7 +2418,7 @@ footer .foot-row .foot-item{
 .chip-small img.mini{
   width: 26px;
   height: 20px;
-  border-radius: 6px;
+  border-radius: 8px;
   object-fit: cover;
   flex: 0 0 auto;
   display: block;
@@ -2436,7 +2442,7 @@ footer .foot-row .foot-item,
   height: 70px;
   display: block;
   object-fit: cover;
-  border-radius: 12px;
+  border-radius: 8px;
 }
 
 .closed-posts .card .thumb{
@@ -2530,7 +2536,7 @@ footer .foot-row .foot-item,
   gap: 8px;
   align-items: center;
   padding: 4px 6px;
-  border-radius: 10px;
+  border-radius: 8px;
   cursor: pointer;
   min-width: 0;
 }
@@ -2580,7 +2586,7 @@ footer .foot-row .foot-item,
   border: 0;
   background: #16283f;
   color: #fff;
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 6px 10px;
   cursor: pointer;
 }
@@ -2695,7 +2701,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 }
 
 .mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 6px 10px 6px 8px;
 }
 
@@ -2736,7 +2742,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   right: var(--gap);
   background:var(--ad-panel-bg);
   z-index:5;
-  border-radius:16px;
+  border-radius:8px;
   overflow:hidden;
   pointer-events:none;
   padding:8px;
@@ -4171,7 +4177,7 @@ function makePosts(){
       const colors = ['#FFADAD','#FFD6A5','#FDFFB6','#CAFFBF','#9BF6FF','#A0C4FF','#BDB2FF','#FFC6FF'];
       const hash = String(id).split('').reduce((a,c)=>a+c.charCodeAt(0),0);
       const color = colors[hash % colors.length];
-      return `data:image/svg+xml;charset=UTF-8,` + encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='1' height='1'><rect width='1' height='1' fill='${color}'/></svg>`);
+      return `data:image/svg+xml;charset=UTF-8,` + encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><rect width='100' height='100' fill='${color}'/></svg>`);
     }
 
     function hoverHTML(p){
@@ -4594,7 +4600,6 @@ function makePosts(){
           if(map && typeof map.resize === 'function'){
             map.resize();
             updatePostPanel();
-            applyFilters();
           }
           if(window.updateAdVisibility) updateAdVisibility();
         }, 310);


### PR DESCRIPTION
## Summary
- Stop result thumbnails from flickering by keeping images loaded and using crisper SVG placeholders
- Apply a consistent 8px corner radius and ensure buttons keep a minimum width
- Match closed-post info spacing with result cards for a uniform layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b715a859b083319593586afce8c65d