### PR TITLE
Ensure closed post thumbnails load and adjust ad panel styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         --session-available: #92D0F7;
         --session-selected: #009FFF;
         --today: #ff0000;
-        --ad-panel-bg: rgba(0,0,0,0.5);
+        --ad-panel-bg: #000000;
         --image-panel-bg: rgba(0,0,0,0.7);
         --filter-active-color: #ff0000;
       --keyword-bg: #FFFFFF;
@@ -2749,8 +2749,10 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   top: calc(var(--header-h) + var(--safe-top));
   bottom: var(--footer-h);
   width:400px;
-  right: var(--gap);
+  right:0;
+  margin:var(--gap) 0 var(--gap) var(--gap);
   background:var(--ad-panel-bg);
+  box-shadow:0 0 0 var(--gap) var(--ad-panel-bg);
   z-index:5;
   border-radius:8px;
   overflow:hidden;
@@ -5280,7 +5282,7 @@ function makePosts(){
     }
 
     function prioritizeVisibleImages(){
-      const roots = [resultsEl, postsWideEl];
+      const roots = [resultsEl, postsModeEl];
       roots.forEach(root => {
         if(!root) return;
         const imgs = root.querySelectorAll('img.thumb');


### PR DESCRIPTION
## Summary
- Observe closed post list container when lazy-loading thumbnails to ensure images load after long scrolls.
- Add theme-controlled black margin around ad panel and position panel flush with the right edge.
- Set ad panel background color variable to black by default.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b71dddf7888331ba14f017d1e5b1b8