### PR TITLE
Add Eighty theme with admin integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -3129,6 +3129,105 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 .img-popup{background-color:rgba(0,0,0,1);}
 
 </style>
+<style id="theme-eighty" disabled>
+:root{--primary:#000000;--secondary:#000000;--accent:#000000;--btn:rgba(74,74,74,0.9);--panel-bg:rgba(0,0,0,1);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--closed-card-bg:rgba(0,0,0,0.37);--placeholder-text:#000000;--filter-placeholder-text:#000000;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--dropdown-venue-text:#000000;--keyword-bg:rgba(255,255,255,1);--date-range-bg:rgba(255,255,255,1);--date-range-text:#000000;--session-available:#90d9fe;--session-selected:#0c86e4;--today:#ff0000;--control-text-bg:#ffffff;--control-placeholder-text:#858585;--control-geolocate-bg:#ffffff;--control-compass-bg:#ffffff;--control-clear-bg:rgba(0,0,0,0);--border:rgba(173,173,173,0);--border-hover:rgba(173,173,173,0);--border-active:rgba(173,173,173,0);--calendar-width:300px;--calendar-height:200px;--control-placeholder-font:Verdana;--control-placeholder-size:16px;}
+.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}
+.header{background-color:rgba(17,39,75,1);}
+.header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.header button{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.header .gear{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.header a{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.header button{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.header .gear{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.header a{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+body{background-color:rgba(41,41,41,1);}
+.res-list{background-color:rgba(0,0,0,0);}
+.res-list .card{background-color:rgba(0,0,0,0.8);box-shadow:0 0 0px #000000;}
+.res-list{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.res-list .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.res-list button{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.res-list .sq{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.res-list .tiny{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.res-list .btn{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.res-list button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .sq{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .tiny{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.res-list .btn{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.closed-posts{background-color:rgba(0,0,0,0);}
+.closed-posts .card{background-color:rgba(0,0,0,0.8);box-shadow:0 0 0px #000000;}
+.closed-posts .open-posts{background-color:rgba(0,0,0,0.8);box-shadow:0 0 0px #000000;}
+.closed-posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.closed-posts .posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.closed-posts .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts .open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.closed-posts button{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.closed-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts{background-color:rgba(0,0,0,0.8);box-shadow:0 0 0px #000000;}
+.open-posts{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .venue-info{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .session-info{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+.open-posts button{background-color:#11274b;border-color:#11274b;box-shadow:0 0 0px #000000;}
+.open-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .detail-header{background-color:#000000;}
+.open-posts .img-box{background-color:#000000;}
+.open-posts .venue-menu button{background-color:#000000;}
+.open-posts .session-menu button{background-color:#000000;}
+footer{background-color:rgba(0,0,0,0.5);}
+footer .foot-row .foot-item{background-color:rgba(0,0,0,0.32);box-shadow:0 0 0px #000000;}
+footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .hover-card .t{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .hover-card .title{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip .t{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip .title{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small .t{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small .title{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item .t{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item .title{color:#000000;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel .panel-content{background-color:rgba(145,145,145,1);}
+#filterPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel button{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+#filterPanel .sq{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+#filterPanel .tiny{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+#filterPanel .btn{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+#filterPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel .sq{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel .tiny{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#filterPanel .btn{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.calendar{background-color:rgba(255,255,255,1);}
+.calendar .day{color:#b3b3b3;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.calendar .weekday{color:#a3a3a3;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.calendar .calendar-header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.calendar .calendar-header{background-color:#3e5393;}
+#adminPanel .panel-content{background-color:rgba(145,145,145,1);}
+#adminPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminPanel .panel-content .t{color:#ffffff;font-family:Verdana;font-size:20px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+#adminPanel .panel-content .title{color:#ffffff;font-family:Verdana;font-size:20px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
+#adminPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
+#adminPanel #spinType span{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
+#adminPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adminPanel #spinType span{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#welcomePopup .panel-content{background-color:rgba(0,0,0,0.48);}
+#welcomePopup .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#welcomePopup .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#welcomePopup .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#welcomePopup button{background-color:#000000;border-color:#000000;box-shadow:0 0 0px #000000;}
+#welcomePopup button{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberPanel .panel-content{background-color:rgba(145,145,145,1);}
+#memberPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberPanel .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
+#memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+#adPanel{background-color:rgba(0,0,0,0.5);}
+.img-popup{background-color:rgba(0,0,0,0.5);}
+</style>
 </head>
 <body class="mode-map" style="padding-bottom:var(--footer-h);">
   <header class="header" role="banner">
@@ -7604,9 +7703,10 @@ document.addEventListener('pointerdown', handleDocInteract);
 
   function loadPresets(){
     const stored = JSON.parse(localStorage.getItem('themePresets')||'[]');
-    presets = [
+  presets = [
       {name:'Default', css:'theme-default'},
       {name:'Blue', css:'theme-blue'},
+      {name:'Eighty', css:'theme-eighty'},
       ...stored
     ];
     const savedCss = localStorage.getItem('selectedCssTheme');
@@ -7707,7 +7807,22 @@ document.addEventListener('pointerdown', handleDocInteract);
       });
       document.querySelectorAll('.res-list .thumb,.closed-posts .thumb').forEach(el=> el.removeAttribute('style'));
       const styleEl = document.getElementById(p.css);
-      if(styleEl) styleEl.disabled = false;
+      if(styleEl){
+        styleEl.disabled = false;
+        const cs = getComputedStyle(document.documentElement);
+        const theme = {
+          primary: cs.getPropertyValue('--primary').trim(),
+          secondary: cs.getPropertyValue('--secondary').trim(),
+          accent: cs.getPropertyValue('--accent').trim(),
+          background: cs.getPropertyValue('--background').trim(),
+          text: cs.getPropertyValue('--text').trim(),
+          buttonText: cs.getPropertyValue('--button-text').trim(),
+          buttonHoverText: cs.getPropertyValue('--button-hover-text').trim()
+        };
+        updateFields(theme);
+        spreadTheme(theme);
+        storeTitleDefaults();
+      }
     }
     repositionPanels();
   }


### PR DESCRIPTION
## Summary
- embed new `Eighty` theme CSS directly in index.html
- make `Eighty` preset selectable in admin theme picker
- sync admin color fields when applying CSS themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b721976bec8331af9f26ca3169fed0