### PR TITLE
Use image panel variable for popup backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -3125,7 +3125,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.img-popup{background-color:rgba(0,0,0,1);}
+.img-popup{background:var(--image-panel-bg);}
 
 </style>
 <style id="theme-eighty" disabled>
@@ -3224,7 +3224,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.img-popup{background-color:rgba(0,0,0,0.5);}
+.img-popup{background:var(--image-panel-bg);}
 </style>
 </head>
 <body class="mode-map" style="padding-bottom:var(--footer-h);">

--- a/themes/blue 6.css
+++ b/themes/blue 6.css
@@ -111,4 +111,4 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #adPanel{background-color:rgba(0,0,0,0.5);}
-.img-popup{background-color:rgba(0,0,0,1);}
+.img-popup{background:var(--image-panel-bg);}

--- a/themes/blue theme 5.css
+++ b/themes/blue theme 5.css
@@ -110,4 +110,4 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #adPanel{background-color:rgba(0,0,0,0.5);}
-.img-popup{background-color:rgba(0,0,0,1);}
+.img-popup{background:var(--image-panel-bg);}

--- a/themes/eighty.css
+++ b/themes/eighty.css
@@ -94,4 +94,4 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #adPanel{background-color:rgba(0,0,0,0.5);}
-.img-popup{background-color:rgba(0,0,0,0.5);}
+.img-popup{background:var(--image-panel-bg);}


### PR DESCRIPTION
## Summary
- Replace hard-coded `.img-popup` background colors with `background:var(--image-panel-bg);` in index.html
- Align all theme CSS files to rely on the `--image-panel-bg` variable for popup backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7250839148331af269d39ae510c9b