### PR TITLE
fix: restore scrolling for posts and results lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -1371,6 +1371,7 @@ body.filters-active #filterBtn{
 
 .res-list{
   overflow: auto;
+  touch-action: pan-y;
   flex: 1;
   min-height: 0;
   scrollbar-gutter: stable;
@@ -1661,6 +1662,7 @@ body.filters-active #filterBtn{
   right: var(--gap);
   overflow-y:scroll;
   overflow-x:hidden;
+  touch-action: pan-y;
   scrollbar-gutter:stable;
   padding:0;
   color:#000;


### PR DESCRIPTION
## Summary
- Ensure .res-list and .closed-posts containers allow vertical scrolling
- Add touch-action: pan-y to make lists scrollable on touch devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74450c1388331b210a76a4a633ac0