### PR TITLE
Allow default interactive states and fix Mapbox style error

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,14 @@
   html,body{margin:0;height:100%;font-family:Verdana,sans-serif;font-size:14px;overflow:hidden;}
   body{position:relative;}
   header{
-    position:absolute;top:0;left:0;right:0;height:80px;background:#333;color:#fff;display:flex;align-items:center;justify-content:space-between;z-index:10;
+    position:absolute;top:0;left:0;right:0;height:80px;background:#333;display:flex;align-items:center;justify-content:space-between;z-index:10;
   }
   header .group{display:flex;}
   header button{
-    width:80px;height:80px;background:#333;color:#fff;border:none;cursor:pointer;font-size:14px;position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;}
-  header button .icon{width:24px;height:24px;fill:#fff;}
+    width:80px;height:80px;font-size:14px;position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;}
+  header button .icon{width:24px;height:24px;}
   #filter-button .count{font-size:12px;}
-  header img.logo{height:60px;cursor:pointer;}
+  header img.logo{height:60px;}
   .panel{
     position:absolute;top:80px;bottom:80px;background:#fff;overflow:auto;padding:10px;box-sizing:border-box;z-index:5;transition:transform 0.3s;
   }
@@ -35,8 +35,8 @@
   footer{
     position:absolute;left:0;right:0;bottom:0;height:80px;background:rgba(0,0,0,0.5);z-index:10;box-sizing:border-box;}
   footer .cards{overflow-x:auto;white-space:nowrap;height:80px;margin-right:80px;}
-  footer .card{display:inline-block;height:60px;width:200px;background:#222;color:#fff;margin-right:10px;padding:10px;box-sizing:border-box;}
-  footer button#fullscreen-button{position:absolute;right:0;bottom:0;width:80px;height:80px;background:#333;color:#fff;border:none;cursor:pointer;padding:0;display:flex;align-items:center;justify-content:center;}
+  footer .card{display:inline-block;height:60px;width:200px;margin-right:10px;padding:10px;box-sizing:border-box;}
+  footer button#fullscreen-button{position:absolute;right:0;bottom:0;width:80px;height:80px;padding:0;display:flex;align-items:center;justify-content:center;}
   .modal{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;align-items:center;justify-content:center;z-index:20;background:transparent;}
   .modal-content{background:rgba(0,0,0,0.5);color:#fff;width:600px;padding:20px;box-sizing:border-box;text-align:center;}
   .modal-content img{max-width:100%;height:auto;}
@@ -82,7 +82,7 @@
 mapboxgl.accessToken = 'pk.eyJ1IjoienhlbiIsImEiOiJjbWViaDRibXEwM2NrMm1wcDhjODg4em5iIn0.2A9teACgwpiCy33uO4WZJQ';
 const map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://styles/mapbox/standard',
+  style: 'mapbox://styles/mapbox/streets-v12',
   projection: 'globe',
   center: [0, 0],
   zoom: 1


### PR DESCRIPTION
## Summary
- Remove custom styles so buttons, cards, and fullscreen control use browser default hover, focus, and active states
- Switch Mapbox map style to streets-v12 to eliminate console error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c7c96848833199b11865d14bbf76