### PR TITLE
Embed blue theme and remove admin theme controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,2919 +11,660 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <style>:root{
-  --header-h: 75px;
-  --subheader-h: 0;
-  --panel-w: 300px;
-  --results-w: 520px;
-  --gap: 12px;
-    --media-h: 200px;
-    --calendar-scale: 1;
-    --ink: #ffffff;
-    --ink-d: #ececec;
-    --gold: #ffc107;
-    --muted: #777;
-      --primary: #3E5393;
-      --secondary: #000000;
-      --accent: #5C6FB1;
-      --active: #2E3A72;
-      --background: rgba(41,41,41,1);
-      --text: #ffffff;
-      --button-text: #ffffff;
-      --button-hover-text: #000000;
-      --button-active-text: #ffffff;
-      --btn: #3E5393;
-      --btn-hover: #5C6FB1;
-      --btn-active: #2E3A72;
-      --panel-bg: rgba(0,0,0,1);
-      --panel-text: #000000;
-      --footer-h: 70px;
-      --list-background: rgba(0,0,0,0.37);
-      --closed-card-bg: rgba(0,0,0,0.37);
-      --scrollbar-track: rgba(0,0,0,0);
-      --scrollbar-thumb: rgba(0,0,0,0.3);
-      --scrollbar-thumb-hover: rgba(0,0,0,0.5);
-      --scrollbar-h: 8px;
-      --border: rgba(173,173,173,0.31);
-      --border-hover: rgba(255,136,0,0.43);
-      --border-active: rgba(255,200,0,0.45);
-      --placeholder-text: gray;
-      --filter-placeholder-text: var(--placeholder-text);
-      --control-text-bg: #ffffff;
-      --control-placeholder-text: var(--placeholder-text);
-      --control-placeholder-font: Verdana, sans-serif;
-      --control-placeholder-size: 16px;
-      --control-geolocate-bg: #ffffff;
-      --control-compass-bg: #ffffff;
-      --control-clear-bg: rgba(0,0,0,0);
-      --popup-bg: rgba(0,0,0,1);
-      --popup-text: #ffffff;
-      --dropdown-title: #000000;
-      --dropdown-selected-bg: rgba(224,224,224,1);
-      --dropdown-selected-text: #000000;
-      --dropdown-text: #000000;
-      --dropdown-bg: rgba(255,255,255,1);
-      --dropdown-hover-bg: rgba(224,224,224,1);
-      --dropdown-hover-text: #000000;
-        --dropdown-venue-text: #000000;
-        --dropdown-radius: 8px;
-        --calendar-width: 300px;
-        --calendar-height: 250px;
-        --calendar-cell-w: calc(var(--calendar-width) / 7);
-        --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
-        --calendar-header-h: var(--calendar-cell-h);
-        --calendar-past-bg: #f0f0f0;
-        --calendar-future-bg: #ffffff;
-        --session-available: #92D0F7;
-        --session-selected: #009FFF;
-        --today: #ff0000;
-        --ad-panel-bg: rgba(0,0,0,0.5);
-        --image-panel-bg: rgba(0,0,0,0.7);
-        --filter-active-color: #ff0000;
-      --keyword-bg: #FFFFFF;
-      --date-range-bg: rgba(74,74,74,0.9);
-      --date-range-text: rgba(255,255,255,1);
-      --control-h: 35px;
-      --panel-label-font: Verdana;
-      --panel-label-size: 16px;
-      --panel-label-color: #ffffff;
-      --panel-title-font: Verdana;
-      --panel-title-size: 20px;
-      --panel-title-color: #ffffff;
-      --safe-top: env(safe-area-inset-top, 0px);
-}
-
-*{
-  box-sizing: border-box;
-  scrollbar-width: thin;
-  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
-  border-color: var(--border) !important;
-}
-
-fieldset{
-  margin:0;
-  padding:6px 0 0;
-  border:0 !important;
-}
-
-*:hover{
-  border-color: var(--border-hover) !important;
-}
-
-*:active{
-  border-color: var(--border-active) !important;
-}
-
-*[aria-pressed="true"],
-*[aria-current="page"],
-*[aria-selected="true"],
-.selected,
-.on{
-  border-color: var(--border-active) !important;
-  color: var(--active);
-}
-
-html,body{
-  height: 100%;
-}
-
-*::-webkit-scrollbar{
-  width:var(--scrollbar-h);
-  height:var(--scrollbar-h);
-}
-*::-webkit-scrollbar-track{
-  background:var(--scrollbar-track);
-}
-*::-webkit-scrollbar-thumb{
-  background:var(--scrollbar-thumb);
-  border-radius:8px;
-}
-*::-webkit-scrollbar-thumb:hover{
-  background:var(--scrollbar-thumb-hover);
-}
-
-  body{
-    margin: 0 auto;
-    max-width: 1920px;
-    font-family: Verdana,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans","Liberation Sans",sans-serif;
-    background: var(--background);
-    color: var(--text);
-    overflow: hidden;
-    cursor: default;
-    caret-color: transparent;
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-    user-select: none;
-    touch-action: manipulation;
-  }
-
-input,
-textarea,
-.wysiwyg{
-  caret-color: auto;
-  user-select: text;
-}
-
-button:not([class^="mapboxgl-ctrl"]),
-[role="button"]{
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  color: var(--button-text);
-  padding: 0 10px;
-  height: var(--control-h);
-  min-width: 35px;
-  border-radius: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  cursor: pointer;
-  transition: background .2s,border-color .2s,color .2s,transform .05s;
-}
-
-button:hover,
-[role="button"]:hover{
-  background: var(--btn-hover);
-  border-color: var(--btn-hover);
-  color: var(--button-hover-text);
-}
-
-button:active,
-[role="button"]:active,
-button[aria-pressed="true"],
-[role="button"][aria-pressed="true"],
-button[aria-current="page"],
-[role="button"][aria-current="page"],
-button[aria-selected="true"],
-[role="button"][aria-selected="true"],
-button.selected,
-[role="button"].selected,
-button.on,
-[role="button"].on{
-  background: var(--btn-active);
-  border-color: var(--btn-active);
-  color: var(--button-active-text);
-}
-
-.mapboxgl-ctrl-attrib-button,
-.mapboxgl-ctrl-attrib-button:hover,
-.mapboxgl-ctrl-attrib-button:active{
-  all: revert !important;
-}
-
-a{
-  color: var(--primary);
-}
-
-a:hover{
-  color: var(--accent);
-}
-
-a:active{
-  color: var(--active);
-}
-button:active,
-[role="button"]:active{
-  transform: scale(0.97);
-}
-button:focus-visible,
-[role="button"]:focus-visible{
-  outline:2px solid var(--ink-d);
-  outline-offset:2px;
-}
-
-input::placeholder,
-textarea::placeholder{
-  color: var(--placeholder-text);
-  font-size: inherit;
-}
-#filterPanel #kwInput::placeholder{
-  color: var(--filter-placeholder-text);
-  font-size: inherit;
-}
-#filterPanel #dateInput::placeholder{
-  color: var(--filter-placeholder-text);
-  font-size: inherit;
-}
-
-.field label{
-  color: var(--panel-label-color);
-  font-family: var(--panel-label-font);
-  font-size: var(--panel-label-size);
-}
-
-.panel-content .title,
-.panel-content .t{
-  color: var(--panel-title-color);
-  font-family: var(--panel-title-font);
-  font-size: var(--panel-title-size);
-}
-
-select{
-  background: var(--dropdown-bg);
-  color: var(--dropdown-text);
-  border-radius: var(--dropdown-radius);
-}
-.venue-select{
-  color: var(--dropdown-venue-text);
-}
-select option{
-  background: var(--dropdown-bg);
-  color: var(--dropdown-text);
-}
-select option:checked{
-  background: var(--dropdown-selected-bg);
-  color: var(--dropdown-selected-text);
-}
-select option:hover{
-  background: var(--dropdown-hover-bg);
-  color: var(--dropdown-hover-text);
-}
-
-input[type="text"],
-input[type="email"],
-input[type="password"],
-input[type="search"],
-input[type="tel"],
-input[type="url"],
-textarea,
-select{
-  height: var(--control-h);
-  border-radius: 8px;
-}
-input[type="checkbox"]{
-  width: var(--control-h);
-  height: var(--control-h);
-  border-radius: 8px;
-}
-
-  .header{
-    height: calc(var(--header-h) + var(--safe-top));
-    min-height: calc(var(--header-h) + var(--safe-top));
-    max-height: calc(var(--header-h) + var(--safe-top));
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    padding: var(--safe-top) 20px 0 20px;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 20;
-  }
-
-  .logo{
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    font-weight: 800;
-    letter-spacing: .4px;
-    user-select: none;
-    cursor: pointer;
-  }
-
-.logo img{
-  height: 48px;
-  display: block;
-}
-
-  .view-toggle{
-  position: absolute;
-  left: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  height: 35px;
-  gap: 8px;
-  }
-
-.view-toggle button{
-  border: 1px solid var(--btn);
-  border-radius: 8px;
-  padding: 0 14px;
-  background: var(--btn);
-  color: var(--button-text);
-  font-weight: 600;
-  cursor: pointer;
-  transition: background .2s,border-color .2s,color .2s;
-}
-
-
-.header button,
-.view-toggle button,
-.auth button,
-.options-menu button{
-  height:35px;
-  border-radius:8px;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:6px;
-  line-height:1;
-}
-.header .gear,
-.header a{
-  border-radius:8px;
-}
-
-
-.results-arrow,
-.dropdown-arrow{
-  display:inline-block;
-  width:8px;
-  height:8px;
-  border-style:solid;
-  border-width:0 2px 2px 0;
-  border-color:currentColor !important;
-  color:inherit;
-  transition:transform .3s;
-}
-
-.results-arrow{
-  margin-right:8px;
-  transform:rotate(45deg);
-  transition:transform .3s;
-  vertical-align:middle;
-}
-body.hide-results #resultsToggle .results-arrow{transform:rotate(-135deg);}
-
-.options-dropdown > button{
-  position:relative;
-  padding-right:30px;
-}
-
-.options-dropdown .dropdown-arrow,
-.options-dropdown .results-arrow{
-  position:absolute;
-  top:50%;
-  right:10px;
-  transform:translateY(-50%) rotate(45deg);
-  margin-right:0;
-}
-
-button[aria-expanded="true"] .dropdown-arrow,
-button[aria-expanded="true"] .results-arrow{
-  transform:translateY(-50%) rotate(-135deg);
-}
-
-
-#smallLogo{
-  display:none;
-  height:48px;
-}
-
-
-
-/* Spin controls */
-.range-wrap{
-  display:flex;
-  align-items:center;
-  gap:8px;
-}
-#spinSpeedVal{
-  min-width:40px;
-  text-align:right;
-}
-  #spinType{
-    display:flex;
-    gap:6px;
-    margin-top:6px;
-  }
-  #spinType label{
-    flex:1;
-    border-radius:8px;
-    overflow:hidden;
-  }
-  #spinType input{
-    display:none;
-  }
-  #spinType span{
-    display:block;
-    padding:0 10px;
-    height:35px;
-    line-height:35px;
-    background:var(--btn);
-    color:var(--button-text);
-    font-weight:600;
-    cursor:pointer;
-    text-align:center;
-    transition:background .2s,border-color .2s,color .2s;
-    border:1px solid var(--btn);
-    border-radius:8px;
-  }
-
-.auth{
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.auth button{
-  border: 1px solid rgba(255,255,255,.6);
-  border-radius: 999px;
-  padding: 0 14px;
-  background: rgba(255,255,255,0.2);
-  color: inherit;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background .2s;
-}
-
-.gear{
-  width: 36px;
-  height: 36px;
-  border-radius: 8px;
-  background: rgba(255,255,255,0.2);
-  display: grid;
-  place-items: center;
-  border:1px solid rgba(255,255,255,0.4);
-  color: #fff;
-}
-
-.gear svg{
-  width: 18px;
-  height: 18px;
-  opacity: .9;
-}
-
-.panel{
-  position:fixed;
-  top:0;
-  left:0;
-  width:100vw;
-  height:100vh;
-  background:transparent;
-  display:none;
-  z-index:2000;
-  pointer-events:none;
-}
-.panel.show{
-  display:block;
-}
-.panel-content{
-  position:absolute;
-  border-radius:8px;
-  width:90%;
-  max-width:600px;
-  max-height:90%;
-  display:flex;
-  flex-direction:column;
-  overflow:hidden;
-  pointer-events:auto;
-}
-.panel-content .resizer{position:absolute;z-index:10;background:transparent;}
-.panel-content .resizer.n{top:0;left:0;right:0;height:6px;cursor:n-resize;}
-.panel-content .resizer.s{bottom:0;left:0;right:0;height:6px;cursor:s-resize;}
-.panel-content .resizer.e{top:0;right:0;bottom:0;width:6px;cursor:e-resize;}
-.panel-content .resizer.w{top:0;left:0;bottom:0;width:6px;cursor:w-resize;}
-.panel-content .resizer.ne{top:0;right:0;width:10px;height:10px;cursor:ne-resize;}
-.panel-content .resizer.nw{top:0;left:0;width:10px;height:10px;cursor:nw-resize;}
-.panel-content .resizer.se{bottom:0;right:0;width:10px;height:10px;cursor:se-resize;}
-.panel-content .resizer.sw{bottom:0;left:0;width:10px;height:10px;cursor:sw-resize;}
-.panel-body{
-  flex:1 1 auto;
-  overflow-y:auto;
-  overflow-x:hidden;
-  padding:0 20px 20px;
-  overscroll-behavior:contain;
-}
-#adminPanel #styleControls{
-  display:flex;
-  flex-direction:column;
-  align-items:flex-start;
-  gap:12px;
-}
-#adminPanel #styleControls > *{
-  width:300px;
-}
-.admin-fieldset{
-  margin:0;
-  border:0;
-  border-radius:8px;
-  padding:0;
-  width:300px;
-  box-sizing:border-box;
-}
-#adminPanel .admin-fieldset{
-  width:300px;
-}
-#adminPanel .admin-fieldset.collapsed{
-  padding:0;
-}
-  #adminPanel .panel-content,
-  #memberPanel .panel-content{
-    width:600px;
-    max-width:90%;
-    max-height:90%;
-  }
-
-  #memberPanel .panel-content{
-    background:rgba(0,0,0,0.7);
-    color:#fff;
-  }
-#filterPanel .panel-content{
-  width:350px;
-  max-width:600px;
-  max-height:90%;
-  background:rgba(0,0,0,0.7);
-  color:#fff;
-}
-
-#filterPanel button,
-#filterPanel .sq,
-#filterPanel .tiny,
-#filterPanel .btn,
-#adminPanel button,
-#memberPanel button{
-  background: var(--btn);
-  color: var(--ink);
-  border: none;
-}
-#adminPanel button{
-  height:35px;
-  line-height:35px;
-}
-#adminPanel input[type="color"]{
-  width:35px;
-  height:35px;
-}
-#filterPanel input[type="text"]{
-  background: var(--panel-bg);
-  color: var(--panel-text);
-}
-#filterPanel .calendar-container{
-  background: var(--dropdown-bg);
-  position:relative;
-  overflow-x:auto;
-  overflow-y:hidden;
-  padding-bottom:0;
-  box-sizing:content-box;
-  width:calc(var(--calendar-width) * var(--calendar-scale));
-  height:calc(var(--calendar-height) * var(--calendar-scale));
-  border:1px solid var(--border);
-  border-radius:8px;
-}
-#filterPanel .calendar-container .today-marker{
-  position:absolute;
-  bottom:0;
-  width:8px;
-  height:8px;
-  border-radius:50%;
-  background:var(--today);
-  cursor:pointer;
-  transform:translateX(-50%);
-}
-#filterPanel #datePicker{
-  width:max-content;
-}
-#filterPanel .calendar{
-  display:flex;
-  width:max-content;
-  transform:scale(var(--calendar-scale));
-  transform-origin:top left;
-  background:var(--dropdown-bg);
-  color:var(--dropdown-text);
-}
-.calendar .month{
-  flex:0 0 auto;
-  width:var(--calendar-width);
-  height:var(--calendar-height);
-  display:flex;
-  flex-direction:column;
-}
-.calendar .month:not(:first-child){
-  border-left:1px solid var(--calendar-past-bg);
-}
-.calendar .grid{
-  flex:1 1 auto;
-  width:100%;
-  height:calc(var(--calendar-height) - var(--calendar-header-h) - var(--scrollbar-h));
-  display:grid;
-  grid-template-columns:repeat(7,var(--calendar-cell-w));
-  grid-template-rows:repeat(7,var(--calendar-cell-h));
-}
-.calendar .calendar-header{
-  height:var(--calendar-header-h);
-  line-height:var(--calendar-header-h);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  text-align:center;
-  font-family:inherit;
-  font-size:inherit;
-  color:inherit;
-}
-.calendar .weekday,
-.calendar .day{
-  width:var(--calendar-cell-w);
-  height:var(--calendar-cell-h);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  line-height:var(--calendar-cell-h);
-  font-family:inherit;
-  font-size:inherit;
-}
-.calendar .weekday{font-weight:bold;}
-.calendar .day{cursor:pointer;}
-.calendar .day.empty{cursor:default;background:var(--calendar-future-bg);}
-.calendar .day.past{background:var(--calendar-past-bg);color:#b3b3b3;}
-.calendar .day.future{background:var(--calendar-future-bg);}
-.calendar .day.today{color:var(--today) !important;font-weight:bold;}
-.calendar .day.in-range{background:var(--session-available);border-radius:0;}
-.calendar .day.selected{background:var(--session-selected);color:#fff;}
-.calendar .day.selected.today{color:var(--today) !important;}
-.calendar .day.range-start{border-radius:8px 0 0 8px;}
-.calendar .day.range-end{border-radius:0 8px 8px 0;}
-.calendar .day.range-start.range-end{border-radius:8px;}
-#memberPanel #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
-#memberPanel input[type=color]{
-  border-radius:8px;
-  padding:0;
-  height:40px;
-  display:block;
-}
-#welcomeBody{
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-}
-#welcomeBody img{
-  max-width:400px;
-  width:100%;
-  max-height:300px;
-  height:auto;
-  margin-bottom:10px;
-}
-#welcomePopup .panel-content{
-  top:200px;
-  left:50%;
-  transform:translateX(-50%);
-}
-#memberPanel .location-info{margin-top:4px;font-size:13px;}
-  @media (max-width:600px){
-  #adminPanel .panel-content,
-  #memberPanel .panel-content,
-  #filterPanel .panel-content{
-    width:95%;
-    max-width:95%;
-    max-height:95%;
-  }
-}
-#adminPanel legend{font-weight:600;padding:0 6px;display:flex;align-items:center;gap:6px;justify-content:space-between;cursor:pointer;user-select:none;width:300px;height:35px;background:var(--btn);border:1px solid var(--btn);border-radius:var(--dropdown-radius);box-sizing:border-box;}
-#adminPanel legend::after{content:'\25BC';margin-left:auto;font-size:12px;}
-#adminPanel fieldset.collapsed legend::after{content:'\25B6';}
-#adminPanel fieldset.collapsed > :not(legend){display:none;}
-#adminPanel .fieldset-actions{display:flex;gap:4px;margin:4px 6px;}
-#adminPanel .fieldset-actions .same-btn{flex:1 1 0;padding:6px;}
-#adminPanel .control-row{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:6px;padding:8px 0;max-width:300px;width:100%;}
-#adminPanel .control-row label:first-child{min-width:80px;font-size:12px;cursor:pointer;user-select:none;}
-.control-row > *:last-child{margin-left:auto;width:200px;}
-#adminPanel .color-group{
-  flex:0 0 200px;
-  width:100%;
-  max-width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:stretch;
-  position:relative;
-}
-#autoTheme-row{
-  flex-direction:row;
-  align-items:center;
-  gap:8px;
-  margin-left:0;
-  width:300px;
-  max-width:300px;
-}
-#autoTheme-row button{
-  flex:0 0 auto;
-  height:35px;
-  padding:0 8px;
-  min-width:0;
-}
-#autoTheme-row input[type=color]{
-  flex:0 0 35px;
-  width:35px;
-  height:35px;
-  padding:0;
-}
-#adminPanel .shadow-group{
-  flex:0 0 200px;
-  width:100%;
-  max-width:200px;
-  display:flex;
-  gap:4px;
-  align-items:center;
-}
-#adminPanel .shadow-group input[type=color]{
-  width:40px;
-  height:40px;
-  padding:0;
-  border-radius:8px;
-}
-#adminPanel .shadow-group input[type=number]{
-  flex:1 1 0;
-}
-#adminPanel .textpicker{
-  flex:0 0 200px;
-  width:200px;
-  position:relative;
-}
-#adminPanel .textpicker .text-preview{
-  width:100%;
-  height:35px;
-  border-radius:8px;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  cursor:pointer;
-}
-#adminPanel .textpicker .text-popup{
-  display:none;
-  position:absolute;
-  top:44px;
-  left:0;
-  z-index:20;
-  background:#fff;
-  border:1px solid #ccc;
-  border-radius:8px;
-  padding:8px;
-  width:200px;
-}
-#adminPanel .textpicker.open .text-popup{display:block;}
-#adminPanel .textpicker .text-popup select,
-#adminPanel .textpicker .text-popup input[type=color]{
-  width:100%;
-  margin-top:4px;
-  border-radius:var(--dropdown-radius);
-  padding:4px;
-  box-sizing:border-box;
-  height:35px;
-}
-#adminPanel .textpicker .text-popup input[type=color]{padding:0;}
-#adminPanel .textpicker .text-popup .shadow-group{
-  display:grid;
-  grid-template-columns:repeat(4,1fr);
-  gap:4px;
-  margin-top:4px;
-}
-#adminPanel .textpicker .text-popup .shadow-group input[type=color],
-#adminPanel .textpicker .text-popup .shadow-group input[type=number]{
-  width:100%;
-  height:40px;
-  border-radius:var(--dropdown-radius);
-  padding:0;
-  box-sizing:border-box;
-}
-.autotheme-row{
-  width:300px;
-  height:35px;
-  display:flex;
-  align-items:center;
-  gap:4px;
-}
-.autotheme-row button,
-.autotheme-row input[type=color]{
-  width:35px;
-  height:35px;
-  padding:0;
-}
-#adminPanel .admin-fieldset input,
-#adminPanel .admin-fieldset select,
-#adminPanel .admin-fieldset textarea{
-  max-width:200px;
-  box-sizing:border-box;
-}
-#adminPanel .control-row select{
-  flex:0 0 200px;
-  width:200px;
-  max-width:200px;
-  margin-left:auto;
-  border-radius:var(--dropdown-radius);
-  padding:4px;
-}
-#adminPanel .color-group input[type=color],
-#adminPanel .color-group input[type=range]{
-  width:100%;
-}
-#adminPanel .color-group input[type=color]{
-  border-radius:8px;
-  padding:0;
-  height:35px;
-  display:block;
-  cursor:pointer;
-  pointer-events:auto;
-}
-#adminPanel .range-group{
-  display:flex;
-  align-items:center;
-  gap:4px;
-}
-#adminPanel .range-group input[type=range]{
-  flex:1;
-  width:auto;
-}
-#adminPanel .range-group span{
-  min-width:32px;
-  text-align:right;
-  font-size:12px;
-}
-#adminPanel .tab-bar{display:flex;gap:6px;}
-#adminPanel .tab-bar button{
-  flex:1;
-  padding:6px 10px;
-  border-radius:8px;
-  background:var(--btn);
-  border:1px solid var(--btn);
-  color:var(--button-text);
-  cursor:pointer;
-}
-#adminPanel .tab-panel{display:none;}
-#adminPanel .tab-panel.active{display:flex;flex-direction:column;align-items:flex-start;gap:12px;}
-#adminPanel .marker-grid{display:flex;flex-direction:column;gap:8px;}
-#adminPanel .marker-grid select{min-width:120px;}
-#adminPanel .marker-options{display:flex;gap:8px;align-items:center;}
-#adminPanel .marker-set{display:grid;grid-template-columns:repeat(10,max-content);gap:4px;}
-#adminPanel .marker-set svg.shadow{filter:drop-shadow(2px 2px 2px rgba(0,0,0,0.5));}
-#adminPanel .marker-set svg.outline *{stroke:#000;stroke-width:1;}
-#adminPanel input[type=range]{width:100%;}
-#adminPanel .preset-actions{display:flex;gap:6px;margin:0;}
-#adminPanel .preset-actions input{flex:1;padding:6px;border-radius:8px;}
-#adminPanel .preset-actions button{padding:6px 10px;}
-.panel-field{
-  margin:8px 0;
-  display:flex;
-  flex-direction:column;
-  gap:8px;
-  max-width:300px;
-  width:100%;
-}
-#adminPanel .panel-field{margin:0;}
-#adminPanel h3{margin:0;}
-.admin-section{display:flex;flex-direction:column;gap:var(--gap);}
-#balloonTool .panel-field,
-#tab-forms .panel-field{max-width:none;}
-.history-group,
-.color-group{display:flex;align-items:center;gap:8px;}
-.preset-select{
-  display:flex;
-  align-items:center;
-  gap:6px;
-}
-.option-label{
-  display:flex;
-  align-items:center;
-  gap:8px;
-}
-.option-group{
-  display:flex;
-  gap:10px;
-}
-.wysiwyg{
-  border:1px solid #ccc;
-  min-height:80px;
-  padding:8px;
-}
-.wysiwyg:empty:before{
-  content:attr(data-placeholder);
-  color:#999;
-}
-.wysiwyg-toolbar{
-  display:flex;
-  gap:4px;
-}
-.wysiwyg-toolbar button{
-  padding:4px 6px;
-}
-.panel-field input,
-.panel-field textarea,
-.panel-field select{
-  padding:8px;
-  border-radius:var(--dropdown-radius);
-  border:none;
-  width:100%;
-  max-width:100%;
-}
-.panel-actions{
-  margin-top:10px;
-  display:flex;
-  gap:10px;
-}
-.panel-header{
-  position:sticky;
-  top:0;
-  padding:10px 20px;
-  border-top-left-radius:8px;
-  border-top-right-radius:8px;
-  z-index:1;
-  cursor:move;
-  display:flex;
-  flex-direction:column;
-  gap:10px;
-  flex-shrink:0;
-}
-.panel-header .header-top{
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-}
-.panel-header .panel-actions{
-  margin-top:0;
-}
-.panel-header h2{
-  margin:0;
-}
-.palette{
-  display:flex;
-  gap:10px;
-  margin-bottom:10px;
-}
-.field-item,
-.field-instance{
-  padding:6px 10px;
-  border:1px solid #ccc;
-  border-radius:8px;
-  background:#f9f9f9;
-  cursor:move;
-}
-.builder-zone{
-  min-height:100px;
-  border:2px dashed #ccc;
-  padding:10px;
-}
-.field-instance{margin:4px 0;}
-
-
-.filters-col{
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.left-tools{
-  display: flex;
-  gap: 8px;
-  margin-bottom: 8px;
-  padding-left: 2px;
-}
-
-.sq{
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
-  background: var(--btn);
-  display: grid;
-  place-items: center;
-  border: 1px solid var(--btn);
-}
-
-.sq svg{
-  width: 14px;
-  height: 14px;
-  opacity: .9;
-}
-
-
-.field{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:8px;
-  padding:8px 0;
-  margin:0;
-}
-
-.field > *:last-child{
-  margin-left:auto;
-}
-
-.field .input{
-  position: relative;
-  display:flex;
-  align-items:center;
-  gap:6px;
-  flex:1;
-}
-
-.field .options-dropdown{
-  flex:1;
-}
-
-.field .options-dropdown > button{
-  width:100%;
-}
-
-.input input,
-.input select{
-  flex: 1;
-  width: 100%;
-  height: 35px;
-  line-height: 35px;
-  border: none;
-  padding: 0 12px;
-  outline: 0;
-  display: flex;
-  align-items: center;
-}
-.input input{
-  border-radius: 8px;
-  background: var(--btn);
-  color: var(--ink);
-}
-.input select{
-  border-radius: var(--dropdown-radius);
-}
-#filterPanel #kwInput{
-  background: var(--keyword-bg);
-}
-#filterPanel #dateInput{
-  background: var(--date-range-bg);
-  color: var(--date-range-text);
-}
-
-.input .down{
-  position: static;
-  width: 35px;
-  height: 35px;
-  border-radius: 8px;
-  background: var(--btn);
-  cursor: pointer;
-  border: 1px solid var(--btn);
-  line-height:35px;
-  text-align:center;
-}
-.input .down svg{
-  vertical-align:middle;
-}
-#filterPanel .input .x{
-  position: static;
-  width: 35px;
-  height: 35px;
-  border-radius: 8px;
-  background: var(--dropdown-bg);
-  cursor: pointer;
-  border: 0;
-  margin-left: 6px;
-  line-height: 35px;
-  text-align: center;
-  color: var(--dropdown-text);
-  opacity:1;
-}
-#filterPanel .input .x.active{
-  background: var(--filter-active-color);
-  color: var(--button-text);
-  opacity:1;
-}
-
-#filterPanel .field label.t{
-  grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.expired-field{
-  grid-template-columns:1fr auto;
-  align-items:center;
-  gap:8px;
-}
-.expired-text{
-  font-family: Verdana;
-  color:#fff;
-  font-size:16px;
-}
-.filter-summary{
-  margin-bottom:8px;
-}
-.switch{
-  position:relative;
-  display:inline-block;
-  width:48px;
-  height:24px;
-  flex:0 0 48px;
-}
-.switch input{
-  opacity:0;
-  width:0;
-  height:0;
-}
-.switch .slider{
-  position:absolute;
-  cursor:pointer;
-  top:0;
-  left:0;
-  right:0;
-  bottom:0;
-  background:var(--btn);
-  border-radius:24px;
-  transition:.2s;
-}
-.switch .slider:before{
-  position:absolute;
-  content:'';
-  height:20px;
-  width:20px;
-  left:2px;
-  top:2px;
-  background:var(--button-text);
-  border-radius:50%;
-  transition:.2s;
-}
-.switch input:checked + .slider{
-  background:var(--session-selected);
-}
-#expiredToggle:checked + .slider{
-  background:var(--filter-active-color);
-}
-.switch input:checked + .slider:before{
-  transform:translateX(24px);
-}
-
-.tiny{
-  display: grid;
-  place-items: center;
-  width: 38px;
-  height: 40px;
-  border-radius: 8px;
-  background: var(--btn);
-  cursor: pointer;
-  border: 1px solid var(--btn);
-}
-
-.tiny svg{
-  width: 18px;
-  height: 18px;
-}
-
-
-.cats{
-  margin:8px 0;
-}
-
-.cat{
-  display: grid;
-  grid-template-columns: 1fr 38px;
-  gap: 8px;
-  align-items: center;
-  margin: 8px 0;
-}
-
-.cat .bar{
-  height: 36px;
-  border-radius: 8px;
-  padding-left: 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  cursor: pointer;
-}
-
-.cat .bar .dot{
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-}
-
-.cat .bar .label{
-  font-weight: 700;
-  letter-spacing: .2px;
-}
-
-.cat .cfg{
-  display: grid;
-  place-items: center;
-  width: 38px;
-  height: 36px;
-  border-radius: 8px;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  cursor: pointer;
-}
-
-.sub{
-  margin: 6px 0 0 6px;
-  display: none;
-  grid-template-columns: 1fr;
-  gap: 6px;
-}
-
-.sub .chip{
-  height: 28px;
-  display: inline-block;
-  padding: 0 10px;
-  border-radius: 999px;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  font-size: 12px;
-  color: var(--ink-d);
-  width: max-content;
-  cursor: pointer;
-  line-height: 28px;
-}
-.sub .chip .badge{
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 8px;
-}
-
-
-.cat[aria-expanded="true"] .sub{
-  display: grid;
-}
-
-.reset-box{
-  display: grid;
-  grid-template-columns: 1fr 38px;
-  gap: 8px;
-  align-items: center;
-  margin:8px 0;
-}
-
-.reset-box .btn{
-  height: 36px;
-  border-radius: 999px;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 0 14px;
-  font-weight: 700;
-  letter-spacing: .2px;
-  color: var(--ink);
-  cursor: pointer;
-}
-.reset-box .btn.active{
-  background: var(--filter-active-color);
-  border-color: var(--filter-active-color);
-}
-
-.reset-box .btn svg{
-  width: 16px;
-  height: 16px;
-}
-
-.reset-box .arr{
-  display: grid;
-  place-items: center;
-  width: 38px;
-  height: 36px;
-  border-radius: 8px;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-}
-
-.results-col{
-  position: fixed;
-  top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top) + var(--gap) - 12px);
-  bottom: var(--footer-h);
-  left: var(--gap);
-  width: var(--results-w);
-  display: flex;
-  flex-direction: column;
-  padding: 0;
-  transition: width .3s ease, padding .3s ease;
-  z-index: 2;
-  pointer-events: auto;
-}
-
-body.hide-results .results-col{
-  width: 0;
-  padding: 0;
-  overflow: hidden;
-  pointer-events: none;
-}
-
-
-#filterBtn{
-  border-radius:8px;
-  gap:4px;
-}
-.icon-search{
-  display:inline-block;
-  vertical-align:middle;
-  color: currentColor;
-  width:20px; height:20px;
-}
-body.filters-active #filterBtn{
-  background: red;
-  border-color: red;
-  box-shadow: none;
-}
-
-.options-dropdown{ position:relative; }
-.options-menu{ position:absolute; top:calc(100% + 4px); left:0; background:var(--dropdown-bg); color:var(--dropdown-text); border:1px solid var(--border); border-radius:var(--dropdown-radius); padding:10px; display:flex; flex-direction:column; gap:6px; box-shadow:0 2px 6px rgba(0,0,0,0.2); z-index:30; }
-.options-menu[hidden]{ display:none; }
-.options-menu label{ display:flex; align-items:center; gap:6px; white-space:nowrap; }
-
-.res-list{
-  overflow: auto;
-  flex: 1;
-  min-height: 0;
-  scrollbar-gutter: stable;
-  height: calc(100vh - var(--header-h) - var(--subheader-h) - var(--footer-h) - var(--safe-top));
-}
-
-.card{
-  display: grid;
-  grid-template-columns:90px 1fr 36px;
-  gap:12px;
-  align-items: flex-start;
-  background: var(--list-background);
-  border: none;
-  border-radius:8px;
-  padding:12px;
-  margin-bottom:12px;
-  cursor:pointer;
-}
-
-.thumb{
-  width: 90px;
-  height: 70px;
-  border-radius: 8px;
-  object-fit: cover;
-  display: block;
-  background: var(--panel-bg);
-  transition: filter .22s ease;
-}
-
-.thumb.lqip{
-  filter: none;
-}
-
-.meta{
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.title{
-  margin: 0;
-  font-weight: 900;
-  line-height: 1.2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.info{
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  font-size: 13px;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.res-list .info{
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-}
-
-.closed-posts .info{
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-}
-
-.res-list .info > div{
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.closed-posts .info > div{
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.badge{
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  display: inline-grid;
-  place-items: center;
-  background: #0e2540;
-  border: 1px solid rgba(255,255,255,.1);
-  font-size: 11px;
-}
-
-.fav{
-  width: 36px;
-  height: 36px;
-  border-radius: 8px;
-  display: grid;
-  place-items: center;
-  background: var(--btn);
-  border: 1px solid var(--btn);
-}
-
-.fav svg{
-  width: 18px;
-  height: 18px;
-  fill: none;
-  stroke: var(--gold);
-  stroke-width: 1.5;
-}
-
-.fav[aria-pressed="true"] svg{
-  fill: var(--gold);
-  stroke: var(--gold);
-}
-
-#favToggle{
-  white-space:nowrap;
-}
-#favToggle svg{
-  width:18px;
-  height:18px;
-  fill:none;
-  stroke:var(--gold);
-  stroke-width:1.5;
-  vertical-align:middle;
-  margin-left:6px;
-}
-#favToggle[aria-pressed="true"] svg{
-  fill:var(--gold);
-  stroke:var(--gold);
-}
-
-
-
-#map{
-  position: absolute;
-  inset: 0;
-}
-
-.map-overlay{
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  display: grid;
-  place-items: center;
-  color: #fff;
-  font-weight: 700;
-  letter-spacing: .5px;
-  opacity: .15;
-  pointer-events: none;
-}
-
-.geocoder{
-  position:static;
-  transform:none;
-  z-index:10;
-  min-width:240px;
-  pointer-events:auto;
-  display:flex;
-  align-items:center;
-  gap:6px;
-  width:100%;
-  margin-bottom:var(--gap);
-}
-.geocoder .mapboxgl-ctrl-geocoder{position:relative;height:var(--control-h);min-width:240px !important;background:var(--control-text-bg) !important;border:1px solid #ccc !important;width:100%;flex:1;border-radius:8px;overflow:visible;font-size:16px;}
-.geocoder .mapboxgl-ctrl-geocoder--suggestions,
-.geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
-.geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 10px;background:var(--control-text-bg) !important;color:#000;font-family:inherit;font-size:16px;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
-.geocoder .mapboxgl-ctrl-geocoder input::placeholder{font-family:var(--control-placeholder-font) !important;font-size:var(--control-placeholder-size) !important;color:var(--control-placeholder-text);}
-.geocoder .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
-  position:absolute;
-  right:0;
-  top:0;
-  bottom:0;
-  margin:auto;
-  width:var(--control-h);
-  height:var(--control-h);
-  background:var(--control-clear-bg) !important;
-  border:0;
-  border-left:1px solid #ccc;
-  color:#000;
-  padding:0;
-  line-height:var(--control-h);
-  text-align:center;
-  border-radius:0 8px 8px 0;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  opacity:1;
-}
-.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg{opacity:1;fill:#000;}
-.geocoder .mapboxgl-ctrl-geocoder--icon,
-.geocoder .mapboxgl-ctrl-geocoder--icon-search{display:none !important;}
-
-.geocoder .mapboxgl-ctrl-group button + button{border-left:1px solid #ccc;}
-.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
-.mapboxgl-ctrl button svg,
-.mapboxgl-ctrl button span{
-  display:block;
-  margin:0;
-}
-.mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
-.mapboxgl-ctrl button svg{
-  width:20px;
-  height:20px;
-}
-.geocoder .mapboxgl-ctrl-group{border-radius:8px;overflow:hidden;}
-.mapboxgl-ctrl button{
-  line-height:var(--control-h);
-  text-align:center;
-  border-radius:8px;
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  flex:none;
-  width:var(--control-h);
-  height:var(--control-h);
-  margin:0;
-  padding:0 !important;
-}
-.mapboxgl-ctrl-group{overflow:hidden;}
-.mapboxgl-ctrl-geolocate,
-.mapboxgl-ctrl-compass{
-  width:var(--control-h);
-  height:var(--control-h);
-  overflow:hidden;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  border:none !important;
-  border-radius:8px;
-}
-#map .mapboxgl-ctrl-geolocate{background:var(--control-geolocate-bg) !important;}
-#map .mapboxgl-ctrl-compass{background:var(--control-compass-bg) !important;}
-.mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon,
-.mapboxgl-ctrl-compass .mapboxgl-ctrl-icon,
-.mapboxgl-ctrl-compass .mapboxgl-ctrl-compass-arrow{
-  margin:0;
-  width:20px;
-  height:20px;
-}
-#map .mapboxgl-ctrl button{
-  width:var(--control-h);
-  height:var(--control-h);
-  border:0 !important;
-  color:#000;
-  padding:0 !important;
-  box-shadow:none;
-}
-#map .mapboxgl-ctrl button:not(.mapboxgl-ctrl-geolocate):not(.mapboxgl-ctrl-compass){
-  background:var(--control-text-bg) !important;
-}
-#map .mapboxgl-ctrl button svg{
-  width:20px;
-  height:20px;
-}
-#map .mapboxgl-ctrl button:hover{filter:brightness(1.1);}
-#map .mapboxgl-ctrl button:active{filter:brightness(0.9);}
-#map .mapboxgl-ctrl-group{
-  background:var(--control-text-bg) !important;
-  border:1px solid #ccc !important;
-  border-radius:8px;
-  overflow:hidden;
-}
-.mapboxgl-ctrl-top-left,
-.mapboxgl-ctrl-top-right,
-.mapboxgl-ctrl-bottom-left,
-.mapboxgl-ctrl-bottom-right{
-  margin:0;
-}
-
-
-
-
-.closed-posts{
-  display:none;
-  position: fixed;
-  top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top) + var(--gap) - 12px);
-  bottom: var(--footer-h);
-  left: calc(var(--results-w) + var(--gap) * 2);
-  right: var(--gap);
-  overflow-y:scroll;
-  overflow-x:hidden;
-  scrollbar-gutter:stable;
-  padding:0;
-  color:#000;
-  background:var(--panel-bg);
-}
-.closed-posts .posts{overflow:visible;padding:12px;margin:0;}
-.closed-posts{color:#000;padding:0;}
-.closed-posts .card,
-.closed-posts .open-posts{background:var(--closed-card-bg);}
-.closed-posts button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
-.closed-posts .open-posts{margin-top:12px}
-.closed-posts.ad-space{right:calc(400px + var(--gap) * 2);}
-
-body.hide-results .closed-posts{
-  left:0;
-}
-
-.mode-posts .closed-posts{
-  display: block;
-  z-index: 1;
-  pointer-events: auto;
-}
-
-.mode-map .closed-posts{
-  display: none;
-}
-.map-area{
-  position: fixed;
-  top: calc(var(--header-h) + var(--safe-top));
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 0;
-}
-
-
-.open-posts{
-  border:none;
-  border-radius:8px;
-  margin:0 0 12px 0;
-  overflow:visible;
-  color:#fff;
-  font-family: Verdana;
-  font-size:16px;
-}
-
-.open-posts .detail-header{
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  padding:6px 12px;
-  opacity:1;
-  border-top-left-radius:inherit;
-  border-top-right-radius:inherit;
-  background:#3E5393;
-}
-.open-posts-sticky-header .open-posts .detail-header{
-  position:sticky;
-  top:0;
-  z-index:3;
-  background:var(--list-background);
-}
-
-.open-posts .body{
-  padding:14px;
-  display:flex;
-  flex-wrap:wrap;
-  gap:8px;
-  align-items:flex-start;
-}
-
-.open-posts .text{
-  margin-top:0;
-  flex:1 1 300px;
-  min-width:300px;
-}
-
-.open-posts .text .info{
-  color: inherit;
-  font-size: inherit;
-  font-family: inherit;
-}
-
-.open-posts .img-area{
-  display:flex;
-  flex-direction:column;
-  gap:8px;
-  flex:0 0 400px;
-}
-
-.open-posts-sticky-images .open-posts .img-area{
-  position:sticky;
-  top:calc(var(--header-h) + var(--safe-top) + 8px);
-  align-self:start;
-}
-
-.open-posts .img-box{
-  width:400px;
-  height:400px;
-  overflow:hidden;
-  border:none;
-  border-radius:8px;
-  flex-shrink:0;
-  cursor:pointer;
-  background:var(--list-background);
-}
-
-.open-posts .img-box img{
-  width:100%;
-  height:100%;
-  object-fit:cover;
-  object-position:center;
-  display:block;
-}
-.open-posts .img-box img.ready{
-  object-fit:contain;
-}
-
-.open-posts .thumb-column{
-  display:flex;
-  flex-direction:row;
-  width:400px;
-  height:auto;
-  overflow-x:auto;
-  gap:4px;
-  padding:0 12px;
-  position:relative;
-}
-
-.open-posts .thumb-column img{
-  width:50px;
-  height:50px;
-  object-fit:cover;
-  object-position:center;
-  aspect-ratio:1/1;
-  border:1px solid var(--border);
-  border-radius:8px;
-  cursor:pointer;
-  position:relative;
-  z-index:1;
-}
-
-@media (max-width: 450px){
-  .closed-posts .posts{padding:0;}
-  .closed-posts .card{
-    grid-template-columns:1fr;
-    gap:0;
-    padding:0;
-    margin:0 0 var(--gap) 0;
-    border-radius:0;
-  }
-  .closed-posts .card .thumb{
-    width:100%;
-    height:100vw;
-    border-radius:0;
-  }
-  .closed-posts .card .meta{padding:12px;}
-  .open-posts{
-    margin:0;
-  }
-  .open-posts .body{
-    padding:0;
-  }
-  .open-posts .detail-header{
-    padding:6px 0;
-  }
-  .open-posts .img-area,
-  .open-posts .venue-dropdown,
-  .open-posts .session-dropdown,
-  .open-posts .text{
-    margin-bottom:6px;
-  }
-  .open-posts .text{
-    padding:14px;
-    margin-bottom:0;
-  }
-  .open-posts .img-area{
-    flex:1 1 100%;
-    width:100%;
-  }
-  .open-posts .img-box{
-    width:100%;
-    height:100vw;
-    margin:0;
-    border-radius:8px;
-  }
-  .open-posts .img-box img{
-    object-fit:cover;
-    object-position:center;
-  }
-  .open-posts .thumb-column{
-    width:auto;
-    padding:0;
-  }
-  .open-posts .venue-dropdown,
-  .open-posts .session-dropdown{
-    width:auto;
-    padding:0;
-  }
-  .open-posts .location-section .map-container,
-  .open-posts .location-section .calendar-container,
-  .open-posts .post-map,
-  .open-posts .post-calendar,
-  .open-posts .venue-dropdown,
-  .open-posts .session-dropdown{
-    min-width:0;
-    width:100%;
-  }
-  body.mode-posts footer{
-    display:none;
-  }
-}
-
-.open-posts .detail-header .title{
-  margin:0;
-  font-size:20px;
-  line-height:1.2;
-  color:#fff;
-  font-family: Verdana;
-}
-
-.open-posts .detail-header .title-block{
-  display:flex;
-  flex-direction:column;
-}
-
-.open-posts .detail-header .cat-line{
-  font-size:14px;
-  margin-top:4px;
-  display:flex;
-  align-items:center;
-  gap:4px;
-}
-
-.open-posts .meta{
-  font-size:13px;
-  display:flex;
-  gap:12px;
-  flex-wrap:wrap;
-}
-
-
-.open-posts .location-section{
-  display:flex;
-  flex-wrap:wrap;
-  gap:8px;
-  margin-top:0;
-  margin-bottom:6px;
-}
-
-.open-posts .location-section .map-container{
-  display:flex;
-  flex-direction:column;
-  gap:var(--gap);
-  flex:1 1 300px;
-  min-width:300px;
-  width:auto;
-}
-.open-posts .map-container .venue-dropdown{
-  width:100%;
-}
-
-.open-posts .post-map{
-  flex:1 1 auto;
-  height:100%;
-  border:1px solid var(--border);
-  border-radius:8px;
-  min-width:300px;
-  min-height:200px;
-}
-
-
-.open-posts .venue-dropdown,
-.open-posts .session-dropdown{
-  position:relative;
-  min-width:300px;
-}
-
-.open-posts .calendar-container .session-dropdown{
-  margin-top:0;
-  width:100%;
-}
-
-
-
-.open-posts .venue-dropdown > button{
-  height:50px;
-  background:var(--btn);
-  border:1px solid var(--btn);
-  border-radius:var(--dropdown-radius);
-  text-align:left;
-  padding:2px 8px;
-  color:var(--button-text);
-  display:inline-flex;
-  flex-direction:column;
-  align-items:flex-start;
-  justify-content:center;
-  width:100%;
-}
-
-.open-posts .session-dropdown > button{
-  height:50px;
-  background:var(--btn);
-  border:1px solid var(--btn);
-  border-radius:var(--dropdown-radius);
-  text-align:left;
-  padding:2px 8px;
-  color:var(--button-text);
-  display:inline-flex;
-  align-items:center;
-  justify-content:flex-start;
-  width:100%;
-}
-
-
-.open-posts .venue-dropdown > button .venue-name{
-  font-weight:bold;
-  display:block;
-}
-
-.open-posts .venue-dropdown > button .venue-address{
-  display:block;
-}
-
-.open-posts .venue-menu button .venue-name{
-  font-weight:bold;
-  display:block;
-}
-
-.open-posts .venue-menu button .venue-address{
-  display:block;
-}
-
-.open-posts .venue-dropdown > button .venue-name,
-.open-posts .venue-dropdown > button .venue-address,
-.open-posts .venue-menu button .venue-name,
-.open-posts .venue-menu button .venue-address{
-  line-height:1.2;
-}
-
-.open-posts .venue-menu,
-.open-posts .session-menu{
-  position:absolute;
-  top:calc(100% + 4px);
-  left:0;
-  width:100%;
-  box-sizing:border-box;
-  max-height:250px;
-  overflow-y:auto;
-  background:var(--dropdown-bg);
-  border:1px solid var(--border);
-  border-radius:var(--dropdown-radius);
-  padding:10px;
-  display:flex;
-  flex-direction:column;
-  gap:6px;
-  box-shadow:0 2px 6px rgba(0,0,0,0.2);
-  z-index:30;
-}
-
-.open-posts .venue-menu[hidden],
-.open-posts .session-menu[hidden]{display:none;}
-
-.open-posts .venue-menu button{
-  height:50px;
-  background:var(--btn);
-  border:1px solid var(--btn);
-  border-radius:var(--dropdown-radius);
-  text-align:left;
-  padding:4px 8px;
-  color:var(--button-text);
-  display:flex;
-  flex-direction:column;
-  align-items:flex-start;
-  justify-content:center;
-}
-
-.open-posts .session-menu button{
-  height:50px;
-  background:var(--btn);
-  border:1px solid var(--btn);
-  border-radius:var(--dropdown-radius);
-  text-align:left;
-  padding:4px 8px;
-  color:var(--button-text);
-  display:flex;
-  align-items:center;
-  justify-content:flex-start;
-}
-
-
-.open-posts .venue-menu button.selected,
-.open-posts .session-menu button.selected{
-  background:var(--dropdown-selected-bg);
-  color:var(--dropdown-selected-text);
-}
-
-.open-posts .session-menu button .session-time{
-  margin-left:auto;
-  padding-right:20px;
-}
-.open-posts .session-dropdown > button .session-time{
-  margin-left:auto;
-  padding-right:20px;
-}
-
-
-.open-posts .location-section .calendar-container{
-  display:flex;
-  flex-direction:column;
-  gap:var(--gap);
-  position:relative;
-  align-items:flex-start;
-  flex:1 1 300px;
-  min-width:300px;
-  width:calc(var(--calendar-width) * var(--calendar-scale));
-  min-height:calc(var(--calendar-height) * var(--calendar-scale));
-}
-.open-posts .location-section .options-menu{
-  width:100%;
-  box-sizing:border-box;
-}
-
-.hide-map-calendar .open-posts .map-container,
-.hide-map-calendar .open-posts .calendar-container{
-  display:none;
-}
-.open-posts .post-calendar{
-  width:var(--calendar-width);
-  height:var(--calendar-height);
-  position:relative;
-  font-size:16px;
-}
-
-
-.open-posts .calendar-container .calendar-scroll{
-  width:100%;
-  height:100%;
-  overflow-x:auto;
-  overflow-y:hidden;
-  padding-bottom:0;
-  box-sizing:content-box;
-  background:var(--dropdown-bg);
-  border:1px solid var(--border);
-  border-radius:8px;
-  flex:1 1 auto;
-}
-.open-posts .post-calendar .calendar{
-  margin:0;
-  box-sizing:border-box;
-  display:flex;
-  width:max-content;
-  height:100%;
-  transform:scale(var(--calendar-scale));
-  transform-origin:top left;
-  background:var(--dropdown-bg);
-  color:var(--dropdown-text);
-}
-.open-posts .post-calendar .month{
-  flex:0 0 auto;
-  width:var(--calendar-width);
-  height:var(--calendar-height);
-  display:flex;
-  flex-direction:column;
-}
-.open-posts .post-calendar .grid{
-  flex:1 1 auto;
-  width:100%;
-  height:calc(var(--calendar-height) - var(--calendar-header-h) - var(--scrollbar-h));
-  display:grid;
-  grid-template-columns:repeat(7,var(--calendar-cell-w));
-  grid-template-rows:repeat(7,var(--calendar-cell-h));
-}
-.open-posts .post-calendar .calendar-header{
-  height:var(--calendar-header-h);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  text-align:center;
-  font-weight:bold;
-}
-.open-posts .post-calendar .weekday,
-.open-posts .post-calendar .day{
-  width:var(--calendar-cell-w);
-  height:var(--calendar-cell-h);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-}
-.open-posts .post-calendar .day{
-  cursor:pointer;
-  font-size:12px;
-  border-radius:8px;
-}
-.open-posts .post-calendar .day.available-day{
-  background:var(--session-available);
-  color:var(--button-text);
-  font-weight:bold;
-}
-.open-posts .post-calendar .day.available-day.selected{
-  background:var(--session-selected);
-  color:#fff;
-}
-.open-posts .post-calendar .day.today{color:var(--today) !important;}
-.open-posts .post-calendar .day.available-day.today,
-.open-posts .post-calendar .day.available-day.selected.today,
-.open-posts .post-calendar .day.selected.today{color:var(--today) !important;}
-
-
-.open-posts .post-calendar .selected-month-name{
-  background:var(--accent);
-  color:var(--button-hover-text);
-  border-radius:8px;
-  padding:0 4px;
-}
-
-.open-posts .calendar-container .time-popup{
-  position:absolute;
-  z-index:10;
-}
-
-.open-posts .calendar-container .time-popup .time-list{
-  background:var(--dropdown-bg);
-  color:var(--dropdown-text);
-  padding:8px;
-  border-radius:8px;
-  display:flex;
-  flex-direction:column;
-  gap:4px;
-  box-shadow:0 2px 6px var(--border);
-}
-
-.open-posts .calendar-container .time-popup .time-list button{
-  background:var(--btn);
-  border:1px solid var(--btn);
-  color:var(--button-text);
-  border-radius:8px;
-  padding:6px 10px;
-  cursor:pointer;
-}
-
-.open-posts .venue-info,
-.open-posts .session-info{
-  color: inherit;
-  font-size: inherit;
-  font-family: inherit;
-}
-.open-posts .venue-info{margin-top:4px;}
-.open-posts .session-info{margin-top:8px;}
-
-
-
-.img-popup{
-  position:fixed;
-  inset:0;
-  background:var(--image-panel-bg);
-  display:flex;
-  justify-content:center;
-  align-items:center;
-  z-index:1000;
-  pointer-events:auto;
-}
-.img-popup img{
-  max-width:90vw;
-  max-height:90vh;
-  cursor:pointer;
-  pointer-events:auto;
-}
-
-.pill{
-  border: 1px solid var(--btn);
-  background: var(--btn);
-  border-radius: 999px;
-  padding: 8px 12px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.close{
-  border: 0;
-  background: #16283f;
-  border-radius: 8px;
-  padding: 8px 12px;
-  cursor: pointer;
-}
-
-.dates{
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-top: 4px;
-}
-
-.date{
-  background: var(--btn);
-  border: 1px solid var(--btn);
-  border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 12px;
-}
-
-.desc{
-  margin-top: 8px;
-}
-.open-posts .desc-wrap .desc{overflow:visible;}
-
-
-@media (max-width:1000px){
-  .results-col{display:none;}
-  .closed-posts{left:0;}
-  #resultsToggle{display:none;}
-  .results-arrow{display:none;}
-}
-
-@media (max-width:650px){
-  .logo{display:none;}
-  #smallLogo{display:block;height:35px;}
-}
-
-@media (max-width:650px){
-  html{
-    touch-action:pan-x pan-y;
-  }
-  .map-container{
-    touch-action:auto;
-  }
-  .img-popup img{
-    touch-action:pinch-zoom;
-  }
-}
-
-@media (max-width:840px){
-  .open-posts .body{
-    flex-direction:column;
-  }
-  .open-posts .text .location-section{
-    order:-1;
-  }
-  .open-posts .img-box{
-    max-width:100%;
-    width:100%;
-  }
-  .open-posts .post-calendar{
-    display:none;
-  }
-  .open-posts .venue-dropdown,
-  .open-posts .session-dropdown{
-    display:block;
-  }
-}
-
-  @media (max-width:450px){
-    .closed-posts,
-    .closed-posts .card,
-    .open-posts,
-    .open-posts .img-box{
-      width:100%;
-      max-width:100%;
-      border:none;
-      border-radius:8px;
+  <style>
+/*THEMEBUILDER_FIELDSETS
+{
+  "header-bg": {
+    "color": "#3e5393",
+    "opacity": "1"
+  },
+  "header-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
     }
-  .closed-posts{
-    left:0;
-    right:0;
-    top:calc(var(--header-h) + var(--safe-top));
+  },
+  "header-btn": {
+    "color": "#3e5393",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "header-btnText": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "12",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "body-bg": {
+    "color": "#292929",
+    "opacity": "1"
+  },
+  "body-border": {
+    "color": "#adadad",
+    "opacity": "0"
+  },
+  "body-hoverAdjust": {
+    "value": "0"
+  },
+  "body-activeAdjust": {
+    "value": "0"
+  },
+  "list-bg": {
+    "color": "#000000",
+    "opacity": "0.5"
+  },
+  "list-card": {
+    "color": "#3e5393",
+    "opacity": "1",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "list-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "12",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "list-title": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "bold",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "list-btn": {
+    "color": "#3e5393",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "list-btnText": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "14",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "closed-posts-bg": {
+    "color": "#000000",
+    "opacity": "0.5"
+  },
+  "closed-posts-card": {
+    "color": "#3e5393",
+    "opacity": "1",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "closed-posts-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "12",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "closed-posts-title": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "bold",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "closed-posts-btn": {
+    "color": "#3e5393",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "closed-posts-btnText": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "14",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "open-posts-card": {
+    "color": "#000000",
+    "opacity": "1",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "open-posts-text": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "open-posts-title": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "open-posts-btn": {
+    "color": "#000000",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "open-posts-btnText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "open-posts-header": {
+    "color": "#000000"
+  },
+  "open-posts-image": {
+    "color": "#000000"
+  },
+  "open-posts-menu": {
+    "color": "#000000"
+  },
+  "footer-bg": {
+    "color": "#000000",
+    "opacity": "0.5"
+  },
+  "footer-card": {
+    "color": "#000000",
+    "opacity": "0.32",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "footer-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "12",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "map-title": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "map-popupBg": {
+    "color": "#000000"
+  },
+  "map-popupText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "filter-bg": {
+    "color": "#919191",
+    "opacity": "1"
+  },
+  "filter-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "filter-title": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "filter-btn": {
+    "color": "#3e5393",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "filter-btnText": {
+    "color": "#ffffff",
+    "font": "Arial",
+    "size": "",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "calendar-bg": {
+    "color": "#ffffff",
+    "opacity": "1"
+  },
+  "calendar-text": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "12",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "calendar-weekday": {
+    "color": "#a3a3a3",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "calendar-title": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "calendar-header": {
+    "color": "#3e5393"
+  },
+  "adminPanel-bg": {
+    "color": "#919191",
+    "opacity": "1"
+  },
+  "adminPanel-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "adminPanel-title": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "20",
+    "weight": "bold",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "adminPanel-btn": {
+    "color": "#16596a",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "adminPanel-btnText": {
+    "color": "#ffffff",
+    "font": "Arial",
+    "size": "",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "welcomePopup-bg": {
+    "color": "#000000",
+    "opacity": "0.48"
+  },
+  "welcomePopup-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "welcomePopup-title": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "welcomePopup-btn": {
+    "color": "#000000",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "welcomePopup-btnText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "memberPanel-bg": {
+    "color": "#919191",
+    "opacity": "1"
+  },
+  "memberPanel-text": {
+    "color": "#ffffff",
+    "font": "Verdana",
+    "size": "16",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "memberPanel-title": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "memberPanel-btn": {
+    "color": "#16596a",
+    "shadow": {
+      "color": "#000000",
+      "blur": "0"
+    }
+  },
+  "memberPanel-btnText": {
+    "color": "#ffffff",
+    "font": "Arial",
+    "size": "",
+    "weight": "normal",
+    "shadow": {
+      "color": "#000000",
+      "x": "0",
+      "y": "0",
+      "blur": "0"
+    }
+  },
+  "adPanel-bg": {
+    "color": "#000000",
+    "opacity": "0.5"
+  },
+  "imagePanel-bg": {
+    "color": "#000000",
+    "opacity": "1"
+  },
+  "open-posts-sticky-header": {
+    "value": "1"
+  },
+  "open-posts-sticky-images": {
+    "value": "1"
+  },
+  "primary": {
+    "color": "#000000"
+  },
+  "secondary": {
+    "color": "#000000"
+  },
+  "accent": {
+    "color": "#000000"
+  },
+  "btn": {
+    "color": "#000000",
+    "opacity": "1"
+  },
+  "panelBg": {
+    "color": "#000000",
+    "opacity": "1"
+  },
+  "scrollbarTrack": {
+    "color": "#000000",
+    "opacity": "0"
+  },
+  "scrollbarThumb": {
+    "color": "#000000",
+    "opacity": "0.3"
+  },
+  "scrollbarThumbHover": {
+    "color": "#000000",
+    "opacity": "0.5"
+  },
+  "listBackground": {
+    "color": "#000000",
+    "opacity": "0.37"
+  },
+  "closedCardBg": {
+    "color": "#000000",
+    "opacity": "0.37"
+  },
+  "dropdownBg": {
+    "color": "#ffffff",
+    "opacity": "1"
+  },
+  "dropdownSelectedBg": {
+    "color": "#e0e0e0",
+    "opacity": "1"
+  },
+  "dropdownHoverBg": {
+    "color": "#e0e0e0",
+    "opacity": "1"
+  },
+  "keywordBg": {
+    "color": "#ffffff",
+    "opacity": "1"
+  },
+  "dateRangeBg": {
+    "color": "#ffffff",
+    "opacity": "1"
+  },
+  "sessionAvailable": {
+    "color": "#000000"
+  },
+  "sessionSelected": {
+    "color": "#000000"
+  },
+  "today": {
+    "color": "#000000"
+  },
+  "controlTextBg": {
+    "color": "#000000"
+  },
+  "geoBtnBg": {
+    "color": "#000000"
+  },
+  "compassBtnBg": {
+    "color": "#000000"
+  },
+  "clearBtnBg": {
+    "color": "#000000",
+    "opacity": "0"
+  },
+  "dropdownTitle": {
+    "color": "#000000"
+  },
+  "panelText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "placeholder": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "filterPlaceholder": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "dropdownSelectedText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "dropdownText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "dropdownHoverText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "dropdownVenueText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "dateRangeText": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "10"
+  },
+  "controlPlaceholder": {
+    "color": "#000000",
+    "font": "Verdana",
+    "size": "16"
+  },
+  "calendar-width": {
+    "value": "300"
+  },
+  "calendar-height": {
+    "value": "200"
   }
-  .open-posts .img-box{
-    height:auto;
-    max-height:100vw;
-    margin-left:0;
-    margin-right:0;
-    padding-left:0;
-    padding-right:0;
-  }
-  .open-posts .img-box img{
-    width:100%;
-    height:100%;
-    object-fit:cover;
-    margin-left:0;
-    margin-right:0;
-  }
-  .open-posts .body{
-    padding:14px 0;
-    gap:8px;
-  }
-  .open-posts .text{
-    padding-left:12px;
-    padding-right:12px;
-  }
 }
-
-@media (max-width:450px){
-  .open-posts .venue-dropdown > button,
-  .open-posts .session-dropdown > button{
-    height:50px;
-  }
-}
-
-footer{
-  height: var(--footer-h);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  background: var(--list-background);
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 20;
-  transition: transform .1s linear;
-}
-
-@media (max-width: 649px){
-  body.mode-posts.hide-posts-ui footer{
-    transform: translateY(100%);
-  }
-  body.mode-posts.hide-posts-ui .closed-posts{
-    top: calc(var(--header-h) + var(--safe-top));
-    bottom: 0;
-  }
-}
-
-
-.foot-row{
-  overflow-x: auto;
-  overflow-y: hidden;
-  white-space: nowrap;
-  display: flex;
-  gap: 8px;
-  width: 100%;
-  flex:1;
-}
-
-.fullscreen-btn{
-    width:50px;
-    height:50px;
-    padding:0;
-    margin-left:auto;
-    flex:0 0 auto;
-  }
-
-
-.chip-small{
-  flex: 0 0 auto;
-  max-width: 240px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--btn);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
-}
-
-footer .foot-row .foot-item{
-  background:var(--list-background);
-  border:1px solid var(--border);
-}
-
-.chip-small img.mini{
-  width: 26px;
-  height: 20px;
-  border-radius: 8px;
-  object-fit: cover;
-  flex: 0 0 auto;
-  display: block;
-  background: var(--btn);
-}
-
-.chip-small .t{
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.card,
-footer .foot-row .foot-item,
-.mapboxgl-popup.hover-pop .hover-card{
-  transition: box-shadow .2s;
-}
-
-.card .thumb{
-  flex: 0 0 90px;
-  width: 90px;
-  height: 70px;
-  display: block;
-  object-fit: cover;
-  border-radius: 8px;
-}
-
-.closed-posts .card .thumb{
-  flex-basis: 80px;
-  width: 80px;
-  height: 80px;
-  padding:0;
-}
-
-.card .meta{
-  flex: 1 1 auto;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.card .fav{
-  flex: 0 0 auto;
-}
-
-.hover-card{
-  display: flex;
-  gap: 10px;
-  align-items: flex-start;
-  max-width: 300px;
-}
-
-.hover-card img{
-  width: 64px;
-  height: 64px;
-  object-fit: cover;
-  border-radius: 8px;
-  flex: 0 0 auto;
-  display: block;
-  background: var(--panel-bg);
-}
-
-.hover-card .t{
-  font-weight: 800;
-  font-size: 13px;
-  line-height: 1.25;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-}
-
-.hover-card .s{
-  font-size: 12px;
-  opacity: .8;
-  margin-top: 2px;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-  overflow: hidden;
-}
-
-.mapboxgl-popup.hover-pop{
-  pointer-events: none;
-}
-.mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  pointer-events: auto;
-}
-
-.multi-hover h4{
-  margin: 0 0 8px 0;
-  font-size: 13px;
-  color: var(--ink-d);
-  font-weight: 700;
-  letter-spacing: .3px;
-}
-
-.multi-list{
-  max-height: 360px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-gutter: stable;
-  padding: 2px 6px 2px 2px;
-  box-sizing: border-box;
-}
-
-.multi-item{
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  padding: 4px 6px;
-  border-radius: 8px;
-  cursor: pointer;
-  min-width: 0;
-}
-
-
-.multi-item img{
-  width: 64px;
-  height: 44px;
-  border-radius: 8px;
-  object-fit: cover;
-  display: block;
-  background: var(--panel-bg);
-  flex: 0 0 auto;
-}
-
-.multi-item .t{
-  white-space: normal;
-  overflow-wrap: anywhere;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  display: -webkit-box;
-}
-
-.multi-item .s{
-  font-size: 12px;
-  opacity: .8;
-  margin-top: 2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.multi-ctrls{
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  margin-top: 8px;
-}
-
-.multi-ctrls .hint{
-  font-size: 12px;
-  color: var(--ink-d);
-}
-
-.multi-ctrls .close{
-  border: 0;
-  background: #16283f;
-  color: #fff;
-  border-radius: 8px;
-  padding: 6px 10px;
-  cursor: pointer;
-}
-
-.multi-item > div{
-  min-width: 0;
-}
-
-.multi-item .hover-card{
-  width: 100%;
-}
-
-.hover-card > div{
-  min-width: 0;
-  flex: 1;
-}
-
-.multi-item .hover-card .t{
-  max-width: none;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-.nowrap{
-  white-space: nowrap;
-}
-
-.multi-hover .soonest{
-  color: var(--ink-d);
-  font-weight: 600;
-}
-
-.hero img.lqip{
-  filter: blur(10px);
-  transform: scale(1.02);
-  transition: filter .22s ease, transform .22s ease;
-}
-
-.hero img.ready{
-  filter: none;
-  transform: none;
-}
-
-.hover-card img, .mapboxgl-popup .hover-card img{
-  width: 64px;
-  height: 64px;
-  object-fit: cover;
-  border-radius: 8px;
-  flex: 0 0 auto;
-  display: block;
-  background: var(--panel-bg);
-}
-
-.foot-item img{
-  width: 40px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: 8px;
-}
-
-img.thumb{
-  width: 80px;
-  height: 80px;
-  object-fit: cover;
-}
-
-#results .card > img, #results .card img.thumb{
-  width: 80px;
-  height: 80px;
-  aspect-ratio: 1/1;
-  object-fit: cover;
-  display: block;
-}
-
-footer .foot-row .foot-item > img, footer .foot-row .foot-item img{
-  width: 40px;
-  height: 40px;
-  aspect-ratio: 1/1;
-  object-fit: cover;
-  display: block;
-  border-radius: 8px;
-}
-
-footer .chip-small img.mini, footer .foot-row .foot-item img{
-  width: 40px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: 8px;
-}
-
-} } .mapboxgl-popup.hover-pop.hover-multi-list{
-  max-width: none;
-}
-
-.mapboxgl-popup.hover-pop.hover-multi-list .mapboxgl-popup-content{
-  max-width: none;
-  width: auto;
-}
-
-.mapboxgl-popup.hover-pop.hover-multi-list .multi-hover{
-  width: auto;
-  max-width: none;
-}
-
-.mapboxgl-popup.hover-pop:not(.hover-multi-list){
-  max-width: 320px;
-}
-
-.multi-item .txt{
-  min-width: 0;
-}
-
-.mapboxgl-popup.hover-pop .mapboxgl-popup-content{
-  border-radius: 8px;
-  padding: 6px 10px 6px 8px;
-}
-
-.mapboxgl-popup.hover-multi-list .mapboxgl-popup-content{
-  width: auto;
-  max-width: none;
-}
-
-.mapboxgl-popup.hover-multi-list .multi-hover{
-  width: auto;
-}
-
-.mapboxgl-popup.hover-multi-list .multi-item .txt{
-  min-width: 0;
-}
-
-.mapboxgl-popup.hover-multi-list .multi-item .t{
-  white-space: normal;
-  overflow-wrap: anywhere;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  display: -webkit-box;
-}
-
-.results-col .res-list{
-  border-radius: inherit;
-  padding: var(--gap);
-  padding-right: 0;
-  margin: 0 calc(-1 * var(--gap));
-}
-
-
-.ad-panel{
-  position:fixed;
-  top: calc(var(--header-h) + var(--safe-top));
-  bottom: var(--footer-h);
-  width:400px;
-  right: var(--gap);
-  background:var(--ad-panel-bg);
-  z-index:5;
-  border-radius:8px;
-  overflow:hidden;
-  pointer-events:none;
-  padding:8px;
-  transform:translateX(calc(100% + var(--gap)));
-  transition:transform .3s ease;
-  cursor:pointer;
-}
-
-.ad-panel.show{
-  pointer-events:auto;
-  transform:translateX(0);
-}
-
-.ad-panel .ad-slide{
-  position:absolute;
-  inset:0;
-  opacity:0;
-  transition:opacity 1.5s ease-in-out;
-  cursor:pointer;
-  border-radius:8px;
-  overflow:hidden;
-}
-
-.ad-panel .ad-slide.active{opacity:1;}
-
-.ad-panel .ad-slide img{
-  width:100%;
-  height:100%;
-  object-fit:cover;
-  animation:pan 20s linear forwards;
-}
-
-.ad-panel .caption{
-  position:absolute;
-  left:0;
-  right:0;
-  bottom:0;
-  padding:12px;
-  background:linear-gradient(to top, rgba(0,0,0,0.7), rgba(0,0,0,0));
-  color:#fff;
-  text-shadow:0 1px 2px rgba(0,0,0,0.8);
-  font-size:13px;
-  display:flex;
-  flex-direction:column;
-  text-align:left;
-}
-
-.ad-panel .caption .title{
-  font-weight:900;
-  margin:0 0 4px;
-}
-
-.ad-panel .caption .info{
-  display:flex;
-  flex-direction:column;
-  gap:4px;
-  align-items:flex-start;
-}
-
-@keyframes pan{
-  from{transform:scale(1) translateX(0);}
-  to{transform:scale(1.1) translateX(-5%);}
-}
-
-.mode-posts #postsWide{
-  border: none;
-  background: transparent;
-}
-
-.mode-posts #postsWide.posts{
-  background: transparent;
-}
-
-
-
-@media (max-width:649px){
-  #filterPanel .panel-content,
-  #adminPanel .panel-content,
-  #memberPanel .panel-content{
-    top:calc(var(--header-h) + var(--safe-top));
-    left:0;
-    right:0;
-    bottom:var(--footer-h);
-    width:100%;
-    max-width:none;
-    max-height:none;
-    border-radius:0;
-  }
-  #filterPanel .panel-content .resizer,
-  #adminPanel .panel-content .resizer,
-  #memberPanel .panel-content .resizer,
-  #filterPanel .panel-actions .move-left,
-  #filterPanel .panel-actions .move-right,
-  #adminPanel .panel-actions .move-left,
-  #adminPanel .panel-actions .move-right,
-  #memberPanel .panel-actions .move-left,
-  #memberPanel .panel-actions .move-right{
-    display:none;
-  }
-}
-
-@media (max-width:449px){
-  .closed-posts{
-    left:0;
-    right:0;
-  }
-  .closed-posts .posts{
-    padding:12px 12px var(--gap);
-    margin:0;
-  }
-  .closed-posts .card{
-    width:100%;
-    margin:0;
-    border-radius:0;
-  }
-  .closed-posts .open-posts{
-    margin:0;
-  }
-  .open-posts{
-    width:100%;
-    border-radius:0;
-    margin:0;
-  }
-  .open-posts .img-area{
-    flex:0 0 100%;
-  }
-  .open-posts .img-box{
-    width:100vw;
-    height:100vw;
-    flex:0 0 100vw;
-    border-radius:8px;
-  }
-  .open-posts .img-box img{
-    width:100%;
-    height:100%;
-    object-fit:cover;
-  }
-}
-
-@media (max-width:450px){
-  :root{
-    --footer-h:0;
-  }
-  footer{
-    display:none;
-  }
-  body.mode-map{
-    --footer-h:0;
-  }
-  body.mode-map footer{
-    display:none;
-  }
-  #filterPanel .panel-content,
-  #memberPanel .panel-content,
-  #adminPanel .panel-content{
-    top:calc(var(--header-h) + var(--safe-top));
-    left:0;
-    right:0;
-    transform:none;
-  }
-  .open-posts .detail-header{
-    padding-bottom:0;
-  }
-  .open-posts .body{
-    padding:0;
-  }
-}
-
-</style>
-<style id="theme-blue">
-:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:#3E5393;--panel-bg:rgba(0,0,0,1);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--closed-card-bg:rgba(0,0,0,0.37);--placeholder-text:#000000;--filter-placeholder-text:#000000;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--dropdown-venue-text:#000000;--keyword-bg:rgba(255,255,255,1);--date-range-bg:rgba(255,255,255,1);--date-range-text:#000000;--session-available:#90d9fe;--session-selected:#0c86e4;--today:#ff0000;--border:rgba(173,173,173,0);--border-hover:rgba(173,173,173,0);--border-active:rgba(173,173,173,0);--calendar-width:300px;--calendar-height:200px;}
+*/
+:root{--primary:#000000;--secondary:#000000;--accent:#000000;--btn:rgba(0,0,0,1);--panel-bg:rgba(0,0,0,1);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--closed-card-bg:rgba(0,0,0,0.37);--placeholder-text:#000000;--filter-placeholder-text:#000000;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--dropdown-venue-text:#000000;--keyword-bg:rgba(255,255,255,1);--date-range-bg:rgba(255,255,255,1);--date-range-text:#000000;--session-available:#000000;--session-selected:#000000;--today:#000000;--control-text-bg:#000000;--control-placeholder-text:#000000;--control-geolocate-bg:#000000;--control-compass-bg:#000000;--control-clear-bg:rgba(0,0,0,0);--border:rgba(173,173,173,0);--border-hover:rgba(173,173,173,0);--border-active:rgba(173,173,173,0);--calendar-width:300px;--calendar-height:200px;--control-placeholder-font:Verdana;--control-placeholder-size:16px;}
 .open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}
 .header{background-color:rgba(62,83,147,1);}
 .header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
@@ -2933,19 +674,16 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 .header button{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header .gear{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .header a{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.options-dropdown > button{background-color:#3a3a3a;border-color:#3a3a3a;box-shadow:0 0 0px #000000;}
-.options-dropdown > button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.options-menu{background-color:rgba(255,255,255,1);}
 body{background-color:rgba(41,41,41,1);}
 .res-list{background-color:rgba(0,0,0,0.5);}
 .res-list .card{background-color:rgba(62,83,147,1);box-shadow:0 0 0px #000000;}
 .res-list{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
 .res-list .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.res-list button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .sq{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .tiny{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .btn{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
+.res-list button{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+.res-list .sq{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+.res-list .tiny{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
+.res-list .btn{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
 .res-list button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list .sq{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 .res-list .tiny{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
@@ -2959,37 +697,31 @@ body{background-color:rgba(41,41,41,1);}
 .closed-posts .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
 .closed-posts .open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
 .closed-posts .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
+.closed-posts button{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
 .closed-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts{background-color:rgba(62,83,147,1);box-shadow:0 0 0px #000000;}
-.open-posts{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .venue-info{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .session-info{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.open-posts button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.open-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .detail-header{background-color:#3e5393;}
+.open-posts{background-color:rgba(0,0,0,1);box-shadow:0 0 0px #000000;}
+.open-posts{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .venue-info{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .session-info{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts button{background-color:#000000;border-color:#000000;box-shadow:0 0 0px #000000;}
+.open-posts button{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.open-posts .detail-header{background-color:#000000;}
 .open-posts .img-box{background-color:#000000;}
 .open-posts .venue-menu button{background-color:#000000;}
 .open-posts .session-menu button{background-color:#000000;}
 footer{background-color:rgba(0,0,0,0.5);}
 footer .foot-row .foot-item{background-color:rgba(0,0,0,0.32);box-shadow:0 0 0px #000000;}
 footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.map-area{background-color:rgba(0,0,0,1);}
-.mapboxgl-popup .mapboxgl-popup-content{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;}
-.mapboxgl-popup .hover-card{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .chip{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .chip-small{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .multi-item{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .hover-card .t,
-.mapboxgl-popup .hover-card .title,
-.mapboxgl-popup .chip .t,
-.mapboxgl-popup .chip .title,
-.mapboxgl-popup .chip-small .t,
-.mapboxgl-popup .chip-small .title,
-.mapboxgl-popup .multi-item .t,
-.mapboxgl-popup .multi-item .title{color:var(--popup-text);}
+.mapboxgl-popup .hover-card .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .hover-card .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .chip-small .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
+.mapboxgl-popup .multi-item .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #filterPanel .panel-content{background-color:rgba(145,145,145,1);}
 #filterPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #filterPanel .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
@@ -3027,11 +759,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
 #memberPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
 #memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
 #memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:0px;padding-left:12px;margin-left:0px;}
-.res-list .thumb{width:80px;height:80px;}
-@media (min-width:450px){.closed-posts .posts{padding:12px;margin:0;}}
-.closed-posts .thumb{width:80px;height:80px;padding:0;}
-#adPanel{background-color:var(--ad-panel-bg);}
+#adPanel{background-color:rgba(0,0,0,0.5);}
 .img-popup{background-color:rgba(0,0,0,1);}
 
 </style>
@@ -3207,51 +935,13 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
           </div>
         </div>
         <div class="tab-bar">
-          <button type="button" class="tab-btn" data-tab="theme" aria-selected="true">Theme</button>
-          <button type="button" class="tab-btn" data-tab="map">Map</button>
+          <button type="button" class="tab-btn" data-tab="map" aria-selected="true">Map</button>
           <button type="button" class="tab-btn" data-tab="settings">Settings</button>
           <button type="button" class="tab-btn" data-tab="forms">Forms</button>
         </div>
       </div>
       <form id="adminForm" class="panel-body">
-        <div id="tab-theme" class="tab-panel active">
-          <div id="themePresetsContainer" class="admin-section">
-            <h3 class="title">Theme Presets</h3>
-            <div class="panel-field">
-              <label for="themePreset">Themes</label>
-              <div class="preset-select">
-                <select id="themePreset" style="width:250px"></select>
-                <button type="button" id="refreshTheme">Refresh</button>
-              </div>
-            </div>
-            <div class="preset-actions">
-              <input id="newPresetName" type="text" placeholder="Name of your new theme" />
-              <button type="button" id="savePreset">Save Theme</button>
-              <button type="button" id="downloadCss">Download CSS</button>
-            </div>
-          </div>
-          <div id="themeBuilderContainer" class="admin-section">
-            <h3 class="title">Theme Builder</h3>
-            <div id="styleControls">
-              <div id="undo-row" class="history-group">
-                <button type="button" id="undoBtn">Undo</button>
-                <button type="button" id="redoBtn">Redo</button>
-              </div>
-              <div id="autoTheme-row">
-                <button type="button" id="autoThemeBtn">AutoTheme</button>
-                <input type="color" id="baseColor" value="#336699" />
-              </div>
-            </div>
-          </div>
-          <div id="backupRestoreContainer" class="admin-section">
-            <div class="panel-field">
-              <label for="themeRestore">Restore Backup</label>
-              <select id="themeRestore" style="width:250px"></select>
-              <button type="button" data-restore="theme">Restore</button>
-            </div>
-          </div>
-        </div>
-          <div id="tab-map" class="tab-panel">
+        <div id="tab-map" class="tab-panel active">
             <div class="panel-field">
               <label for="mapTheme">Theme</label>
               <select id="mapTheme">
@@ -6312,1495 +4002,11 @@ document.addEventListener('pointerdown', handleDocInteract);
     });
   });
 
-  const colorAreas = [
-    {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
-    {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
-    {key:'list', label:'List', selectors:{bg:['.res-list'], text:['.res-list'], title:['.res-list .card .t','.res-list .card .title'], btn:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], btnText:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], card:['.res-list .card']}},
-    {key:'closed-posts', label:'Closed Posts', selectors:{bg:['.closed-posts'], text:['.closed-posts','.closed-posts .posts'], title:['.closed-posts .card .t','.closed-posts .card .title','.closed-posts .open-posts .t','.closed-posts .open-posts .title'], btn:['.closed-posts button'], btnText:['.closed-posts button'], card:['.closed-posts .card','.closed-posts .open-posts']}},
-    {key:'open-posts', label:'Open Posts', selectors:{text:['.open-posts','.open-posts .venue-info','.open-posts .session-info'], title:['.open-posts .t','.open-posts .title'], btn:['.open-posts button'], btnText:['.open-posts button'], card:['.open-posts'], header:['.open-posts .detail-header'], image:['.open-posts .img-box'], menu:['.open-posts .venue-menu button','.open-posts .session-menu button']}},
-    {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
-    {key:'map', label:'Map', selectors:{popupBg:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], popupText:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
-    {key:'filter', label:'Filter Panel', selectors:{bg:['#filterPanel .panel-content'], text:['#filterPanel .panel-content'], title:['#filterPanel .panel-content .t','#filterPanel .panel-content .title'], btn:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn'], btnText:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn']}},
-    {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar .day'], weekday:['.calendar .weekday'], title:['.calendar .calendar-header'], header:['.calendar .calendar-header']}},
-  {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},
-  {key:'welcomePopup', label:'Welcome Popup', selectors:{bg:['#welcomePopup .panel-content'], text:['#welcomePopup .panel-content'], title:['#welcomePopup .panel-content .t','#welcomePopup .panel-content .title'], btn:['#welcomePopup button'], btnText:['#welcomePopup button']}},
-  {key:'memberPanel', label:'Member Panel', selectors:{bg:['#memberPanel .panel-content'], text:['#memberPanel .panel-content'], title:['#memberPanel .panel-content .t','#memberPanel .panel-content .title'], btn:['#memberPanel button'], btnText:['#memberPanel button']}},
-  {key:'adPanel', label:'Ad Panel', selectors:{bg:['#adPanel']}},
-  {key:'imagePanel', label:'Image Popup', selectors:{bg:['.img-popup']}}
-];
-
-  function storeTitleDefaults(){
-    colorAreas.forEach(area=>{
-      (area.selectors.title||[]).forEach(sel=>{
-        document.querySelectorAll(sel).forEach(el=>{
-          const cs = getComputedStyle(el);
-          el.dataset.titleDefaultColor = cs.color;
-          el.dataset.titleDefaultFont = cs.fontFamily;
-          el.dataset.titleDefaultSize = cs.fontSize;
-          el.dataset.titleDefaultWeight = cs.fontWeight;
-          el.dataset.titleDefaultShadow = cs.textShadow;
-        });
-      });
-    });
-    const varMap = {'today-c':'--today', 'sessionAvailable-c':'--session-available', 'sessionSelected-c':'--session-selected'};
-    Object.entries(varMap).forEach(([id,varName])=>{
-      const el = document.getElementById(id);
-      if(el){
-        const val = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
-        if(val) el.value = val;
-      }
-    });
-  }
-
-  function restoreTitleDefaults(area){
-    (area.selectors.title||[]).forEach(sel=>{
-      document.querySelectorAll(sel).forEach(el=>{
-        if(el.dataset.titleDefaultColor) el.style.color = el.dataset.titleDefaultColor;
-        if(el.dataset.titleDefaultFont) el.style.fontFamily = el.dataset.titleDefaultFont;
-        if(el.dataset.titleDefaultSize) el.style.fontSize = el.dataset.titleDefaultSize;
-        if(el.dataset.titleDefaultWeight) el.style.fontWeight = el.dataset.titleDefaultWeight;
-        if(el.dataset.titleDefaultShadow) el.style.textShadow = el.dataset.titleDefaultShadow;
-      });
-    });
-  }
-
-  storeTitleDefaults();
-
-  let lastFieldsetKey = null;
-  let undoStack = [];
-  let redoStack = [];
-  let currentState = {};
-  let undoBtn, redoBtn;
-
-  const COLOR_PICKER_MODE = 'hex';
-  const FONT_OPTIONS = ['Verdana','Inter','Roboto','Montserrat','Arial','Helvetica','Georgia','Times New Roman','Courier New','Trebuchet MS','Tahoma','Comic Sans MS'];
-  const FONT_SIZE_OPTIONS = ['10','12','14','16','18','20','24','32'];
-  const TEXT_BG_MAP = {text:'bg', weekday:'bg', title:'card', btnText:'btn', popupText:'popupBg'};
-
-  function updateTextPicker(areaKey, type){
-    const picker = document.getElementById(`${areaKey}-${type}-picker`);
-    if(!picker) return;
-    const preview = picker.querySelector('.text-preview');
-    const color = document.getElementById(`${areaKey}-${type}-c`).value;
-    const font = document.getElementById(`${areaKey}-${type}-font`).value;
-    const size = document.getElementById(`${areaKey}-${type}-size`).value;
-    const weight = document.getElementById(`${areaKey}-${type}-weight`).value;
-    const sc = document.getElementById(`${areaKey}-${type}-shadow-color`).value;
-    const sx = document.getElementById(`${areaKey}-${type}-shadow-x`).value;
-    const sy = document.getElementById(`${areaKey}-${type}-shadow-y`).value;
-    const sb = document.getElementById(`${areaKey}-${type}-shadow-blur`).value;
-    const bgInput = document.getElementById(picker.dataset.bgSource);
-    preview.style.backgroundColor = bgInput ? bgInput.value : '#ffffff';
-    preview.style.color = color;
-    preview.style.fontFamily = font;
-    preview.style.fontSize = size + 'px';
-    preview.style.fontWeight = weight;
-    preview.style.textShadow = `${sx}px ${sy}px ${sb}px ${sc}`;
-  }
-
-  function createTextPickerRow(id,label,bgSource){
-    const row = document.createElement('div');
-    row.className = 'control-row';
-    const labelEl = document.createElement('label');
-    labelEl.textContent = label;
-    row.appendChild(labelEl);
-    const picker = document.createElement('div');
-    picker.className = 'textpicker';
-    picker.id = `${id}-picker`;
-    picker.dataset.bgSource = bgSource;
-    const preview = document.createElement('div');
-    preview.className = 'text-preview';
-    preview.textContent = 'Text';
-    picker.appendChild(preview);
-    const popup = document.createElement('div');
-    popup.className = 'text-popup';
-    const colorInput = document.createElement('input');
-    colorInput.type = 'color';
-    colorInput.id = `${id}-c`;
-    colorInput.setAttribute('data-mode', COLOR_PICKER_MODE);
-    const fontSelect = document.createElement('select');
-    fontSelect.id = `${id}-font`;
-    FONT_OPTIONS.forEach(f=>{ const opt=document.createElement('option'); opt.value=f; opt.textContent=f; fontSelect.appendChild(opt); });
-    const sizeSelect = document.createElement('select');
-    sizeSelect.id = `${id}-size`;
-    FONT_SIZE_OPTIONS.forEach(sz=>{ const opt=document.createElement('option'); opt.value=sz; opt.textContent=`${sz}px`; sizeSelect.appendChild(opt); });
-    const weightSelect = document.createElement('select');
-    weightSelect.id = `${id}-weight`;
-    ['normal','bold'].forEach(w=>{ const opt=document.createElement('option'); opt.value=w; opt.textContent=w.charAt(0).toUpperCase()+w.slice(1); weightSelect.appendChild(opt); });
-    const shadowGroup = document.createElement('div');
-    shadowGroup.className = 'shadow-group';
-    const sc = document.createElement('input'); sc.type='color'; sc.id = `${id}-shadow-color`; sc.setAttribute('data-mode', COLOR_PICKER_MODE);
-    const sx = document.createElement('input'); sx.type='number'; sx.id = `${id}-shadow-x`; sx.value='0'; sx.step='1';
-    const sy = document.createElement('input'); sy.type='number'; sy.id = `${id}-shadow-y`; sy.value='0'; sy.step='1';
-    const sb = document.createElement('input'); sb.type='number'; sb.id = `${id}-shadow-blur`; sb.value='0'; sb.step='1';
-    shadowGroup.append(sc, sx, sy, sb);
-    popup.append(colorInput, fontSelect, sizeSelect, weightSelect, shadowGroup);
-    picker.appendChild(popup);
-    row.appendChild(picker);
-    const update = ()=>{
-      const bg = document.getElementById(picker.dataset.bgSource);
-      preview.style.backgroundColor = bg ? bg.value : '#ffffff';
-      preview.style.color = colorInput.value;
-      preview.style.fontFamily = fontSelect.value;
-      preview.style.fontSize = sizeSelect.value + 'px';
-      preview.style.fontWeight = weightSelect.value;
-      preview.style.textShadow = `${sx.value}px ${sy.value}px ${sb.value}px ${sc.value}`;
-    };
-    [colorInput,fontSelect,sizeSelect,weightSelect,sc,sx,sy,sb].forEach(el=> el.addEventListener('input', update));
-    const bgInput = document.getElementById(picker.dataset.bgSource);
-    bgInput && bgInput.addEventListener('input', update);
-    preview.addEventListener('click', e=>{ e.stopPropagation(); picker.classList.toggle('open'); });
-    popup.addEventListener('click', e=> e.stopPropagation());
-    document.addEventListener('click', e=>{
-      const active = document.activeElement;
-      if(!picker.contains(e.target) && (!active || !picker.contains(active))){
-        picker.classList.remove('open');
-      }
-    });
-    update();
-    return row;
-  }
-
-  function rgbToHex(r,g,b){
-    return '#' + [r,g,b].map(x=>x.toString(16).padStart(2,'0')).join('');
-  }
-
-  function hexToRgba(hex, alpha){
-    const r = parseInt(hex.slice(1,3),16);
-    const g = parseInt(hex.slice(3,5),16);
-    const b = parseInt(hex.slice(5,7),16);
-    return `rgba(${r},${g},${b},${alpha})`;
-  }
-
-  function hexToRgb(hex){
-    const m = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
-    return m ? { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) } : null;
-  }
-
-  function clamp(v){
-    return Math.max(0, Math.min(255, v));
-  }
-
-  function adjust(hex, amt){
-    const rgb = hexToRgb(hex);
-    if(!rgb) return hex;
-    return rgbToHex(clamp(rgb.r + amt), clamp(rgb.g + amt), clamp(rgb.b + amt));
-  }
-
-  function luminance(hex){
-    const rgb = hexToRgb(hex);
-    if(!rgb) return 0;
-    const { r, g, b } = rgb;
-    const a = [r, g, b].map(v => {
-      v /= 255;
-      return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
-    });
-    return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
-  }
-
-  function generateTheme(baseColor){
-    const primary = baseColor;
-    const secondary = adjust(baseColor, 30);
-    const accent = adjust(baseColor, -30);
-    const background = adjust(baseColor, 60);
-    const text = luminance(background) > 0.5 ? '#000000' : '#ffffff';
-    const buttonText = luminance(secondary) > 0.5 ? '#000000' : '#ffffff';
-    const buttonHoverText = luminance(accent) > 0.5 ? '#000000' : '#ffffff';
-    return { primary, secondary, accent, background, text, buttonText, buttonHoverText };
-  }
-
-  function updateFields(theme){
-    Object.entries(theme).forEach(([key,val])=>{
-      const input = document.getElementById(key);
-      if(input) input.value = val;
-    });
-  }
-
-  function spreadTheme(theme){
-    colorAreas.forEach(area=>{
-      const set = (type,val)=>{
-        const el = document.getElementById(`${area.key}-${type}-c`);
-        if(el && val) el.value = val;
-      };
-      set('bg', theme.background);
-      set('text', theme.text);
-      set('weekday', theme.text);
-      set('card', theme.secondary);
-      set('btn', theme.primary);
-      set('btnText', theme.buttonText);
-    });
-    const b = document.getElementById('body-border-c');
-    if(b) b.value = theme.primary;
-    const hb = document.getElementById('body-hoverBorder-c');
-    if(hb) hb.value = theme.accent;
-    const ab = document.getElementById('body-activeBorder-c');
-    if(ab) ab.value = theme.accent;
-    applyAdmin();
-  }
-
-
-  function syncAdminControls(){
-      const themeSelect = document.getElementById('mapTheme');
-      if(themeSelect) themeSelect.value = mapStyle;
-      const skySelect = document.getElementById('skyTheme');
-      if(skySelect) skySelect.value = skyStyle;
-      const pitchInput = document.getElementById('mapPitch');
-      const pitchVal = document.getElementById('pitchVal');
-        if(pitchInput){
-          const p = (map && typeof map.getPitch === 'function')
-            ? map.getPitch()
-            : startPitch;
-        pitchInput.value = p;
-        if(pitchVal) pitchVal.textContent = p.toFixed(0);
-      }
-      const bearingInput = document.getElementById('mapBearing');
-      const bearingVal = document.getElementById('bearingVal');
-        if(bearingInput){
-          const b = (map && typeof map.getBearing === 'function')
-            ? map.getBearing()
-            : startBearing;
-        bearingInput.value = b;
-        if(bearingVal) bearingVal.textContent = b.toFixed(0);
-      }
-      const radiusInput = document.getElementById('clusterRadius');
-      if(radiusInput) radiusInput.value = clusterRadius;
-      const maxZoomInput = document.getElementById('clusterMaxZoom');
-      if(maxZoomInput) maxZoomInput.value = clusterMaxZoom;
-      const iconSelect = document.getElementById('clusterIconType');
-      if(iconSelect) iconSelect.value = clusterIconType;
-      const svgInput = document.getElementById('clusterSvg');
-      const svgRow = document.getElementById('clusterSvgRow');
-      if(svgInput) svgInput.value = clusterSvg;
-      if(svgRow) svgRow.style.display = clusterIconType === 'svg' ? 'flex' : 'none';
-      const calWidthInput = document.getElementById('calendar-width');
-      if(calWidthInput){
-        const w = getComputedStyle(document.documentElement).getPropertyValue('--calendar-width').trim();
-        calWidthInput.value = parseInt(w) || 0;
-      }
-      const calHeightInput = document.getElementById('calendar-height');
-      if(calHeightInput){
-        const h = getComputedStyle(document.documentElement).getPropertyValue('--calendar-height').trim();
-        calHeightInput.value = parseInt(h) || 0;
-      }
-    colorAreas.forEach(area=>{
-      ['bg','card','text','weekday','title','btn','btnText','border','hoverBorder','activeBorder','header','image','optionsMenu','menu','popupBg','popupText'].forEach(type=>{
-        const cInput = document.getElementById(`${area.key}-${type}-c`);
-        const oInput = document.getElementById(`${area.key}-${type}-o`);
-        const fontSel = document.getElementById(`${area.key}-${type}-font`);
-        const sizeSel = document.getElementById(`${area.key}-${type}-size`);
-        const weightSel = document.getElementById(`${area.key}-${type}-weight`);
-        const shColor = document.getElementById(`${area.key}-${type}-shadow-color`);
-        const shX = document.getElementById(`${area.key}-${type}-shadow-x`);
-        const shY = document.getElementById(`${area.key}-${type}-shadow-y`);
-        const shB = document.getElementById(`${area.key}-${type}-shadow-blur`);
-        if(!cInput && !fontSel && !sizeSel && !weightSel && !shColor) return;
-        let selectors = area.selectors[type] || [];
-        if(area.key==='body' && ['border','hoverBorder','activeBorder'].includes(type)){
-          const varMap = {border:'--border', hoverBorder:'--border-hover', activeBorder:'--border-active'};
-          const val = getComputedStyle(document.documentElement).getPropertyValue(varMap[type]).trim();
-          if(type==='hoverBorder' || type==='activeBorder'){
-            if(cInput){
-              if(cInput.dataset.custom === 'true'){
-                if(val){
-                  const match = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-                  if(match){
-                    const r = parseInt(match[1],10);
-                    const g = parseInt(match[2],10);
-                    const bVal = parseInt(match[3],10);
-                    const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
-                    cInput.value = rgbToHex(r,g,bVal);
-                    cInput.placeholder = '';
-                    if(oInput){ oInput.value = alpha; updateOpacityDisplay(oInput); }
-                  }
-                }
-              } else {
-                cInput.value = '';
-                cInput.placeholder = 'default';
-                delete cInput.dataset.custom;
-              }
-            }
-            return;
-          }
-          if(cInput && val){
-            const match = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-            if(match){
-              const r = parseInt(match[1],10);
-              const g = parseInt(match[2],10);
-              const bVal = parseInt(match[3],10);
-              const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
-              cInput.value = rgbToHex(r,g,bVal);
-              if(oInput){ oInput.value = alpha; updateOpacityDisplay(oInput); }
-            }
-          }
-          return;
-        }
-        if((type==='hoverBorder' || type==='activeBorder') && selectors.length===0){
-          selectors = area.selectors.border || [];
-        }
-        let col = null, font = null, size = null, weight = null, shadow = null;
-        selectors.some(sel=>{
-          const cleanSel = sel.replace(/:hover|:active|\[.*?\]/g,'');
-          const el = document.querySelector(cleanSel);
-          if(!el) return false;
-          const cs = getComputedStyle(el);
-          if(cInput){
-            if(type === 'bg' || type === 'btn' || type === 'card' || type === 'header' || type === 'image' || type === 'optionsMenu' || type === 'popupBg') col = cs.backgroundColor;
-            else if(type === 'text' || type === 'btnText' || type === 'title' || type === 'weekday' || type === 'popupText') col = cs.color;
-            else if(type === 'border' || type === 'hoverBorder' || type === 'activeBorder') col = cs.borderColor;
-          }
-          if(fontSel) font = cs.fontFamily.split(',')[0].replace(/"/g,'').trim();
-          if(sizeSel) size = parseInt(cs.fontSize,10);
-          if(weightSel) weight = cs.fontWeight;
-          if(shColor){
-            if(type==='text' || type==='title' || type==='btnText' || type==='weekday' || type==='popupText') shadow = cs.textShadow;
-            else if(type==='card' || type==='btn' || type==='popupBg') shadow = cs.boxShadow;
-          }
-          return true;
-        });
-        if(cInput && col){
-          const match = col.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-          if(match){
-            const r = parseInt(match[1],10);
-            const g = parseInt(match[2],10);
-            const bVal = parseInt(match[3],10);
-            const alpha = match[4] !== undefined ? parseFloat(match[4]) : 1;
-            cInput.value = rgbToHex(r,g,bVal);
-            if((type==='bg' || type==='card' || type==='header' || type==='image' || type==='border' || type==='hoverBorder' || type==='activeBorder' || type==='optionsMenu' || type==='popupBg') && oInput){ oInput.value = alpha; updateOpacityDisplay(oInput); }
-          }
-        }
-        if(fontSel && font){
-          fontSel.value = FONT_OPTIONS.includes(font) ? font : FONT_OPTIONS[0];
-        }
-        if(sizeSel && size){
-          sizeSel.value = String(size);
-        }
-        if(weightSel && weight){
-          weightSel.value = parseInt(weight,10) >= 600 ? 'bold' : 'normal';
-        }
-        if(shColor && shadow && shadow !== 'none'){
-          if(type==='text' || type==='title' || type==='btnText' || type==='weekday'){
-            const m = shadow.match(/(-?\d+)px\s+(-?\d+)px\s+(-?\d+)px\s+rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-            if(m){
-              shX.value = m[1];
-              shY.value = m[2];
-              shB.value = m[3];
-              shColor.value = rgbToHex(parseInt(m[4],10),parseInt(m[5],10),parseInt(m[6],10));
-            }
-          } else {
-            const m = shadow.match(/0px\s+0px\s+(\d+)px\s+rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-            if(m){
-              shB.value = m[1];
-              shColor.value = rgbToHex(parseInt(m[2],10),parseInt(m[3],10),parseInt(m[4],10));
-            }
-          }
-        }
-      });
-      ['hoverAdjust','activeAdjust'].forEach(type=>{
-        const v = document.getElementById(`${area.key}-${type}`);
-        if(v && currentState[`${area.key}-${type}`]){
-          v.value = currentState[`${area.key}-${type}`].value;
-        }
-      });
-      ['text','title','btnText','weekday','popupText'].forEach(t=> updateTextPicker(area.key, t));
-    });
-    const cpFont = document.getElementById('controlPlaceholder-text-font');
-    const cpSize = document.getElementById('controlPlaceholder-text-size');
-    if(cpFont){
-      const val = getComputedStyle(document.documentElement).getPropertyValue('--control-placeholder-font').trim().replace(/"/g,'');
-      cpFont.value = FONT_OPTIONS.includes(val) ? val : FONT_OPTIONS[0];
-    }
-    if(cpSize){
-      const val = getComputedStyle(document.documentElement).getPropertyValue('--control-placeholder-size').trim();
-      cpSize.value = parseInt(val) || cpSize.value;
-    }
-    ['panelText','placeholder','filterPlaceholder','dropdownSelectedText','dropdownText','dropdownHoverText','dropdownVenueText','dateRangeText','controlPlaceholder','popupText'].forEach(id=> updateTextPicker(id,'text'));
-    const varMap = {btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',popupBg:'--popup-bg',popupText:'--popup-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg'};
-    Object.entries(varMap).forEach(([id,varName])=>{
-      const cInput = document.getElementById(`${id}-c`) || document.getElementById(`${id}-text-c`) || document.getElementById(id);
-      const oInput = document.getElementById(`${id}-o`);
-      if(cInput){
-        const val = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
-        if(val){
-          const match = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-          if(match){
-            cInput.value = rgbToHex(parseInt(match[1],10),parseInt(match[2],10),parseInt(match[3],10));
-            if(oInput){ oInput.value = match[4] !== undefined ? parseFloat(match[4]) : 1; updateOpacityDisplay(oInput); }
-          }
-        }
-      }
-    });
-    const stickyHeaderInput = document.getElementById('open-posts-sticky-header');
-    if(stickyHeaderInput){
-      const state = currentState['open-posts-sticky-header'];
-      stickyHeaderInput.checked = state ? state.value === '1' : true;
-      document.documentElement.classList.toggle('open-posts-sticky-header', stickyHeaderInput.checked);
-      stickyHeaderInput.addEventListener('change', () => {
-        document.documentElement.classList.toggle('open-posts-sticky-header', stickyHeaderInput.checked);
-        const data = collectThemeValues();
-        currentState = JSON.parse(JSON.stringify(data));
-        localStorage.setItem('currentTheme', JSON.stringify(data));
-        updateHistoryButtons();
-      });
-    }
-    const stickyImageInput = document.getElementById('open-posts-sticky-images');
-    if(stickyImageInput){
-      const state = currentState['open-posts-sticky-images'];
-      stickyImageInput.checked = state ? state.value === '1' : true;
-      if (typeof updateStickyImages === 'function') {
-        updateStickyImages();
-      }
-      stickyImageInput.addEventListener('change', () => {
-        if (typeof updateStickyImages === 'function') {
-          updateStickyImages();
-        }
-        const data = collectThemeValues();
-        currentState = JSON.parse(JSON.stringify(data));
-        localStorage.setItem('currentTheme', JSON.stringify(data));
-        updateHistoryButtons();
-      });
-    }
-  }
-
-  function buildStyleControls(){
-    const wrap = document.getElementById('styleControls');
-    if(!wrap) return;
-    colorAreas.forEach(area=>{
-      const fs = document.createElement('fieldset');
-      fs.className = 'admin-fieldset collapsed';
-      fs.id = `${area.key}-fieldset`;
-      fs.dataset.key = area.key;
-      fs.addEventListener('click',()=>{ lastFieldsetKey = area.key; });
-      fs.addEventListener('input',()=>{ lastFieldsetKey = area.key; });
-      const lg = document.createElement('legend');
-      lg.textContent = area.label;
-      lg.addEventListener('click', (e)=>{ e.preventDefault(); fs.classList.toggle('collapsed'); });
-      fs.appendChild(lg);
-      const btnRow = document.createElement('div');
-      btnRow.className = 'fieldset-actions';
-      const colBtn = document.createElement('button');
-      colBtn.type = 'button';
-      colBtn.textContent = '=Col';
-      colBtn.className = 'same-btn';
-      colBtn.addEventListener('click', (e)=>{
-        e.stopPropagation();
-        if(!lastFieldsetKey || lastFieldsetKey === area.key) return;
-        ['bg','card','btn','border','hoverBorder','activeBorder','header','image','optionsMenu','popupBg'].forEach(type=>{
-          const fromC = document.getElementById(`${lastFieldsetKey}-${type}-c`);
-          const fromO = document.getElementById(`${lastFieldsetKey}-${type}-o`);
-          const toC = document.getElementById(`${area.key}-${type}-c`);
-          const toO = document.getElementById(`${area.key}-${type}-o`);
-          if(fromC && toC){ toC.value = fromC.value; }
-          if(fromO && toO){ toO.value = fromO.value; }
-        });
-        ['hoverAdjust','activeAdjust'].forEach(type=>{
-          const fromV = document.getElementById(`${lastFieldsetKey}-${type}`);
-          const toV = document.getElementById(`${area.key}-${type}`);
-          if(fromV && toV){ toV.value = fromV.value; }
-        });
-        ['text','title','btnText','weekday','popupText'].forEach(t=> updateTextPicker(area.key, t));
-        applyAdmin();
-      });
-      const txtBtn = document.createElement('button');
-      txtBtn.type = 'button';
-      txtBtn.textContent = '=Txt';
-      txtBtn.className = 'same-btn';
-      txtBtn.addEventListener('click', (e)=>{
-        e.stopPropagation();
-        if(!lastFieldsetKey || lastFieldsetKey === area.key) return;
-        ['text','title','btnText','weekday','popupText'].forEach(type=>{
-          const fields = ['c','font','size','weight','shadow-color','shadow-x','shadow-y','shadow-blur'];
-          fields.forEach(suf=>{
-            const from = document.getElementById(`${lastFieldsetKey}-${type}-${suf}`);
-            const to = document.getElementById(`${area.key}-${type}-${suf}`);
-            if(from && to){ to.value = from.value; }
-          });
-          updateTextPicker(area.key, type);
-        });
-        applyAdmin();
-      });
-      btnRow.appendChild(colBtn);
-      btnRow.appendChild(txtBtn);
-      fs.appendChild(btnRow);
-      const types = [];
-      if(area.selectors.bg) types.push('bg');
-      if(area.selectors.card) types.push('card');
-      if(area.selectors.text) types.push('text');
-      if(area.selectors.popupBg) types.push('popupBg');
-      if(area.selectors.popupText) types.push('popupText');
-      if(area.selectors.weekday) types.push('weekday');
-      if(area.selectors.title) types.push('title');
-      if(area.selectors.btn) types.push('btn','btnText');
-      if(area.selectors.border) types.push('border');
-      if(area.selectors.hoverBorder) types.push('hoverAdjust','hoverBorder');
-      if(area.selectors.activeBorder) types.push('activeAdjust','activeBorder');
-      if(area.selectors.header) types.push('header');
-      if(area.selectors.image) types.push('image');
-      if(area.selectors.optionsMenu) types.push('optionsMenu');
-      if(area.selectors.menu) types.push('menu');
-        types.forEach(type=>{
-          const labelMap = {
-            bg: 'Background',
-            card: 'Card',
-            text: 'Text',
-            weekday: 'Weekday Text',
-            title: 'Title',
-            btn: 'Button',
-            btnText: 'Button Text',
-            border: 'Border',
-            hoverBorder: 'Hover Border',
-            activeBorder: 'Active Border',
-            hoverAdjust: 'Hover Brightness',
-            activeAdjust: 'Active Brightness',
-            header: 'Header',
-            image: 'Image Box',
-            optionsMenu: 'Options Menu',
-            menu: 'Menu Background',
-            popupBg: 'Marker Popup Background',
-            popupText: 'Marker Popup Text'
-          };
-          let label = labelMap[type] || type;
-          if(area.key === 'calendar' && type === 'text') label = 'Date Text';
-        if(type === 'text' || type === 'title' || type === 'btnText' || type === 'weekday' || type === 'popupText'){
-          const row = document.createElement('div');
-          row.className = 'control-row';
-          const labelEl = document.createElement('label');
-          labelEl.textContent = label;
-          row.appendChild(labelEl);
-          const picker = document.createElement('div');
-          picker.className = 'textpicker';
-          picker.id = `${area.key}-${type}-picker`;
-          let bgKey = TEXT_BG_MAP[type];
-          if(type === 'text' && ['list','closed-posts','open-posts','footer','map'].includes(area.key)){
-            bgKey = 'card';
-          }
-          picker.dataset.bgSource = `${area.key}-${bgKey}-c`;
-          const preview = document.createElement('div');
-          preview.className = 'text-preview';
-          preview.textContent = 'Text';
-          picker.appendChild(preview);
-          const popup = document.createElement('div');
-          popup.className = 'text-popup';
-          const colorInput = document.createElement('input');
-          colorInput.type = 'color';
-          colorInput.id = `${area.key}-${type}-c`;
-          colorInput.setAttribute('data-mode', COLOR_PICKER_MODE);
-          const fontSelect = document.createElement('select');
-          fontSelect.className = 'font-select';
-          fontSelect.id = `${area.key}-${type}-font`;
-          FONT_OPTIONS.forEach(f=>{ const opt = document.createElement('option'); opt.value = f; opt.textContent = f; fontSelect.appendChild(opt); });
-          const sizeSelect = document.createElement('select');
-          sizeSelect.className = 'font-size-select';
-          sizeSelect.id = `${area.key}-${type}-size`;
-          FONT_SIZE_OPTIONS.forEach(sz=>{ const opt = document.createElement('option'); opt.value = sz; opt.textContent = `${sz}px`; sizeSelect.appendChild(opt); });
-          const weightSelect = document.createElement('select');
-          weightSelect.className = 'font-weight-select';
-          weightSelect.id = `${area.key}-${type}-weight`;
-          ['normal','bold'].forEach(w=>{ const opt = document.createElement('option'); opt.value = w; opt.textContent = w.charAt(0).toUpperCase()+w.slice(1); weightSelect.appendChild(opt); });
-          const shadowGroup = document.createElement('div');
-          shadowGroup.className = 'shadow-group';
-          const sc = document.createElement('input'); sc.type='color'; sc.id = `${area.key}-${type}-shadow-color`; sc.setAttribute('data-mode', COLOR_PICKER_MODE);
-          const sx = document.createElement('input'); sx.type='number'; sx.id = `${area.key}-${type}-shadow-x`; sx.value='0'; sx.step='1';
-          const sy = document.createElement('input'); sy.type='number'; sy.id = `${area.key}-${type}-shadow-y`; sy.value='0'; sy.step='1';
-          const sb = document.createElement('input'); sb.type='number'; sb.id = `${area.key}-${type}-shadow-blur`; sb.value='0'; sb.step='1';
-          shadowGroup.append(sc, sx, sy, sb);
-          popup.append(colorInput, fontSelect, sizeSelect, weightSelect, shadowGroup);
-          picker.appendChild(popup);
-          row.appendChild(picker);
-          fs.appendChild(row);
-          const update = ()=>updateTextPicker(area.key, type);
-          [colorInput,fontSelect,sizeSelect,weightSelect,sc,sx,sy,sb].forEach(el=> el.addEventListener('input', update));
-          const bgInput = document.getElementById(picker.dataset.bgSource);
-          bgInput && bgInput.addEventListener('input', update);
-          preview.addEventListener('click', e=>{ e.stopPropagation(); picker.classList.toggle('open'); });
-          popup.addEventListener('click', e=> e.stopPropagation());
-          document.addEventListener('click', e=>{
-            const active = document.activeElement;
-            if(!picker.contains(e.target) && (!active || !picker.contains(active))){
-              picker.classList.remove('open');
-            }
-          });
-          update();
-          return;
-        }
-        const row = document.createElement('div');
-        row.className = 'control-row';
-        if(type === 'bg' || type === 'card' || type === 'border' || type === 'hoverBorder' || type === 'activeBorder' || type === 'header' || type === 'image' || type === 'optionsMenu' || type === 'menu' || type === 'popupBg'){
-          row.innerHTML = `
-              <label>${label}</label>
-              <div class="color-group">
-                <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-                <div class="range-group">
-                  <input id="${area.key}-${type}-o" type="range" min="0" max="1" step="0.01" value="1" />
-                  <span id="${area.key}-${type}-o-v">1.00</span>
-                </div>
-              </div>
-            `;
-        } else if(type === 'hoverAdjust' || type === 'activeAdjust'){
-          row.innerHTML = `
-              <label>${label}</label>
-              <div class="color-group">
-                <input id="${area.key}-${type}" type="range" min="-50" max="50" step="1" value="0" />
-              </div>
-            `;
-        } else {
-          row.innerHTML = `
-              <label>${label}</label>
-              <div class="color-group">
-                <input id="${area.key}-${type}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              </div>
-            `;
-        }
-        fs.appendChild(row);
-        if(type === 'card' || type === 'btn'){
-          const shadowRow = document.createElement('div');
-          shadowRow.className = 'control-row';
-          shadowRow.innerHTML = `
-              <label>Shadow</label>
-              <div class="color-group">
-                <input id="${area.key}-${type}-shadow-color" type="color" data-mode="${COLOR_PICKER_MODE}" />
-                <input id="${area.key}-${type}-shadow-blur" type="range" min="0" max="50" step="1" value="0" />
-              </div>
-            `;
-          fs.appendChild(shadowRow);
-        }
-      });
-      if(area.key === 'open-posts'){
-        fs.appendChild(createTextPickerRow('dropdownVenueText-text','Venue Button Text','open-posts-menu-c'));
-        const stickyHeaderRow = document.createElement('div');
-        stickyHeaderRow.className = 'control-row';
-        stickyHeaderRow.innerHTML = `
-            <label>Sticky Header</label>
-            <label class="switch">
-              <input id="open-posts-sticky-header" type="checkbox" checked />
-              <span class="slider"></span>
-            </label>
-        `;
-        fs.appendChild(stickyHeaderRow);
-        const stickyImageRow = document.createElement('div');
-        stickyImageRow.className = 'control-row';
-        stickyImageRow.innerHTML = `
-            <label>Sticky Images</label>
-            <label class="switch">
-              <input id="open-posts-sticky-images" type="checkbox" checked />
-              <span class="slider"></span>
-            </label>
-        `;
-        fs.appendChild(stickyImageRow);
-      }
-      if(area.key === 'map'){
-        const textBg = document.createElement('div');
-        textBg.className = 'control-row';
-        textBg.innerHTML = `
-            <label>Control Text Background</label>
-            <div class="color-group">
-              <input id="controlTextBg-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-            </div>`;
-        fs.appendChild(textBg);
-        fs.appendChild(createTextPickerRow('controlPlaceholder-text','Control Placeholder Text','controlTextBg-c'));
-        const geoBg = document.createElement('div');
-        geoBg.className = 'control-row';
-        geoBg.innerHTML = `
-            <label>Geolocate Button Background</label>
-            <div class="color-group">
-              <input id="geoBtnBg-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-            </div>`;
-        fs.appendChild(geoBg);
-        const compassBg = document.createElement('div');
-        compassBg.className = 'control-row';
-        compassBg.innerHTML = `
-            <label>Compass Button Background</label>
-            <div class="color-group">
-              <input id="compassBtnBg-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-            </div>`;
-        fs.appendChild(compassBg);
-        const clearBg = document.createElement('div');
-        clearBg.className = 'control-row';
-        clearBg.innerHTML = `
-            <label>Clear X Button Background</label>
-            <div class="color-group">
-              <input id="clearBtnBg-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              <div class="range-group">
-                <input id="clearBtnBg-o" type="range" min="0" max="1" step="0.01" value="0" />
-                <span id="clearBtnBg-o-v">0.00</span>
-              </div>
-            </div>`;
-        fs.appendChild(clearBg);
-      }
-      if(area.key === 'filter'){
-        fs.appendChild(createTextPickerRow('filterPlaceholder-text','Keyword Placeholder','btn-c'));
-        const kwBg = document.createElement('div');
-        kwBg.className = 'control-row';
-        kwBg.innerHTML = `
-            <label>Keyword Background</label>
-            <div class="color-group">
-              <input id="keywordBg-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              <div class="range-group">
-                <input id="keywordBg-o" type="range" min="0" max="1" step="0.01" value="1" />
-                <span id="keywordBg-o-v">1.00</span>
-              </div>
-            </div>
-          `;
-        fs.appendChild(kwBg);
-        const dateBg = document.createElement('div');
-        dateBg.className = 'control-row';
-        dateBg.innerHTML = `
-            <label>Date Range Background</label>
-            <div class="color-group">
-              <input id="dateRangeBg-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              <div class="range-group">
-                <input id="dateRangeBg-o" type="range" min="0" max="1" step="0.01" value="1" />
-                <span id="dateRangeBg-o-v">1.00</span>
-              </div>
-            </div>
-          `;
-        fs.appendChild(dateBg);
-        fs.appendChild(createTextPickerRow('dateRangeText-text','Date Range Text','dateRangeBg-c'));
-      }
-      if(area.key === 'calendar'){
-        const widthRow = document.createElement('div');
-        widthRow.className = 'control-row';
-        widthRow.innerHTML = `
-            <label>Width</label>
-            <input id="calendar-width" type="number" value="300" />`;
-        fs.appendChild(widthRow);
-        const heightRow = document.createElement('div');
-        heightRow.className = 'control-row';
-        heightRow.innerHTML = `
-            <label>Height</label>
-            <input id="calendar-height" type="number" value="250" />`;
-        fs.appendChild(heightRow);
-        const availRow = document.createElement('div');
-        availRow.className = 'control-row';
-        availRow.innerHTML = `
-            <label>Available Day</label>
-            <div class="color-group">
-              <input id="sessionAvailable-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-            </div>`;
-        fs.appendChild(availRow);
-        const selRow = document.createElement('div');
-        selRow.className = 'control-row';
-        selRow.innerHTML = `
-            <label>Selected Day</label>
-            <div class="color-group">
-              <input id="sessionSelected-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-            </div>`;
-        fs.appendChild(selRow);
-        const todayRow = document.createElement('div');
-        todayRow.className = 'control-row';
-        todayRow.innerHTML = `
-            <label>Today</label>
-            <div class="color-group">
-              <input id="today-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-            </div>`;
-        fs.appendChild(todayRow);
-      }
-      wrap.appendChild(fs);
-    });
-    const misc = document.createElement('fieldset');
-    misc.className = 'admin-fieldset collapsed';
-    misc.id = 'misc-fieldset';
-    const miscLg = document.createElement('legend');
-    miscLg.textContent = 'Miscellaneous';
-    miscLg.addEventListener('click', (e)=>{ e.preventDefault(); misc.classList.toggle('collapsed'); });
-    misc.appendChild(miscLg);
-    const miscColors = [
-      {id:'btn', label:'Button Base'},
-      {id:'panelBg', label:'Panel Background'},
-      {id:'scrollbarTrack', label:'Scrollbar Track'},
-      {id:'scrollbarThumb', label:'Scrollbar Thumb'},
-      {id:'scrollbarThumbHover', label:'Scrollbar Thumb Hover'},
-      {id:'listBackground', label:'List Background'},
-      {id:'closedCardBg', label:'Closed Post Background'}
-    ];
-    miscColors.forEach(p=>{
-      const row = document.createElement('div');
-      row.className = 'control-row';
-      row.innerHTML = `
-            <label>${p.label}</label>
-            <div class="color-group">
-              <input id="${p.id}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              <div class="range-group">
-                <input id="${p.id}-o" type="range" min="0" max="1" step="0.01" value="1" />
-                <span id="${p.id}-o-v">1.00</span>
-              </div>
-            </div>
-          `;
-      misc.appendChild(row);
-    });
-    misc.appendChild(createTextPickerRow('panelText-text','Image Popup Text','panelBg-c'));
-    misc.appendChild(createTextPickerRow('placeholder-text','Placeholder Text','btn-c'));
-    wrap.appendChild(misc);
-    const dropdown = document.createElement('fieldset');
-    dropdown.className = 'admin-fieldset collapsed';
-    dropdown.id = 'dropdown-fieldset';
-    const ddLg = document.createElement('legend');
-    ddLg.textContent = 'Dropdown Boxes';
-    ddLg.addEventListener('click', (e)=>{ e.preventDefault(); dropdown.classList.toggle('collapsed'); });
-    dropdown.appendChild(ddLg);
-    const ddColors = [
-      {id:'dropdownTitle', label:'Title'},
-      {id:'dropdownSelectedBg', label:'Selected Background', opacity:true},
-      {id:'dropdownBg', label:'Background', opacity:true},
-      {id:'dropdownHoverBg', label:'Hover Background', opacity:true}
-    ];
-    ddColors.forEach(f=>{
-      const row = document.createElement('div');
-      row.className = 'control-row';
-      row.innerHTML = `
-            <label>${f.label}</label>
-            <div class="color-group">
-              <input id="${f.id}-c" type="color" data-mode="${COLOR_PICKER_MODE}" />
-              ${f.opacity ? `<div class="range-group"><input id="${f.id}-o" type="range" min="0" max="1" step="0.01" value="1" /><span id="${f.id}-o-v">1.00</span></div>` : ''}
-            </div>
-          `;
-      dropdown.appendChild(row);
-    });
-    dropdown.appendChild(createTextPickerRow('dropdownSelectedText-text','Selected Text','dropdownSelectedBg-c'));
-    dropdown.appendChild(createTextPickerRow('dropdownText-text','Text','dropdownBg-c'));
-    dropdown.appendChild(createTextPickerRow('dropdownHoverText-text','Hover Text','dropdownHoverBg-c'));
-    wrap.appendChild(dropdown);
-  }
-
-  function updateOpacityDisplay(el){
-    const v = document.getElementById(`${el.id}-v`);
-    if(v) v.textContent = parseFloat(el.value).toFixed(2);
-  }
-
-  function applyAdmin(targetInput){
-    if(targetInput){
-      if(targetInput.type === 'range' && targetInput.id && targetInput.id.endsWith('-o')) updateOpacityDisplay(targetInput);
-      undoStack.push(JSON.parse(JSON.stringify(currentState)));
-      redoStack.length = 0;
-    }
-    if(targetInput && targetInput.id){
-      const [areaKey, type] = targetInput.id.split('-');
-      if(areaKey === 'body' && ['border','hoverBorder','activeBorder'].includes(type)){
-        const colorInput = document.getElementById(`${areaKey}-${type}-c`);
-        const opacityInput = document.getElementById(`${areaKey}-${type}-o`);
-        if((type==='hoverBorder' || type==='activeBorder') && colorInput && colorInput.dataset.custom !== 'true' && !targetInput.id.endsWith('-c')){
-          // not a custom override; allow sliders to handle
-        } else {
-          const color = colorInput ? colorInput.value : '#ffffff';
-          const opacity = opacityInput ? opacityInput.value : 1;
-          const varMap = {border:'--border', hoverBorder:'--border-hover', activeBorder:'--border-active'};
-          document.documentElement.style.setProperty(varMap[type], hexToRgba(color, opacity));
-          if(colorInput && (type==='hoverBorder' || type==='activeBorder')){
-            if(targetInput.id.endsWith('-c') || (targetInput.id.endsWith('-o') && colorInput.value)){
-              colorInput.dataset.custom = 'true';
-            }
-          }
-          const data = collectThemeValues();
-          currentState = JSON.parse(JSON.stringify(data));
-          localStorage.setItem('currentTheme', JSON.stringify(data));
-          syncAdminControls();
-          updateHistoryButtons();
-          return;
-        }
-      }
-    }
-    ['border','hoverBorder','activeBorder'].forEach(type=>{
-      const c = document.getElementById(`body-${type}-c`);
-      const o = document.getElementById(`body-${type}-o`);
-      if(c){
-        if((type==='hoverBorder' || type==='activeBorder') && c.dataset.custom !== 'true') return;
-        const rgba = hexToRgba(c.value, o ? o.value : 1);
-        const varMap = {border:'--border', hoverBorder:'--border-hover', activeBorder:'--border-active'};
-        document.documentElement.style.setProperty(varMap[type], rgba);
-      }
-    });
-    const borderC = document.getElementById('body-border-c');
-    const borderO = document.getElementById('body-border-o');
-    const baseColor = borderC ? borderC.value : '#ffffff';
-    const baseOpacity = borderO ? borderO.value : 1;
-    const hoverAdj = document.getElementById('body-hoverAdjust');
-    const hoverColorInput = document.getElementById('body-hoverBorder-c');
-    if(hoverAdj && (!hoverColorInput || hoverColorInput.dataset.custom !== 'true')){
-      const col = adjust(baseColor, parseInt(hoverAdj.value,10)||0);
-      document.documentElement.style.setProperty('--border-hover', hexToRgba(col, baseOpacity));
-    }
-    const activeAdj = document.getElementById('body-activeAdjust');
-    const activeColorInput = document.getElementById('body-activeBorder-c');
-    if(activeAdj && (!activeColorInput || activeColorInput.dataset.custom !== 'true')){
-      const col = adjust(baseColor, parseInt(activeAdj.value,10)||0);
-      document.documentElement.style.setProperty('--border-active', hexToRgba(col, baseOpacity));
-    }
-    const varMap = {btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',popupBg:'--popup-bg',popupText:'--popup-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg',controlPlaceholderFont:'--control-placeholder-font',controlPlaceholderSize:'--control-placeholder-size'};
-    Object.entries(varMap).forEach(([id,varName])=>{
-      if(id==='controlPlaceholderFont'){
-        const f = document.getElementById('controlPlaceholder-text-font');
-        if(f) document.documentElement.style.setProperty(varName, f.value);
-        return;
-      }
-      if(id==='controlPlaceholderSize'){
-        const s = document.getElementById('controlPlaceholder-text-size');
-        if(s) document.documentElement.style.setProperty(varName, s.value + 'px');
-        return;
-      }
-      const c = document.getElementById(`${id}-c`) || document.getElementById(`${id}-text-c`) || document.getElementById(id);
-      const o = document.getElementById(`${id}-o`);
-      if(c){
-        const color = c.value;
-        const opacity = o ? o.value : 1;
-        document.documentElement.style.setProperty(varName, hexToRgba(color, opacity));
-      }
-    });
-    const calW = document.getElementById('calendar-width');
-    const calH = document.getElementById('calendar-height');
-    if(calW){ document.documentElement.style.setProperty('--calendar-width', `${calW.value}px`); }
-    if(calH){ document.documentElement.style.setProperty('--calendar-height', `${calH.value}px`); }
-    colorAreas.forEach(area=>{
-      ['bg','card','text','weekday','title','btn','btnText','header','image','optionsMenu','menu','popupBg','popupText'].forEach(type=>{
-        const c = document.getElementById(`${area.key}-${type}-c`);
-        const o = document.getElementById(`${area.key}-${type}-o`);
-        const f = document.getElementById(`${area.key}-${type}-font`);
-        const s = document.getElementById(`${area.key}-${type}-size`);
-        const w = document.getElementById(`${area.key}-${type}-weight`);
-        const sc = document.getElementById(`${area.key}-${type}-shadow-color`);
-        const sx = document.getElementById(`${area.key}-${type}-shadow-x`);
-        const sy = document.getElementById(`${area.key}-${type}-shadow-y`);
-        const sb = document.getElementById(`${area.key}-${type}-shadow-blur`);
-        if(!c && !f && !s && !w && !sc) return;
-        const color = c ? c.value : null;
-        const opacity = o ? o.value : 1;
-        const font = f ? f.value : null;
-        const size = s ? s.value : null;
-        const weight = w ? w.value : null;
-        if(area.key==='imagePanel' && type==='bg'){
-          if(color){
-            document.documentElement.style.setProperty('--image-panel-bg', hexToRgba(color, opacity));
-            document.querySelectorAll('.img-popup').forEach(el=>el.style.removeProperty('background-color'));
-          }
-          return;
-        }
-        const targets = area.selectors[type] || [];
-        targets.forEach(sel=>{
-          document.querySelectorAll(sel).forEach(el=>{
-            if(type==='bg' || type==='card' || type==='header' || type==='image' || type==='optionsMenu' || type==='popupBg'){
-              if(color) el.style.backgroundColor = hexToRgba(color, opacity);
-              if(type==='card' || type==='popupBg'){
-                const shadowColor = sc ? sc.value : null;
-                const blur = sb ? sb.value : 0;
-                if(shadowColor) el.style.boxShadow = `0 0 ${blur}px ${shadowColor}`;
-              }
-            } else if(type==='text' || type==='btnText' || type==='title' || type==='weekday' || type==='popupText'){
-              if(color) el.style.color = color;
-              if(font) el.style.fontFamily = font;
-              if(size) el.style.fontSize = `${size}px`;
-              if(weight) el.style.fontWeight = weight;
-              if(sc){
-                const x = sx ? sx.value : 0;
-                const y = sy ? sy.value : 0;
-                const blur = sb ? sb.value : 0;
-                el.style.textShadow = `${x}px ${y}px ${blur}px ${sc.value}`;
-              }
-            } else if(type==='btn'){
-              if(color){
-                el.style.backgroundColor = color;
-                el.style.borderColor = color;
-              }
-              const shadowColor = sc ? sc.value : null;
-              const blur = sb ? sb.value : 0;
-              if(shadowColor) el.style.boxShadow = `0 0 ${blur}px ${shadowColor}`;
-            }
-          });
-        });
-        if(type==='text'){
-          restoreTitleDefaults(area);
-        }
-      });
-    });
-    const stickyHeader = document.getElementById('open-posts-sticky-header');
-    document.documentElement.classList.toggle('open-posts-sticky-header', stickyHeader && stickyHeader.checked);
-    const stickyImages = document.getElementById('open-posts-sticky-images');
-    document.documentElement.classList.toggle('open-posts-sticky-images', stickyImages && stickyImages.checked);
-    const data = collectThemeValues();
-    currentState = JSON.parse(JSON.stringify(data));
-    localStorage.setItem('currentTheme', JSON.stringify(data));
-    syncAdminControls();
-    updateHistoryButtons();
-  }
-
-  function collectThemeValues(){
-    const data = {};
-    colorAreas.forEach(area=>{
-      ['bg','card','text','weekday','title','btn','btnText','border','hoverBorder','activeBorder','hoverAdjust','activeAdjust','header','image','optionsMenu','menu','popupBg','popupText'].forEach(type=>{
-        const c = document.getElementById(`${area.key}-${type}-c`);
-        const o = document.getElementById(`${area.key}-${type}-o`);
-        const f = document.getElementById(`${area.key}-${type}-font`);
-        const s = document.getElementById(`${area.key}-${type}-size`);
-        const w = document.getElementById(`${area.key}-${type}-weight`);
-        const sc = document.getElementById(`${area.key}-${type}-shadow-color`);
-        const sx = document.getElementById(`${area.key}-${type}-shadow-x`);
-        const sy = document.getElementById(`${area.key}-${type}-shadow-y`);
-        const sb = document.getElementById(`${area.key}-${type}-shadow-blur`);
-        const v = document.getElementById(`${area.key}-${type}`);
-        if(c || f || s || v || w || sc){
-          const entry = {};
-          if(c && (!(['hoverBorder','activeBorder'].includes(type)) || c.dataset.custom === 'true') && c.value){
-            entry.color = c.value;
-          }
-          if((['bg','card','border','hoverBorder','activeBorder','optionsMenu'].includes(type)) && o && (!(['hoverBorder','activeBorder'].includes(type)) || (c && c.dataset.custom === 'true'))){
-            entry.opacity = o.value;
-          }
-          if(v){ entry.value = v.value; }
-          if(f){ entry.font = f.value; }
-          if(s){ entry.size = s.value; }
-          if(w){ entry.weight = w.value; }
-          if(sc){
-            entry.shadow = { color: sc.value };
-            if(sx) entry.shadow.x = sx.value;
-            if(sy) entry.shadow.y = sy.value;
-            if(sb) entry.shadow.blur = sb.value;
-          }
-          if(Object.keys(entry).length){
-            data[`${area.key}-${type}`] = entry;
-          }
-        }
-      });
-    });
-    const stickyHeader = document.getElementById('open-posts-sticky-header');
-    if(stickyHeader){ data['open-posts-sticky-header'] = { value: stickyHeader.checked ? '1' : '0' }; }
-    const stickyImages = document.getElementById('open-posts-sticky-images');
-    if(stickyImages){ data['open-posts-sticky-images'] = { value: stickyImages.checked ? '1' : '0' }; }
-    ['primary','secondary','accent'].forEach(id=>{
-      const val = getComputedStyle(document.documentElement).getPropertyValue(`--${id}`).trim();
-      if(val){
-        const match = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
-        if(match){
-          data[id] = { color: rgbToHex(parseInt(match[1],10),parseInt(match[2],10),parseInt(match[3],10)) };
-        } else {
-          data[id] = { color: val };
-        }
-      }
-    });
-    ['btn','panelBg','scrollbarTrack','scrollbarThumb','scrollbarThumbHover','listBackground','closedCardBg','dropdownBg','dropdownSelectedBg','dropdownHoverBg','keywordBg','dateRangeBg','sessionAvailable','sessionSelected','today','controlTextBg','popupBg','popupText','geoBtnBg','compassBtnBg','clearBtnBg'].forEach(id=>{
-      const c = document.getElementById(`${id}-c`);
-      const o = document.getElementById(`${id}-o`);
-      if(c){
-        data[id] = { color: c.value };
-        if(o) data[id].opacity = o.value;
-      }
-    });
-    ['dropdownTitle','panelText','placeholder','filterPlaceholder','dropdownSelectedText','dropdownText','dropdownHoverText','dropdownVenueText','dateRangeText','controlPlaceholder'].forEach(id=>{
-      const c = document.getElementById(`${id}-text-c`) || document.getElementById(`${id}-c`);
-      const f = document.getElementById(`${id}-text-font`);
-      const s = document.getElementById(`${id}-text-size`);
-      if(c || f || s){
-        data[id] = {};
-        if(c && c.value) data[id].color = c.value;
-        if(f && f.value) data[id].font = f.value;
-        if(s && s.value) data[id].size = s.value;
-      }
-    });
-    const calWidth = document.getElementById('calendar-width');
-    if(calWidth){ data['calendar-width'] = { value: calWidth.value }; }
-    const calHeight = document.getElementById('calendar-height');
-    if(calHeight){ data['calendar-height'] = { value: calHeight.value }; }
-    return data;
-  }
-
-  function generateCss(data){
-    const varNames = {primary:'--primary',secondary:'--secondary',accent:'--accent',btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',popupBg:'--popup-bg',popupText:'--popup-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg',border:'--border',hoverBorder:'--border-hover',activeBorder:'--border-active'};
-    let css = '';
-    const rootVars = [];
-    Object.entries(varNames).forEach(([key,varName])=>{
-      if(['border','hoverBorder','activeBorder'].includes(key)) return;
-      const entry = data[key];
-      if(entry && entry.color){
-        const color = entry.opacity!==undefined ? hexToRgba(entry.color, entry.opacity) : entry.color;
-        rootVars.push(`${varName}:${color};`);
-      }
-    });
-    ['border','hoverBorder','activeBorder'].forEach(type=>{
-      const entry = data[`body-${type}`];
-      if(entry && entry.color){
-        const color = entry.opacity!==undefined ? hexToRgba(entry.color, entry.opacity) : entry.color;
-        rootVars.push(`${varNames[type]}:${color};`);
-      }
-    });
-    const baseBorder = data['body-border'];
-    if(baseBorder){
-      const hoverAdj = data['body-hoverAdjust'];
-      if(hoverAdj && !data['body-hoverBorder']){
-        const adj = adjust(baseBorder.color, parseInt(hoverAdj.value,10)||0);
-        const col = baseBorder.opacity!==undefined ? hexToRgba(adj, baseBorder.opacity) : adj;
-        rootVars.push(`--border-hover:${col};`);
-      }
-      const activeAdj = data['body-activeAdjust'];
-      if(activeAdj && !data['body-activeBorder']){
-        const adj = adjust(baseBorder.color, parseInt(activeAdj.value,10)||0);
-        const col = baseBorder.opacity!==undefined ? hexToRgba(adj, baseBorder.opacity) : adj;
-        rootVars.push(`--border-active:${col};`);
-      }
-    }
-    const calW = data['calendar-width'];
-    if(calW && calW.value){ rootVars.push(`--calendar-width:${calW.value}px;`); }
-    const calH = data['calendar-height'];
-    if(calH && calH.value){ rootVars.push(`--calendar-height:${calH.value}px;`); }
-    const cp = data.controlPlaceholder;
-    if(cp){
-      if(cp.font) rootVars.push(`--control-placeholder-font:${cp.font};`);
-      if(cp.size) rootVars.push(`--control-placeholder-size:${cp.size}px;`);
-    }
-    if(rootVars.length){
-      css += `:root{${rootVars.join('')}}\n`;
-    }
-    if(data['open-posts-sticky-header'] && data['open-posts-sticky-header'].value === '1'){
-      css += '.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}\n';
-    }
-    colorAreas.forEach(area=>{
-      ['bg','card','text','weekday','title','btn','btnText','header','image','optionsMenu','menu'].forEach(type=>{
-        const entry = data[`${area.key}-${type}`];
-        if(!entry) return;
-        const selectors = area.selectors[type] || [];
-        if(!selectors.length) return;
-        const rules = [];
-        if(type==='bg' || type==='card' || type==='header' || type==='image' || type==='optionsMenu' || type==='menu' || type==='popupBg'){
-          if(entry.color){
-            const color = entry.opacity!==undefined ? hexToRgba(entry.color, entry.opacity) : entry.color;
-            rules.push(`background-color:${color};`);
-          }
-          if((type==='card' || type==='popupBg') && entry.shadow){
-            const s = entry.shadow; const blur = s.blur || 0;
-            rules.push(`box-shadow:0 0 ${blur}px ${s.color};`);
-          }
-        } else if(type==='text' || type==='title' || type==='btnText' || type==='weekday' || type==='popupText'){
-          if(entry.color) rules.push(`color:${entry.color};`);
-          if(entry.font) rules.push(`font-family:${entry.font};`);
-          if(entry.size) rules.push(`font-size:${entry.size}px;`);
-          if(entry.weight) rules.push(`font-weight:${entry.weight};`);
-          if(entry.shadow){
-            const s = entry.shadow; const x = s.x || 0; const y = s.y || 0; const blur = s.blur || 0;
-            rules.push(`text-shadow:${x}px ${y}px ${blur}px ${s.color};`);
-          }
-        } else if(type==='btn'){
-          if(entry.color) rules.push(`background-color:${entry.color};border-color:${entry.color};`);
-          if(entry.shadow){
-            const s = entry.shadow; const blur = s.blur || 0;
-            rules.push(`box-shadow:0 0 ${blur}px ${s.color};`);
-          }
-        }
-        if(rules.length){
-          css += selectors.map(sel=>`${sel}{${rules.join('')}}`).join('\n') + '\n';
-        }
-      });
-    });
-    return css;
-  }
-  function updateHistoryButtons(){
-    if(undoBtn) undoBtn.disabled = undoStack.length === 0;
-    if(redoBtn) redoBtn.disabled = redoStack.length === 0;
-  }
-
-  let presets = [];
-  let defaultTheme = {};
-
-  function updatePresetOptions(idx=0){
-    const sel = document.getElementById('themePreset');
-    if(!sel) return;
-    sel.innerHTML = '';
-    presets.forEach((p,i)=>{
-      const opt = document.createElement('option');
-      opt.value = i;
-      opt.textContent = p.name;
-      sel.appendChild(opt);
-    });
-    sel.selectedIndex = idx;
-  }
-
-  function loadPresets(){
-    const stored = JSON.parse(localStorage.getItem('themePresets')||'[]');
-    presets = [
-      {name:'Blue', css:'theme-blue'},
-      ...stored
-    ];
-    const savedCss = localStorage.getItem('selectedCssTheme');
-    let selectedIdx = 0;
-    if(savedCss){
-      const found = presets.findIndex(p=>p.css===savedCss);
-      if(found!==-1) selectedIdx = found;
-    }
-    updatePresetOptions(selectedIdx);
-  }
-
-  function applyPresetData(data){
-      ['hoverBorder','activeBorder'].forEach(t=>{
-        const inp = document.getElementById(`body-${t}-c`);
-        if(inp) delete inp.dataset.custom;
-      });
-      Object.entries(data).forEach(([key,val])=>{
-        const parts = key.split('-');
-        const areaKey = parts.shift();
-        const type = parts.join('-');
-        if(!type){
-          const colorInput = document.getElementById(`${key}-c`) || document.getElementById(`${key}-text-c`) || document.getElementById(key);
-          const opacityInput = document.getElementById(`${key}-o`);
-          const fontInput = document.getElementById(`${key}-text-font`);
-          const sizeInput = document.getElementById(`${key}-text-size`);
-          if(colorInput && val.color){ colorInput.value = val.color; }
-          if(opacityInput && val.opacity!==undefined){ opacityInput.value = val.opacity; }
-          if(fontInput && val.font){ fontInput.value = val.font; }
-          if(sizeInput && val.size){ sizeInput.value = val.size; }
-          const varMap = {primary:'--primary',secondary:'--secondary',accent:'--accent',btn:'--btn',panelBg:'--panel-bg',panelText:'--panel-text',scrollbarTrack:'--scrollbar-track',scrollbarThumb:'--scrollbar-thumb',scrollbarThumbHover:'--scrollbar-thumb-hover',listBackground:'--list-background',closedCardBg:'--closed-card-bg',placeholder:'--placeholder-text',filterPlaceholder:'--filter-placeholder-text',dropdownTitle:'--dropdown-title',dropdownSelectedBg:'--dropdown-selected-bg',dropdownSelectedText:'--dropdown-selected-text',dropdownText:'--dropdown-text',dropdownBg:'--dropdown-bg',dropdownHoverBg:'--dropdown-hover-bg',dropdownHoverText:'--dropdown-hover-text',dropdownVenueText:'--dropdown-venue-text',keywordBg:'--keyword-bg',dateRangeBg:'--date-range-bg',dateRangeText:'--date-range-text',sessionAvailable:'--session-available',sessionSelected:'--session-selected',today:'--today',controlTextBg:'--control-text-bg',controlPlaceholder:'--control-placeholder-text',popupBg:'--popup-bg',popupText:'--popup-text',geoBtnBg:'--control-geolocate-bg',compassBtnBg:'--control-compass-bg',clearBtnBg:'--control-clear-bg'};
-          if(varMap[key]){
-            const color = val.opacity!==undefined ? hexToRgba(val.color, val.opacity) : val.color;
-            document.documentElement.style.setProperty(varMap[key], color);
-          }
-          if(key==='controlPlaceholder'){
-            if(val.font) document.documentElement.style.setProperty('--control-placeholder-font', val.font);
-            if(val.size) document.documentElement.style.setProperty('--control-placeholder-size', val.size + 'px');
-          }
-          return;
-        }
-        const direct = document.getElementById(`${areaKey}-${type}`);
-        if(direct && val.value!==undefined){
-          direct.value = val.value;
-          return;
-        }
-        const c = document.getElementById(`${areaKey}-${type}-c`);
-        const o = document.getElementById(`${areaKey}-${type}-o`);
-        const f = document.getElementById(`${areaKey}-${type}-font`);
-        const s = document.getElementById(`${areaKey}-${type}-size`);
-        const w = document.getElementById(`${areaKey}-${type}-weight`);
-        const sc = document.getElementById(`${areaKey}-${type}-shadow-color`);
-        const sx = document.getElementById(`${areaKey}-${type}-shadow-x`);
-        const sy = document.getElementById(`${areaKey}-${type}-shadow-y`);
-        const sb = document.getElementById(`${areaKey}-${type}-shadow-blur`);
-        const v = document.getElementById(`${areaKey}-${type}`);
-        if(c && val.color){
-          c.value = val.color;
-          if(areaKey==='body' && (type==='hoverBorder' || type==='activeBorder')) c.dataset.custom = 'true';
-        }
-        if((['bg','card','border','hoverBorder','activeBorder'].includes(type)) && o && val.opacity!==undefined){ o.value = val.opacity; }
-        if(v && val.value!==undefined){ v.value = val.value; }
-        if(f && val.font){ f.value = val.font; }
-        if(s && val.size){ s.value = val.size; }
-        if(w && val.weight){ w.value = val.weight; }
-        if(sc && val.shadow){
-          if(val.shadow.color) sc.value = val.shadow.color;
-          if(sx && val.shadow.x!==undefined) sx.value = val.shadow.x;
-          if(sy && val.shadow.y!==undefined) sy.value = val.shadow.y;
-          if(sb && val.shadow.blur!==undefined) sb.value = val.shadow.blur;
-        }
-      });
-      applyAdmin();
-      repositionPanels();
-    }
-
-  function applyPreset(p){
-    document.querySelectorAll('[id^="theme-"]').forEach(el=>{ el.disabled = true; });
-    if(!p) return;
-    if(p.data){
-      localStorage.removeItem('selectedCssTheme');
-      applyPresetData(p.data);
-    } else if(p.css){
-      localStorage.setItem('selectedCssTheme', p.css);
-      localStorage.removeItem('currentTheme');
-      document.documentElement.removeAttribute('style');
-      colorAreas.forEach(area=>{
-        Object.values(area.selectors).flat().forEach(sel=>{
-          document.querySelectorAll(sel).forEach(el=>{
-            if(el === document.body){
-              const pad = el.style.paddingBottom;
-              el.removeAttribute('style');
-              if(pad) el.style.paddingBottom = pad;
-            } else {
-              el.removeAttribute('style');
-            }
-          });
-        });
-      });
-      document.querySelectorAll('.res-list .thumb,.closed-posts .thumb').forEach(el=> el.removeAttribute('style'));
-      const styleEl = document.getElementById(p.css);
-      if(styleEl) styleEl.disabled = false;
-    }
-    repositionPanels();
-  }
-
-  function savePreset(name){
-    const stored = JSON.parse(localStorage.getItem('themePresets')||'[]');
-    stored.push({name,data: collectThemeValues()});
-    localStorage.setItem('themePresets', JSON.stringify(stored));
-    loadPresets();
-  }
-
-  function loadSavedTheme(){
-    const cssTheme = localStorage.getItem('selectedCssTheme');
-    if(cssTheme){
-      if(!document.getElementById(cssTheme)){
-        localStorage.removeItem('selectedCssTheme');
-      } else {
-        const idx = presets.findIndex(p=>p.css===cssTheme);
-        if(idx !== -1){
-          const sel = document.getElementById('themePreset');
-          if(sel) sel.value = idx;
-          applyPreset(presets[idx]);
-          return;
-        }
-      }
-    }
-    const saved = JSON.parse(localStorage.getItem('currentTheme')||'null');
-    if(saved){
-      localStorage.removeItem('selectedCssTheme');
-      applyPresetData(saved);
-    }
-  }
-
-
-  buildStyleControls();
-  syncAdminControls();
-  applyAdmin();
-  defaultTheme = collectThemeValues();
-  loadPresets();
-  loadSavedTheme();
-  currentState = collectThemeValues();
-  updateHistoryButtons();
-
-    const adminForm = document.getElementById('adminForm');
-    if(adminForm){
-          const speedInput = document.getElementById("spinSpeed");
-          const speedVal = document.getElementById("spinSpeedVal");
-          const loadStartChk = document.getElementById("spinLoadStart");
-          const typeRadios = document.querySelectorAll("#spinType input");
-          const logoClickChk = document.getElementById("spinLogoClick");
-          const themeSelect = document.getElementById("mapTheme");
-          const pitchInput = document.getElementById("mapPitch");
-          const pitchVal = document.getElementById("pitchVal");
-          const bearingInput = document.getElementById("mapBearing");
-          const bearingVal = document.getElementById("bearingVal");
-          const radiusInput = document.getElementById("clusterRadius");
-          const maxZoomInput = document.getElementById("clusterMaxZoom");
-          const iconSelect = document.getElementById("clusterIconType");
-          const svgInput = document.getElementById("clusterSvg");
-          const svgRow = document.getElementById("clusterSvgRow");
-        if(themeSelect){
-          themeSelect.value = mapStyle;
-          themeSelect.addEventListener("change", ()=>{
-              mapStyle = window.mapStyle = themeSelect.value;
-              localStorage.setItem("mapStyle", mapStyle);
-              if(map) map.setStyle(mapStyle);
-          });
-        }
-        const skySelect = document.getElementById("skyTheme");
-        if(skySelect){
-          skySelect.value = skyStyle;
-          skySelect.addEventListener("change", ()=>{
-              skyStyle = window.skyStyle = skySelect.value;
-              localStorage.setItem("skyStyle", skyStyle);
-              if(map) applySky(skyStyle);
-          });
-        }
-        if(speedInput && speedVal){
-        speedInput.value = sg.spinEnabled ? sg.spinSpeed : 0;
-        speedVal.textContent = sg.spinEnabled ? sg.spinSpeed.toFixed(2) : "Off";
-        speedInput.addEventListener("input", ()=>{
-          const val = Math.max(0, parseFloat(speedInput.value) || 0);
-          sg.spinEnabled = val > 0;
-          sg.spinSpeed = val;
-          speedVal.textContent = sg.spinEnabled ? val.toFixed(2) : "Off";
-          localStorage.setItem("spinGlobe", JSON.stringify(sg.spinEnabled));
-          localStorage.setItem("spinSpeed", String(sg.spinSpeed));
-          if(sg.spinEnabled) sg.startSpin(); else sg.stopSpin();
-        });
-      }
-      if(pitchInput && pitchVal){
-        pitchInput.value = startPitch;
-        pitchVal.textContent = startPitch.toFixed(0);
-        pitchInput.addEventListener("input", ()=>{
-          const val = parseFloat(pitchInput.value) || 0;
-            if(map) map.setPitch(val);
-          pitchVal.textContent = val.toFixed(0);
-        });
-      }
-      if(bearingInput && bearingVal){
-        bearingInput.value = startBearing;
-        bearingVal.textContent = startBearing.toFixed(0);
-        bearingInput.addEventListener("input", ()=>{
-          const val = parseFloat(bearingInput.value) || 0;
-            if(map) map.setBearing(val);
-          bearingVal.textContent = val.toFixed(0);
-        });
-      }
-      if(radiusInput){
-        radiusInput.value = clusterRadius;
-        radiusInput.addEventListener("change", ()=>{
-          clusterRadius = parseInt(radiusInput.value,10) || 52;
-          localStorage.setItem("clusterRadius", String(clusterRadius));
-          addPostSource();
-        });
-      }
-      if(maxZoomInput){
-        maxZoomInput.value = clusterMaxZoom;
-        maxZoomInput.addEventListener("change", ()=>{
-          let val = parseInt(maxZoomInput.value,10);
-          if(isNaN(val)) val = 14;
-          clusterMaxZoom = Math.max(0, Math.min(18, val));
-          localStorage.setItem("clusterMaxZoom", String(clusterMaxZoom));
-          addPostSource();
-        });
-      }
-      if(iconSelect){
-        iconSelect.value = clusterIconType;
-        iconSelect.addEventListener("change", ()=>{
-          clusterIconType = iconSelect.value;
-          localStorage.setItem("clusterIconType", clusterIconType);
-          if(svgRow) svgRow.style.display = clusterIconType === "svg" ? "flex" : "none";
-          addPostSource();
-        });
-      }
-      if(svgInput){
-        svgInput.value = clusterSvg;
-        svgInput.addEventListener("change", ()=>{
-          clusterSvg = svgInput.value;
-          localStorage.setItem("clusterSvg", clusterSvg);
-          if(clusterIconType === "svg") addPostSource();
-        });
-        if(svgRow) svgRow.style.display = clusterIconType === "svg" ? "flex" : "none";
-      }
-      if(loadStartChk){
-        loadStartChk.checked = sg.spinLoadStart;
-        loadStartChk.addEventListener("change", ()=>{
-          sg.spinLoadStart = loadStartChk.checked;
-          localStorage.setItem("spinLoadStart", JSON.stringify(sg.spinLoadStart));
-          sg.updateSpinState();
-        });
-      }
-      if(typeRadios.length){
-        typeRadios.forEach(radio=>{
-          radio.checked = radio.value === sg.spinLoadType;
-          radio.addEventListener("change", ()=>{
-            if(!radio.checked) return;
-            sg.spinLoadType = radio.value;
-            localStorage.setItem("spinLoadType", sg.spinLoadType);
-            sg.updateSpinState();
-          });
-        });
-      }
-      if(logoClickChk){
-        logoClickChk.checked = sg.spinLogoClick;
-        logoClickChk.addEventListener("change", ()=>{
-          sg.spinLogoClick = logoClickChk.checked;
-          localStorage.setItem("spinLogoClick", JSON.stringify(sg.spinLogoClick));
-          sg.updateLogoClickState();
-        });
-      }
-        adminForm.addEventListener("input", e=>{
-          if(["spinSpeed","mapTheme","skyTheme","mapPitch","mapBearing","clusterRadius","clusterMaxZoom","clusterIconType","clusterSvg"].includes(e.target.id)) return;
-          if(e.target.matches('input[type="range"]') && e.target.id.endsWith('-o')) updateOpacityDisplay(e.target);
-          applyAdmin(e.target);
-        });
-        adminForm.addEventListener("change", e=>{
-          if(["spinSpeed","mapTheme","skyTheme","mapPitch","mapBearing","clusterRadius","clusterMaxZoom","clusterIconType","clusterSvg"].includes(e.target.id)) return;
-          if(e.target.matches('input[type="range"]') && e.target.id.endsWith('-o')) updateOpacityDisplay(e.target);
-          applyAdmin(e.target);
-        });
-    }
-
-    // Save/Discard/Restore logic
+  // Save/Discard/Restore logic
     const saveBtn = document.getElementById('saveNow');
     const discardBtn = document.getElementById('discardChanges');
     const adminClose = document.querySelector('#adminPanel .close-panel');
-    const tabPanels = ['theme','map','settings'];
+    const tabPanels = ['map','settings'];
     const savedData = {};
 
     function toHex(val){
@@ -7952,130 +4158,6 @@ document.addEventListener('pointerdown', handleDocInteract);
     });
 
     loadSaved();
-
-  const presetSelect = document.getElementById('themePreset');
-  presetSelect && presetSelect.addEventListener('change', e=>{
-    const idx = parseInt(e.target.value, 10);
-    applyPreset(presets[idx]);
-  });
-  const refreshBtn = document.getElementById('refreshTheme');
-  refreshBtn && refreshBtn.addEventListener('click', ()=>{
-    const idx = parseInt(presetSelect.value, 10);
-    applyPreset(presets[idx]);
-  });
-  const savePresetBtn = document.getElementById('savePreset');
-  savePresetBtn && savePresetBtn.addEventListener('click', ()=>{
-    const name = document.getElementById('newPresetName').value.trim();
-    if(name){
-      savePreset(name);
-      document.getElementById('newPresetName').value = '';
-    }
-  });
-
-  const downloadCssBtn = document.getElementById('downloadCss');
-  downloadCssBtn && downloadCssBtn.addEventListener('click', ()=>{
-    const data = collectThemeValues();
-    const css = generateCss(data);
-    const metadata = `/*THEMEBUILDER_FIELDSETS\n${JSON.stringify(data, null, 2)}\n*/\n`;
-    const blob = new Blob([metadata, css], { type:'text/css' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'theme.css';
-    a.click();
-    URL.revokeObjectURL(url);
-  });
-
-  const baseColorInput = document.getElementById('baseColor');
-  const autoThemeBtn = document.getElementById('autoThemeBtn');
-  undoBtn = document.getElementById('undoBtn');
-  redoBtn = document.getElementById('redoBtn');
-  autoThemeBtn && autoThemeBtn.addEventListener('click', ()=>{
-    undoStack.push(JSON.parse(JSON.stringify(currentState)));
-    redoStack.length = 0;
-    const base = baseColorInput.value;
-    const theme = generateTheme(base);
-    const root = document.documentElement;
-    root.style.setProperty('--primary', theme.primary);
-    root.style.setProperty('--secondary', theme.secondary);
-    root.style.setProperty('--accent', theme.accent);
-    root.style.setProperty('--background', theme.background);
-    root.style.setProperty('--text', theme.text);
-    root.style.setProperty('--btn', theme.btn);
-    root.style.setProperty('--ink', theme.text);
-    root.style.setProperty('--ink-d', theme.text);
-    root.style.setProperty('--button-text', theme.buttonText);
-    root.style.setProperty('--button-hover-text', theme.buttonHoverText);
-    updateFields(theme);
-    spreadTheme(theme);
-    syncAdminControls();
-    currentState = collectThemeValues();
-    updateHistoryButtons();
-    localStorage.setItem('currentTheme', JSON.stringify(currentState));
-  });
-  undoBtn && undoBtn.addEventListener('click', ()=>{
-    if(!undoStack.length) return;
-    redoStack.push(JSON.parse(JSON.stringify(currentState)));
-    const prev = undoStack.pop();
-    applyPresetData(prev);
-    currentState = JSON.parse(JSON.stringify(prev));
-    updateHistoryButtons();
-  });
-  redoBtn && redoBtn.addEventListener('click', ()=>{
-    if(!redoStack.length) return;
-    undoStack.push(JSON.parse(JSON.stringify(currentState)));
-    const next = redoStack.pop();
-    applyPresetData(next);
-    currentState = JSON.parse(JSON.stringify(next));
-    updateHistoryButtons();
-  });
-
-    const fieldBindings = {
-      btn: '--btn',
-      panelBg: '--panel-bg',
-      panelText: '--panel-text',
-      scrollbarTrack: '--scrollbar-track',
-      scrollbarThumb: '--scrollbar-thumb',
-      scrollbarThumbHover: '--scrollbar-thumb-hover',
-      listBackground: '--list-background',
-      closedCardBg: '--closed-card-bg',
-      placeholder: '--placeholder-text',
-      filterPlaceholder: '--filter-placeholder-text',
-      dropdownTitle: '--dropdown-title',
-      dropdownSelectedBg: '--dropdown-selected-bg',
-      dropdownSelectedText: '--dropdown-selected-text',
-      dropdownText: '--dropdown-text',
-      dropdownBg: '--dropdown-bg',
-      dropdownHoverBg: '--dropdown-hover-bg',
-      dropdownHoverText: '--dropdown-hover-text',
-      dropdownVenueText: '--dropdown-venue-text',
-      keywordBg: '--keyword-bg',
-      dateRangeBg: '--date-range-bg',
-      dateRangeText: '--date-range-text',
-      controlTextBg: '--control-text-bg',
-      controlPlaceholder: '--control-placeholder-text',
-      popupBg: '--popup-bg',
-      popupText: '--popup-text',
-      geoBtnBg: '--control-geolocate-bg',
-      compassBtnBg: '--control-compass-bg',
-      clearBtnBg: '--control-clear-bg'
-    };
-  Object.entries(fieldBindings).forEach(([id, varName])=>{
-    const el = document.getElementById(`${id}-c`) || document.getElementById(`${id}-text-c`) || document.getElementById(id);
-    const oEl = document.getElementById(`${id}-o`);
-    if(el){
-      const handler = ()=>{
-        const color = oEl ? hexToRgba(el.value, oEl.value) : el.value;
-        document.documentElement.style.setProperty(varName, color);
-        updateFields({ [id]: el.value });
-        currentState = collectThemeValues();
-        updateHistoryButtons();
-        localStorage.setItem('currentTheme', JSON.stringify(currentState));
-      };
-      el.addEventListener('input', handler);
-      if(oEl) oEl.addEventListener('input', handler);
-    }
-  });
 
   const palette = document.getElementById('fieldPalette');
   const builder = document.getElementById('formBuilder');


### PR DESCRIPTION
## Summary
- Replace inline styles with the contents of `blue 7.css` to hard-code the blue theme
- Remove Theme tab from the admin panel and activate Map tab by default
- Drop theme customization logic, limiting admin tabs to Map and Settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b901ca1e28833183e3c4e3ac60bc29