### PR TITLE
Standardize panel identifiers and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,11 +35,11 @@
       --btn: #3E5393;
       --btn-hover: #5C6FB1;
       --btn-active: #2E3A72;
-      --panel-bg: rgba(0,0,0,1);
+      --panel-bg: #444444;
       --panel-text: #000000;
       --footer-h: 70px;
-      --list-background: rgba(0,0,0,0.37);
-      --closed-card-bg: rgba(0,0,0,0.37);
+      --list-background: #555555;
+      --closed-card-bg: #555555;
       --scrollbar-track: rgba(0,0,0,0);
       --scrollbar-thumb: rgba(0,0,0,0.3);
       --scrollbar-thumb-hover: rgba(0,0,0,0.5);
@@ -174,6 +174,7 @@ button:not([class^="mapboxgl-ctrl"]),
   height: var(--control-h);
   min-width: 35px;
   border-radius: 8px;
+  opacity: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -238,11 +239,11 @@ textarea::placeholder{
   color: var(--placeholder-text);
   font-size: inherit;
 }
-#filterPanel #kwInput::placeholder{
+#filter-panel #kwInput::placeholder{
   color: var(--filter-placeholder-text);
   font-size: inherit;
 }
-#filterPanel #dateInput::placeholder{
+#filter-panel #dateInput::placeholder{
   color: var(--filter-placeholder-text);
   font-size: inherit;
 }
@@ -532,13 +533,13 @@ button[aria-expanded="true"] .results-arrow{
   padding:0 20px 20px;
   overscroll-behavior:contain;
 }
-#adminPanel #styleControls{
+#admin-panel #styleControls{
   display:flex;
   flex-direction:column;
   align-items:flex-start;
   gap:12px;
 }
-#adminPanel #styleControls > *{
+#admin-panel #styleControls > *{
   width:300px;
 }
 .admin-fieldset{
@@ -549,24 +550,24 @@ button[aria-expanded="true"] .results-arrow{
   width:300px;
   box-sizing:border-box;
 }
-#adminPanel .admin-fieldset{
+#admin-panel .admin-fieldset{
   width:300px;
 }
-#adminPanel .admin-fieldset.collapsed{
+#admin-panel .admin-fieldset.collapsed{
   padding:0;
 }
-  #adminPanel .panel-content,
-  #memberPanel .panel-content{
+  #admin-panel .panel-content,
+  #member-panel .panel-content{
     width:600px;
     max-width:90%;
     max-height:90%;
   }
 
-  #memberPanel .panel-content{
+  #member-panel .panel-content{
     background:rgba(0,0,0,0.7);
     color:#fff;
   }
-#filterPanel .panel-content{
+#filter-panel .panel-content{
   width:350px;
   max-width:600px;
   max-height:90%;
@@ -574,29 +575,29 @@ button[aria-expanded="true"] .results-arrow{
   color:#fff;
 }
 
-#filterPanel button,
-#filterPanel .sq,
-#filterPanel .tiny,
-#filterPanel .btn,
-#adminPanel button,
-#memberPanel button{
+#filter-panel button,
+#filter-panel .sq,
+#filter-panel .tiny,
+#filter-panel .btn,
+#admin-panel button,
+#member-panel button{
   background: var(--btn);
   color: var(--ink);
   border: none;
 }
-#adminPanel button{
+#admin-panel button{
   height:35px;
   line-height:35px;
 }
-#adminPanel input[type="color"]{
+#admin-panel input[type="color"]{
   width:35px;
   height:35px;
 }
-#filterPanel input[type="text"]{
+#filter-panel input[type="text"]{
   background: var(--panel-bg);
   color: var(--panel-text);
 }
-#filterPanel .calendar-container{
+#filter-panel .calendar-container{
   background: var(--dropdown-bg);
   position:relative;
   overflow-x:auto;
@@ -608,7 +609,7 @@ button[aria-expanded="true"] .results-arrow{
   border:1px solid var(--border);
   border-radius:8px;
 }
-#filterPanel .calendar-container .today-marker{
+#filter-panel .calendar-container .today-marker{
   position:absolute;
   bottom:0;
   width:8px;
@@ -618,10 +619,10 @@ button[aria-expanded="true"] .results-arrow{
   cursor:pointer;
   transform:translateX(-50%);
 }
-#filterPanel #datePicker{
+#filter-panel #datePicker{
   width:max-content;
 }
-#filterPanel .calendar{
+#filter-panel .calendar{
   display:flex;
   width:max-content;
   transform:scale(var(--calendar-scale));
@@ -681,8 +682,8 @@ button[aria-expanded="true"] .results-arrow{
 .calendar .day.range-start{border-radius:8px 0 0 8px;}
 .calendar .day.range-end{border-radius:0 8px 8px 0;}
 .calendar .day.range-start.range-end{border-radius:8px;}
-#memberPanel #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
-#memberPanel input[type=color]{
+#member-panel #mLocation .mapboxgl-ctrl-geocoder{width:100%;}
+#member-panel input[type=color]{
   border-radius:8px;
   padding:0;
   height:40px;
@@ -706,26 +707,26 @@ button[aria-expanded="true"] .results-arrow{
   left:50%;
   transform:translateX(-50%);
 }
-#memberPanel .location-info{margin-top:4px;font-size:13px;}
+#member-panel .location-info{margin-top:4px;font-size:13px;}
   @media (max-width:600px){
-  #adminPanel .panel-content,
-  #memberPanel .panel-content,
-  #filterPanel .panel-content{
+  #admin-panel .panel-content,
+  #member-panel .panel-content,
+  #filter-panel .panel-content{
     width:95%;
     max-width:95%;
     max-height:95%;
   }
 }
-#adminPanel legend{font-weight:600;padding:0 6px;display:flex;align-items:center;gap:6px;justify-content:space-between;cursor:pointer;user-select:none;width:300px;height:35px;background:var(--btn);border:1px solid var(--btn);border-radius:var(--dropdown-radius);box-sizing:border-box;}
-#adminPanel legend::after{content:'\25BC';margin-left:auto;font-size:12px;}
-#adminPanel fieldset.collapsed legend::after{content:'\25B6';}
-#adminPanel fieldset.collapsed > :not(legend){display:none;}
-#adminPanel .fieldset-actions{display:flex;gap:4px;margin:4px 6px;}
-#adminPanel .fieldset-actions .same-btn{flex:1 1 0;padding:6px;}
-#adminPanel .control-row{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:6px;padding:8px 0;max-width:300px;width:100%;}
-#adminPanel .control-row label:first-child{min-width:80px;font-size:12px;cursor:pointer;user-select:none;}
+#admin-panel legend{font-weight:600;padding:0 6px;display:flex;align-items:center;gap:6px;justify-content:space-between;cursor:pointer;user-select:none;width:300px;height:35px;background:var(--btn);border:1px solid var(--btn);border-radius:var(--dropdown-radius);box-sizing:border-box;}
+#admin-panel legend::after{content:'\25BC';margin-left:auto;font-size:12px;}
+#admin-panel fieldset.collapsed legend::after{content:'\25B6';}
+#admin-panel fieldset.collapsed > :not(legend){display:none;}
+#admin-panel .fieldset-actions{display:flex;gap:4px;margin:4px 6px;}
+#admin-panel .fieldset-actions .same-btn{flex:1 1 0;padding:6px;}
+#admin-panel .control-row{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:6px;padding:8px 0;max-width:300px;width:100%;}
+#admin-panel .control-row label:first-child{min-width:80px;font-size:12px;cursor:pointer;user-select:none;}
 .control-row > *:last-child{margin-left:auto;width:200px;}
-#adminPanel .color-group{
+#admin-panel .color-group{
   flex:0 0 200px;
   width:100%;
   max-width:200px;
@@ -734,7 +735,7 @@ button[aria-expanded="true"] .results-arrow{
   align-items:stretch;
   position:relative;
 }
-#adminPanel .shadow-group{
+#admin-panel .shadow-group{
   flex:0 0 200px;
   width:100%;
   max-width:200px;
@@ -742,21 +743,21 @@ button[aria-expanded="true"] .results-arrow{
   gap:4px;
   align-items:center;
 }
-#adminPanel .shadow-group input[type=color]{
+#admin-panel .shadow-group input[type=color]{
   width:40px;
   height:40px;
   padding:0;
   border-radius:8px;
 }
-#adminPanel .shadow-group input[type=number]{
+#admin-panel .shadow-group input[type=number]{
   flex:1 1 0;
 }
-#adminPanel .textpicker{
+#admin-panel .textpicker{
   flex:0 0 200px;
   width:200px;
   position:relative;
 }
-#adminPanel .textpicker .text-preview{
+#admin-panel .textpicker .text-preview{
   width:100%;
   height:35px;
   border-radius:8px;
@@ -765,7 +766,7 @@ button[aria-expanded="true"] .results-arrow{
   justify-content:center;
   cursor:pointer;
 }
-#adminPanel .textpicker .text-popup{
+#admin-panel .textpicker .text-popup{
   display:none;
   position:absolute;
   top:44px;
@@ -777,9 +778,9 @@ button[aria-expanded="true"] .results-arrow{
   padding:8px;
   width:200px;
 }
-#adminPanel .textpicker.open .text-popup{display:block;}
-#adminPanel .textpicker .text-popup select,
-#adminPanel .textpicker .text-popup input[type=color]{
+#admin-panel .textpicker.open .text-popup{display:block;}
+#admin-panel .textpicker .text-popup select,
+#admin-panel .textpicker .text-popup input[type=color]{
   width:100%;
   margin-top:4px;
   border-radius:var(--dropdown-radius);
@@ -787,28 +788,28 @@ button[aria-expanded="true"] .results-arrow{
   box-sizing:border-box;
   height:35px;
 }
-#adminPanel .textpicker .text-popup input[type=color]{padding:0;}
-#adminPanel .textpicker .text-popup .shadow-group{
+#admin-panel .textpicker .text-popup input[type=color]{padding:0;}
+#admin-panel .textpicker .text-popup .shadow-group{
   display:grid;
   grid-template-columns:repeat(4,1fr);
   gap:4px;
   margin-top:4px;
 }
-#adminPanel .textpicker .text-popup .shadow-group input[type=color],
-#adminPanel .textpicker .text-popup .shadow-group input[type=number]{
+#admin-panel .textpicker .text-popup .shadow-group input[type=color],
+#admin-panel .textpicker .text-popup .shadow-group input[type=number]{
   width:100%;
   height:40px;
   border-radius:var(--dropdown-radius);
   padding:0;
   box-sizing:border-box;
 }
-#adminPanel .admin-fieldset input,
-#adminPanel .admin-fieldset select,
-#adminPanel .admin-fieldset textarea{
+#admin-panel .admin-fieldset input,
+#admin-panel .admin-fieldset select,
+#admin-panel .admin-fieldset textarea{
   max-width:200px;
   box-sizing:border-box;
 }
-#adminPanel .control-row select{
+#admin-panel .control-row select{
   flex:0 0 200px;
   width:200px;
   max-width:200px;
@@ -816,11 +817,11 @@ button[aria-expanded="true"] .results-arrow{
   border-radius:var(--dropdown-radius);
   padding:4px;
 }
-#adminPanel .color-group input[type=color],
-#adminPanel .color-group input[type=range]{
+#admin-panel .color-group input[type=color],
+#admin-panel .color-group input[type=range]{
   width:100%;
 }
-#adminPanel .color-group input[type=color]{
+#admin-panel .color-group input[type=color]{
   border-radius:8px;
   padding:0;
   height:35px;
@@ -828,22 +829,22 @@ button[aria-expanded="true"] .results-arrow{
   cursor:pointer;
   pointer-events:auto;
 }
-#adminPanel .range-group{
+#admin-panel .range-group{
   display:flex;
   align-items:center;
   gap:4px;
 }
-#adminPanel .range-group input[type=range]{
+#admin-panel .range-group input[type=range]{
   flex:1;
   width:auto;
 }
-#adminPanel .range-group span{
+#admin-panel .range-group span{
   min-width:32px;
   text-align:right;
   font-size:12px;
 }
-#adminPanel .tab-bar{display:flex;gap:6px;}
-#adminPanel .tab-bar button{
+#admin-panel .panel-subheader{display:flex;gap:6px;}
+#admin-panel .panel-subheader button{
   flex:1;
   padding:6px 10px;
   border-radius:8px;
@@ -852,18 +853,18 @@ button[aria-expanded="true"] .results-arrow{
   color:var(--button-text);
   cursor:pointer;
 }
-#adminPanel .tab-panel{display:none;}
-#adminPanel .tab-panel.active{display:flex;flex-direction:column;align-items:flex-start;gap:12px;}
-#adminPanel .marker-grid{display:flex;flex-direction:column;gap:8px;}
-#adminPanel .marker-grid select{min-width:120px;}
-#adminPanel .marker-options{display:flex;gap:8px;align-items:center;}
-#adminPanel .marker-set{display:grid;grid-template-columns:repeat(10,max-content);gap:4px;}
-#adminPanel .marker-set svg.shadow{filter:drop-shadow(2px 2px 2px rgba(0,0,0,0.5));}
-#adminPanel .marker-set svg.outline *{stroke:#000;stroke-width:1;}
-#adminPanel input[type=range]{width:100%;}
-#adminPanel .preset-actions{display:flex;gap:6px;margin:0;}
-#adminPanel .preset-actions input{flex:1;padding:6px;border-radius:8px;}
-#adminPanel .preset-actions button{padding:6px 10px;}
+#admin-panel .tab-panel{display:none;}
+#admin-panel .tab-panel.active{display:flex;flex-direction:column;align-items:flex-start;gap:12px;}
+#admin-panel .marker-grid{display:flex;flex-direction:column;gap:8px;}
+#admin-panel .marker-grid select{min-width:120px;}
+#admin-panel .marker-options{display:flex;gap:8px;align-items:center;}
+#admin-panel .marker-set{display:grid;grid-template-columns:repeat(10,max-content);gap:4px;}
+#admin-panel .marker-set svg.shadow{filter:drop-shadow(2px 2px 2px rgba(0,0,0,0.5));}
+#admin-panel .marker-set svg.outline *{stroke:#000;stroke-width:1;}
+#admin-panel input[type=range]{width:100%;}
+#admin-panel .preset-actions{display:flex;gap:6px;margin:0;}
+#admin-panel .preset-actions input{flex:1;padding:6px;border-radius:8px;}
+#admin-panel .preset-actions button{padding:6px 10px;}
 .panel-field{
   margin:8px 0;
   display:flex;
@@ -872,11 +873,11 @@ button[aria-expanded="true"] .results-arrow{
   max-width:300px;
   width:100%;
 }
-#adminPanel .panel-field{margin:0;}
-#adminPanel h3{margin:0;}
+#admin-panel .panel-field{margin:0;}
+#admin-panel h3{margin:0;}
 .admin-section{display:flex;flex-direction:column;gap:var(--gap);}
 #balloonTool .panel-field,
-#tab-forms .panel-field{max-width:none;}
+#form-tab .panel-field{max-width:none;}
 .history-group,
 .color-group{display:flex;align-items:center;gap:8px;}
 .preset-select{
@@ -1047,10 +1048,10 @@ button[aria-expanded="true"] .results-arrow{
 .input select{
   border-radius: var(--dropdown-radius);
 }
-#filterPanel #kwInput{
+#filter-panel #kwInput{
   background: var(--keyword-bg);
 }
-#filterPanel #dateInput{
+#filter-panel #dateInput{
   background: var(--date-range-bg);
   color: var(--date-range-text);
 }
@@ -1069,7 +1070,7 @@ button[aria-expanded="true"] .results-arrow{
 .input .down svg{
   vertical-align:middle;
 }
-#filterPanel .input .x{
+#filter-panel .input .x{
   position: static;
   width: 35px;
   height: 35px;
@@ -1083,13 +1084,13 @@ button[aria-expanded="true"] .results-arrow{
   color: var(--dropdown-text);
   opacity:1;
 }
-#filterPanel .input .x.active{
+#filter-panel .input .x.active{
   background: var(--filter-active-color);
   color: var(--button-text);
   opacity:1;
 }
 
-#filterPanel .field label.t{
+#filter-panel .field label.t{
   grid-column: 1 / -1;
   display: flex;
   align-items: center;
@@ -1293,7 +1294,7 @@ button[aria-expanded="true"] .results-arrow{
   border: 1px solid var(--btn);
 }
 
-.results-col{
+.list-panel{
   position: fixed;
   top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top) + var(--gap) - 12px);
   bottom: var(--footer-h);
@@ -1302,12 +1303,13 @@ button[aria-expanded="true"] .results-arrow{
   display: flex;
   flex-direction: column;
   padding: 0;
+  background: rgba(0,0,0,0.5);
   transition: width .3s ease, padding .3s ease;
   z-index: 2;
   pointer-events: auto;
 }
 
-body.hide-results .results-col{
+body.hide-results .list-panel{
   width: 0;
   padding: 0;
   overflow: hidden;
@@ -1406,7 +1408,7 @@ body.filters-active #filterBtn{
   gap: 4px;
 }
 
-.closed-posts .info{
+.post-panel .info{
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
@@ -1418,7 +1420,7 @@ body.filters-active #filterBtn{
   gap: 4px;
 }
 
-.closed-posts .info > div{
+.post-panel .info > div{
   display: flex;
   align-items: center;
   gap: 4px;
@@ -1619,7 +1621,7 @@ body.filters-active #filterBtn{
 
 
 
-.closed-posts{
+.post-panel{
   display:none;
   position: fixed;
   top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top) + var(--gap) - 12px);
@@ -1631,27 +1633,26 @@ body.filters-active #filterBtn{
   scrollbar-gutter:stable;
   padding:0;
   color:#000;
-  background:var(--panel-bg);
+  background: rgba(0,0,0,0.5);
 }
-.closed-posts .posts{overflow:visible;padding:12px;margin:0;}
-.closed-posts{color:#000;padding:0;}
-.closed-posts .card,
-.closed-posts .open-posts{background:var(--closed-card-bg);}
-.closed-posts button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
-.closed-posts .open-posts{margin-top:12px}
-.closed-posts.ad-space{right:calc(400px + var(--gap) * 2);}
+.post-panel .posts{overflow:visible;padding:12px;margin:0;}
+.post-panel .card,
+.post-panel .open-posts{background:var(--closed-card-bg);}
+.post-panel button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
+.post-panel .open-posts{margin-top:12px}
+.post-panel.ad-space{right:calc(400px + var(--gap) * 2);}
 
-body.hide-results .closed-posts{
+body.hide-results .post-panel{
   left:0;
 }
 
-.mode-posts .closed-posts{
+.mode-posts .post-panel{
   display: block;
   z-index: 1;
   pointer-events: auto;
 }
 
-.mode-map .closed-posts{
+.mode-map .post-panel{
   display: none;
 }
 .map-area{
@@ -1771,20 +1772,20 @@ body.hide-results .closed-posts{
 }
 
 @media (max-width: 450px){
-  .closed-posts .posts{padding:0;}
-  .closed-posts .card{
+  .post-panel .posts{padding:0;}
+  .post-panel .card{
     grid-template-columns:1fr;
     gap:0;
     padding:0;
     margin:0 0 var(--gap) 0;
     border-radius:0;
   }
-  .closed-posts .card .thumb{
+  .post-panel .card .thumb{
     width:100%;
     height:100vw;
     border-radius:0;
   }
-  .closed-posts .card .meta{padding:12px;}
+  .post-panel .card .meta{padding:12px;}
   .open-posts{
     margin:0;
   }
@@ -2236,8 +2237,8 @@ body.hide-results .closed-posts{
 
 
 @media (max-width:1000px){
-  .results-col{display:none;}
-  .closed-posts{left:0;}
+  .list-panel{display:none;}
+  .post-panel{left:0;}
   #resultsToggle{display:none;}
   .results-arrow{display:none;}
 }
@@ -2280,8 +2281,8 @@ body.hide-results .closed-posts{
 }
 
   @media (max-width:450px){
-    .closed-posts,
-    .closed-posts .card,
+    .post-panel,
+    .post-panel .card,
     .open-posts,
     .open-posts .img-box{
       width:100%;
@@ -2289,7 +2290,7 @@ body.hide-results .closed-posts{
       border:none;
       border-radius:8px;
     }
-  .closed-posts{
+  .post-panel{
     left:0;
     right:0;
     top:calc(var(--header-h) + var(--safe-top));
@@ -2345,7 +2346,7 @@ footer{
   body.mode-posts.hide-posts-ui footer{
     transform: translateY(100%);
   }
-  body.mode-posts.hide-posts-ui .closed-posts{
+  body.mode-posts.hide-posts-ui .post-panel{
     top: calc(var(--header-h) + var(--safe-top));
     bottom: 0;
   }
@@ -2422,7 +2423,7 @@ footer .foot-row .foot-item,
   border-radius: 8px;
 }
 
-.closed-posts .card .thumb{
+.post-panel .card .thumb{
   flex-basis: 80px;
   width: 80px;
   height: 80px;
@@ -2703,7 +2704,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   display: -webkit-box;
 }
 
-.results-col .res-list{
+.list-panel .res-list{
   border-radius: inherit;
   padding: var(--gap);
   padding-right: 0;
@@ -2717,7 +2718,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   bottom: var(--footer-h);
   width:400px;
   right: var(--gap);
-  background:var(--ad-panel-bg);
+  background: rgba(0,0,0,0.5);
   z-index:5;
   border-radius:8px;
   overflow:hidden;
@@ -2796,9 +2797,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 
 
 @media (max-width:649px){
-  #filterPanel .panel-content,
-  #adminPanel .panel-content,
-  #memberPanel .panel-content{
+  #filter-panel .panel-content,
+  #admin-panel .panel-content,
+  #member-panel .panel-content{
     top:calc(var(--header-h) + var(--safe-top));
     left:0;
     right:0;
@@ -2808,34 +2809,34 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     max-height:none;
     border-radius:0;
   }
-  #filterPanel .panel-content .resizer,
-  #adminPanel .panel-content .resizer,
-  #memberPanel .panel-content .resizer,
-  #filterPanel .panel-actions .move-left,
-  #filterPanel .panel-actions .move-right,
-  #adminPanel .panel-actions .move-left,
-  #adminPanel .panel-actions .move-right,
-  #memberPanel .panel-actions .move-left,
-  #memberPanel .panel-actions .move-right{
+  #filter-panel .panel-content .resizer,
+  #admin-panel .panel-content .resizer,
+  #member-panel .panel-content .resizer,
+  #filter-panel .panel-actions .move-left,
+  #filter-panel .panel-actions .move-right,
+  #admin-panel .panel-actions .move-left,
+  #admin-panel .panel-actions .move-right,
+  #member-panel .panel-actions .move-left,
+  #member-panel .panel-actions .move-right{
     display:none;
   }
 }
 
 @media (max-width:449px){
-  .closed-posts{
+  .post-panel{
     left:0;
     right:0;
   }
-  .closed-posts .posts{
+  .post-panel .posts{
     padding:12px 12px var(--gap);
     margin:0;
   }
-  .closed-posts .card{
+  .post-panel .card{
     width:100%;
     margin:0;
     border-radius:0;
   }
-  .closed-posts .open-posts{
+  .post-panel .open-posts{
     margin:0;
   }
   .open-posts{
@@ -2872,9 +2873,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   body.mode-map footer{
     display:none;
   }
-  #filterPanel .panel-content,
-  #memberPanel .panel-content,
-  #adminPanel .panel-content{
+  #filter-panel .panel-content,
+  #member-panel .panel-content,
+  #admin-panel .panel-content{
     top:calc(var(--header-h) + var(--safe-top));
     left:0;
     right:0;
@@ -2931,15 +2932,15 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     <div id="map"></div>
   </section>
 
-  <section class="results-col" aria-label="Results">
+  <section id="list-panel" class="list-panel" aria-label="Results">
     <div class="res-list" id="results"></div>
   </section>
 
-  <section class="closed-posts" aria-label="Closed Posts">
+  <section id="post-panel" class="post-panel" aria-label="Closed Posts">
     <div class="posts" id="postsWide"></div>
   </section>
 
-  <section id="adPanel" class="ad-panel" aria-label="Advertisement"></section>
+  <section id="ad-panel" class="ad-panel" aria-label="Advertisement"></section>
 
 
     <footer>
@@ -2947,7 +2948,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
       <button id="fullscreenBtn" type="button" class="fullscreen-btn" aria-label="Toggle fullscreen">⛶</button>
     </footer>
 
-  <div id="filterPanel" class="panel" role="dialog" aria-panel="true" aria-hidden="true">
+  <div id="filter-panel" class="panel filter-panel" role="dialog" aria-panel="true" aria-hidden="true">
     <div class="panel-content" style="top:calc(var(--header-h) + var(--safe-top));left:0;transform:none;">
       <div class="panel-header">
         <div class="header-top">
@@ -3008,7 +3009,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     </div>
   </div>
 
-  <div id="memberPanel" class="panel" role="dialog" aria-panel="true" aria-hidden="true">
+  <div id="member-panel" class="panel member-panel" role="dialog" aria-panel="true" aria-hidden="true">
     <div class="panel-content" style="top:calc(var(--header-h) + var(--safe-top));right:0;transform:none;">
       <div class="panel-header">
         <div class="header-top">
@@ -3047,7 +3048,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     </div>
   </div>
 
-  <div id="adminPanel" class="panel" role="dialog" aria-panel="true" aria-hidden="true">
+  <div id="admin-panel" class="panel admin-panel" role="dialog" aria-panel="true" aria-hidden="true">
     <div class="panel-content" style="top:calc(var(--header-h) + var(--safe-top));right:0;transform:none;">
       <div class="panel-header">
         <div class="header-top">
@@ -3060,14 +3061,14 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
             <button type="button" class="close-panel">Close</button>
           </div>
         </div>
-        <div class="tab-bar">
+        <div class="panel-subheader">
           <button type="button" class="tab-btn" data-tab="map" aria-selected="true">Map</button>
           <button type="button" class="tab-btn" data-tab="settings">Settings</button>
-          <button type="button" class="tab-btn" data-tab="forms">Forms</button>
+          <button type="button" class="tab-btn" data-tab="form">Forms</button>
         </div>
       </div>
       <form id="adminForm" class="panel-body">
-        <div id="tab-map" class="tab-panel active">
+        <div id="map-tab" class="tab-panel active">
             <div class="panel-field">
               <label for="mapTheme">Theme</label>
               <select id="mapTheme">
@@ -3217,7 +3218,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
               </div>
             </div>
         </div>
-        <div id="tab-settings" class="tab-panel">
+        <div id="settings-tab" class="tab-panel">
           <div class="panel-field">
             <label for="catList">Categories</label>
             <textarea id="catList" rows="3" placeholder="One category per line"></textarea>
@@ -3254,12 +3255,12 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
             <button type="button" data-restore="settings">Restore</button>
           </div>
         </div>
-        <div id="tab-forms" class="tab-panel">
+        <div id="form-tab" class="tab-panel">
           <style>
-            #tab-forms .form-category{margin:10px 0;border:1px solid #ccc;padding:10px;}
-            #tab-forms .category-header{display:flex;gap:6px;align-items:center;margin-bottom:8px;}
-            #tab-forms .subcategory-table{border-collapse:collapse;}
-            #tab-forms .subcategory-table td,#tab-forms .subcategory-table th{border:1px solid #999;padding:4px;}
+            #form-tab .form-category{margin:10px 0;border:1px solid #ccc;padding:10px;}
+            #form-tab .category-header{display:flex;gap:6px;align-items:center;margin-bottom:8px;}
+            #form-tab .subcategory-table{border-collapse:collapse;}
+            #form-tab .subcategory-table td,#form-tab .subcategory-table th{border:1px solid #999;padding:4px;}
           </style>
           <div id="formsControls">
             <button type="button" id="addCategory">Add Category</button>
@@ -3901,7 +3902,7 @@ function makePosts(){
 
     const resultsEl = $('#results');
     const postsWideEl = $('#postsWide');
-    const postsModeEl = $('.closed-posts');
+    const postsModeEl = $('.post-panel');
 
     // Image helpers (unique per post)
     function isPortrait(id){ let h=0; for(let i=0;i<id.length;i++){ h=(h<<5)-h+id.charCodeAt(i); h|=0; } return Math.abs(h)%2===0; }
@@ -4298,23 +4299,23 @@ function makePosts(){
       });
 
       const resultsToggle = $('#resultsToggle');
-      const resultsCol = $('.results-col');
+      const listPanel = $('.list-panel');
       const isSmall = window.innerWidth < 1000;
       const storedHidden = JSON.parse(localStorage.getItem('resultsHidden') || 'false');
       if(storedHidden || isSmall){
         document.body.classList.add('hide-results');
         resultsToggle.setAttribute('aria-pressed','false');
-        resultsCol.setAttribute('aria-hidden','true');
+        listPanel.setAttribute('aria-hidden','true');
       } else {
         resultsToggle.setAttribute('aria-pressed','true');
-        resultsCol.setAttribute('aria-hidden','false');
+        listPanel.setAttribute('aria-hidden','false');
       }
       window.addEventListener('resize', ()=>{
         if(window.innerWidth < 1000){
           if(!document.body.classList.contains('hide-results')){
             document.body.classList.add('hide-results');
             resultsToggle.setAttribute('aria-pressed','false');
-            resultsCol.setAttribute('aria-hidden','true');
+            listPanel.setAttribute('aria-hidden','true');
             localStorage.setItem('resultsHidden','true');
           }
         }
@@ -4330,7 +4331,7 @@ function makePosts(){
       resultsToggle.addEventListener('click', ()=>{
         const hidden = document.body.classList.toggle('hide-results');
         resultsToggle.setAttribute('aria-pressed', hidden ? 'false' : 'true');
-        resultsCol.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+        listPanel.setAttribute('aria-hidden', hidden ? 'true' : 'false');
         localStorage.setItem('resultsHidden', JSON.stringify(hidden));
         window.adjustListHeight();
         if(window.updateAdVisibility) updateAdVisibility();
@@ -4354,7 +4355,7 @@ function makePosts(){
         if(e.target === resList){
           document.body.classList.add('hide-results');
           resultsToggle.setAttribute('aria-pressed','false');
-          resultsCol.setAttribute('aria-hidden','true');
+          listPanel.setAttribute('aria-hidden','true');
           localStorage.setItem('resultsHidden','true');
           if(window.updateAdVisibility) updateAdVisibility();
           setMode('map');
@@ -4617,9 +4618,9 @@ function makePosts(){
       if(!resultsWasHidden){
         document.body.classList.add('hide-results');
         const resultsToggle = document.getElementById('resultsToggle');
-        const resultsCol = document.querySelector('.results-col');
+        const listPanel = document.querySelector('.list-panel');
         if(resultsToggle) resultsToggle.setAttribute('aria-pressed','false');
-        if(resultsCol) resultsCol.setAttribute('aria-hidden','true');
+        if(listPanel) listPanel.setAttribute('aria-hidden','true');
       }
       function step(){
         if(!spinning || !map) return;
@@ -4640,10 +4641,10 @@ function makePosts(){
       resultsWasHidden = null;
       if(wasHidden === false){
         const resultsToggle = document.getElementById('resultsToggle');
-        const resultsCol = document.querySelector('.results-col');
+        const listPanel = document.querySelector('.list-panel');
         document.body.classList.remove('hide-results');
       if(resultsToggle) resultsToggle.setAttribute('aria-pressed','true');
-      if(resultsCol) resultsCol.setAttribute('aria-hidden','false');
+      if(listPanel) listPanel.setAttribute('aria-hidden','false');
     }
     applyFilters();
   }
@@ -5039,7 +5040,7 @@ function makePosts(){
     }
 
       function updateAds(list){
-        const panel = document.getElementById('adPanel');
+        const panel = document.getElementById('ad-panel');
         stopAdCycle();
         panel.innerHTML = '';
         if(window.innerWidth < 1200 || !list.length){
@@ -5052,14 +5053,14 @@ function makePosts(){
         startAdCycle();
       }
     function startAdCycle(){
-      const panel = document.getElementById('adPanel');
+      const panel = document.getElementById('ad-panel');
       if(!panel.classList.contains('show') || !adPosts.length || adTimer) return;
       showNextAd();
       adTimer = setInterval(showNextAd,20000);
     }
     function stopAdCycle(){ clearInterval(adTimer); adTimer = null; }
     function showNextAd(){
-      const panel = document.getElementById('adPanel');
+      const panel = document.getElementById('ad-panel');
       if(!panel.classList.contains('show') || !adPosts.length) return;
       adIndex = (adIndex + 1) % adPosts.length;
       const p = adPosts[adIndex];
@@ -5322,7 +5323,7 @@ function makePosts(){
       const mapCard = document.querySelector('.mapboxgl-popup .hover-card');
       if(mapCard) mapCard.setAttribute('aria-selected','true');
 
-      const container = postsWideEl.closest('.closed-posts');
+      const container = postsWideEl.closest('.post-panel');
       const detail = buildDetail(p);
       target.replaceWith(detail);
       hookDetailActions(detail, p);
@@ -5384,7 +5385,7 @@ function makePosts(){
             btn.setAttribute('aria-pressed', p.fav ? 'true' : 'false');
           });
           const detailEl = el;
-          const container = detailEl.closest('.closed-posts');
+          const container = detailEl.closest('.post-panel');
           renderFooter();
           const replacement = postsWideEl.querySelector(`[data-id="${p.id}"]`);
           if(replacement){
@@ -5817,7 +5818,7 @@ function openPanel(m){
     const subH = parseFloat(rootStyles.getPropertyValue('--subheader-h')) || 0;
     const footerH = parseFloat(rootStyles.getPropertyValue('--footer-h')) || 0;
     const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
-    if(m.id==='adminPanel' || m.id==='memberPanel'){
+    if(m.id==='admin-panel' || m.id==='member-panel'){
       if(window.innerWidth < 450){
         const topPos = headerH + safeTop;
         content.style.left='0';
@@ -5834,7 +5835,7 @@ function openPanel(m){
         content.style.transform='none';
         content.style.maxHeight='';
       }
-    } else if(m.id==='filterPanel'){
+    } else if(m.id==='filter-panel'){
       const topPos = headerH + subH + safeTop;
       if(window.innerWidth < 450){
         content.style.left='0';
@@ -5865,7 +5866,7 @@ function openPanel(m){
       content.style.top='50%';
       content.style.transform='translate(-50%, -50%)';
     }
-    if(m.id !== 'welcomePopup' && !['adminPanel','memberPanel','filterPanel'].includes(m.id)) loadPanelState(m);
+    if(m.id !== 'welcomePopup' && !['admin-panel','member-panel','filter-panel'].includes(m.id)) loadPanelState(m);
   }
   if(!m.__bringToTopAdded){
     m.addEventListener('mousedown', ()=> bringToTop(m));
@@ -5909,7 +5910,7 @@ function movePanelToEdge(panel, side){
   }
 }
 function repositionPanels(){
-  ['adminPanel','memberPanel','filterPanel'].forEach(id=>{
+  ['admin-panel','member-panel','filter-panel'].forEach(id=>{
     const panel = document.getElementById(id);
     if(panel && panel.classList.contains('show')){
       const content = panel.querySelector('.panel-content');
@@ -5926,7 +5927,7 @@ function handleEsc(){
   const top = panelStack[panelStack.length-1];
   if(!top) return;
   if(top instanceof Element){
-    if(top.id === 'adminPanel' && typeof window.saveAdminChanges === 'function'){
+    if(top.id === 'admin-panel' && typeof window.saveAdminChanges === 'function'){
       window.saveAdminChanges();
     }
     requestClosePanel(top);
@@ -5939,7 +5940,7 @@ document.addEventListener('keydown', e=>{
   if(e.key==='Escape') handleEsc();
   else if(e.key==='ArrowLeft' || e.key==='ArrowRight'){
     const top = panelStack[panelStack.length-1];
-    if(window.innerWidth >= 450 && top && (top.id==='adminPanel' || top.id==='memberPanel')){
+    if(window.innerWidth >= 450 && top && (top.id==='admin-panel' || top.id==='member-panel')){
       movePanelToEdge(top, e.key==='ArrowLeft' ? 'left' : 'right');
     }
   }
@@ -5976,9 +5977,9 @@ document.addEventListener('pointerdown', handleDocInteract);
   const memberBtn = document.getElementById('memberBtn');
   const adminBtn = document.getElementById('adminBtn');
   const filterBtn = document.getElementById('filterBtn');
-  const memberPanel = document.getElementById('memberPanel');
-  const adminPanel = document.getElementById('adminPanel');
-  const filterPanel = document.getElementById('filterPanel');
+  const memberPanel = document.getElementById('member-panel');
+  const adminPanel = document.getElementById('admin-panel');
+  const filterPanel = document.getElementById('filter-panel');
   const sg = window.spinGlobals || {};
 
   memberBtn && memberBtn.addEventListener('click', ()=> togglePanel(memberPanel));
@@ -5990,7 +5991,7 @@ document.addEventListener('pointerdown', handleDocInteract);
   document.querySelectorAll('.panel .close-panel').forEach(btn=>{
     btn.addEventListener('click', ()=>{
       const panel = btn.closest('.panel');
-      if(panel && panel.id === 'adminPanel') return;
+      if(panel && panel.id === 'admin-panel') return;
       requestClosePanel(panel);
     });
   });
@@ -6019,7 +6020,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       openWelcome();
       localStorage.setItem('welcome-seen','true');
     }
-    if(filterPanel && window.innerWidth >= 450 && !filterPanel.classList.contains('show') && localStorage.getItem('panel-open-filterPanel') !== 'false'){
+    if(filterPanel && window.innerWidth >= 450 && !filterPanel.classList.contains('show') && localStorage.getItem('panel-open-filter-panel') !== 'false'){
       openPanel(filterPanel);
     }
   document.querySelectorAll('.panel').forEach(panel=>{
@@ -6116,14 +6117,14 @@ document.addEventListener('pointerdown', handleDocInteract);
     }
   });
 
-  const adminTabs = document.querySelectorAll('#adminPanel .tab-bar button');
-  const adminPanels = document.querySelectorAll('#adminPanel .tab-panel');
+  const adminTabs = document.querySelectorAll('#admin-panel .panel-subheader button');
+  const adminPanels = document.querySelectorAll('#admin-panel .tab-panel');
   adminTabs.forEach(btn=>{
     btn.addEventListener('click', ()=>{
       adminTabs.forEach(b=>b.setAttribute('aria-selected','false'));
       adminPanels.forEach(p=>p.classList.remove('active'));
       btn.setAttribute('aria-selected','true');
-      const panel = document.getElementById(`tab-${btn.dataset.tab}`);
+      const panel = document.getElementById(`${btn.dataset.tab}-tab`);
       panel && panel.classList.add('active');
     });
   });
@@ -6132,16 +6133,16 @@ document.addEventListener('pointerdown', handleDocInteract);
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
     {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
     {key:'list', label:'List', selectors:{bg:['.res-list'], text:['.res-list'], title:['.res-list .card .t','.res-list .card .title'], btn:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], btnText:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], card:['.res-list .card']}},
-    {key:'closed-posts', label:'Closed Posts', selectors:{bg:['.closed-posts'], text:['.closed-posts','.closed-posts .posts'], title:['.closed-posts .card .t','.closed-posts .card .title','.closed-posts .open-posts .t','.closed-posts .open-posts .title'], btn:['.closed-posts button'], btnText:['.closed-posts button'], card:['.closed-posts .card','.closed-posts .open-posts']}},
+    {key:'post-panel', label:'Closed Posts', selectors:{bg:['.post-panel'], text:['.post-panel','.post-panel .posts'], title:['.post-panel .card .t','.post-panel .card .title','.post-panel .open-posts .t','.post-panel .open-posts .title'], btn:['.post-panel button'], btnText:['.post-panel button'], card:['.post-panel .card','.post-panel .open-posts']}},
     {key:'open-posts', label:'Open Posts', selectors:{text:['.open-posts','.open-posts .venue-info','.open-posts .session-info'], title:['.open-posts .t','.open-posts .title'], btn:['.open-posts button'], btnText:['.open-posts button'], card:['.open-posts'], header:['.open-posts .detail-header'], image:['.open-posts .img-box'], menu:['.open-posts .venue-menu button','.open-posts .session-menu button']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},
     {key:'map', label:'Map', selectors:{popupBg:['.mapboxgl-popup .mapboxgl-popup-content','.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], popupText:['.mapboxgl-popup .hover-card','.mapboxgl-popup .chip','.mapboxgl-popup .chip-small','.mapboxgl-popup .multi-item'], title:['.mapboxgl-popup .hover-card .t','.mapboxgl-popup .hover-card .title','.mapboxgl-popup .chip .t','.mapboxgl-popup .chip .title','.mapboxgl-popup .chip-small .t','.mapboxgl-popup .chip-small .title','.mapboxgl-popup .multi-item .t','.mapboxgl-popup .multi-item .title']}},
-    {key:'filter', label:'Filter Panel', selectors:{bg:['#filterPanel .panel-content'], text:['#filterPanel .panel-content'], title:['#filterPanel .panel-content .t','#filterPanel .panel-content .title'], btn:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn'], btnText:['#filterPanel button','#filterPanel .sq','#filterPanel .tiny','#filterPanel .btn']}},
+    {key:'filter', label:'Filter Panel', selectors:{bg:['#filter-panel .panel-content'], text:['#filter-panel .panel-content'], title:['#filter-panel .panel-content .t','#filter-panel .panel-content .title'], btn:['#filter-panel button','#filter-panel .sq','#filter-panel .tiny','#filter-panel .btn'], btnText:['#filter-panel button','#filter-panel .sq','#filter-panel .tiny','#filter-panel .btn']}},
     {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar .day'], weekday:['.calendar .weekday'], title:['.calendar .calendar-header'], header:['.calendar .calendar-header']}},
-  {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},
+  {key:'admin-panel', label:'Admin Panel', selectors:{bg:['#admin-panel .panel-content'], text:['#admin-panel .panel-content'], title:['#admin-panel .panel-content .t','#admin-panel .panel-content .title'], btn:['#admin-panel button','#admin-panel #spinType span'], btnText:['#admin-panel button','#admin-panel #spinType span']}},
   {key:'welcomePopup', label:'Welcome Popup', selectors:{bg:['#welcomePopup .panel-content'], text:['#welcomePopup .panel-content'], title:['#welcomePopup .panel-content .t','#welcomePopup .panel-content .title'], btn:['#welcomePopup button'], btnText:['#welcomePopup button']}},
-  {key:'memberPanel', label:'Member Panel', selectors:{bg:['#memberPanel .panel-content'], text:['#memberPanel .panel-content'], title:['#memberPanel .panel-content .t','#memberPanel .panel-content .title'], btn:['#memberPanel button'], btnText:['#memberPanel button']}},
-  {key:'adPanel', label:'Ad Panel', selectors:{bg:['#adPanel']}},
+  {key:'member-panel', label:'Member Panel', selectors:{bg:['#member-panel .panel-content'], text:['#member-panel .panel-content'], title:['#member-panel .panel-content .t','#member-panel .panel-content .title'], btn:['#member-panel button'], btnText:['#member-panel button']}},
+  {key:'ad-panel', label:'Ad Panel', selectors:{bg:['#ad-panel']}},
   {key:'imagePanel', label:'Image Popup', selectors:{bg:['.img-popup']}}
 ];
   let lastFieldsetKey = null;
@@ -6278,8 +6279,8 @@ document.addEventListener('pointerdown', handleDocInteract);
     // Save/Discard/Restore logic
     const saveBtn = document.getElementById('saveNow');
     const discardBtn = document.getElementById('discardChanges');
-    const adminClose = document.querySelector('#adminPanel .close-panel');
-    const tabPanels = ['map','settings','forms'];
+    const adminClose = document.querySelector('#admin-panel .close-panel');
+    const tabPanels = ['map','settings','form'];
     const savedData = {};
 
     function toHex(val){
@@ -6292,7 +6293,7 @@ document.addEventListener('pointerdown', handleDocInteract);
     }
 
     function snapshot(tab){
-      const panel = document.getElementById(`tab-${tab}`);
+      const panel = document.getElementById(`${tab}-tab`);
       const inputs = panel.querySelectorAll('input,select,textarea,button.toggle-btn');
       const data = {};
       inputs.forEach(el=>{
@@ -6311,7 +6312,7 @@ document.addEventListener('pointerdown', handleDocInteract);
     }
 
     function applyData(tab,data){
-      const panel = document.getElementById(`tab-${tab}`);
+      const panel = document.getElementById(`${tab}-tab`);
       Object.entries(data||{}).forEach(([id,val])=>{
         const el = panel.querySelector(`#${id}`);
         if(!el) return;
@@ -6726,7 +6727,7 @@ document.querySelectorAll('.wysiwyg-toolbar button').forEach(btn => {
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('#adminPanel input[type="checkbox"]').forEach(cb => {
+  document.querySelectorAll('#admin-panel input[type="checkbox"]').forEach(cb => {
     if (cb.closest('.switch')) return;
     const wrapper = document.createElement('label');
     wrapper.className = 'switch';
@@ -6777,7 +6778,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (window.innerWidth >= 650) return;
 
-  const posts = document.querySelector('.closed-posts');
+  const posts = document.querySelector('.post-panel');
   if (!posts) return;
 
   let defaultSize = parseFloat(getComputedStyle(posts).fontSize);
@@ -6839,8 +6840,8 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  const adPanel = document.getElementById('adPanel');
-  const postsPanel = document.querySelector('.closed-posts');
+  const adPanel = document.getElementById('ad-panel');
+  const postsPanel = document.querySelector('.post-panel');
   if(adPanel){
     adPanel.addEventListener('click', e => {
       if(e.target === adPanel) setMode('map');


### PR DESCRIPTION
## Summary
- Rename panel elements to `list-panel`, `post-panel`, `ad-panel`, `filter-panel`, `member-panel`, and `admin-panel`
- Style panels and cards with new color scheme and uniform button appearance
- Add `panel-subheader` with `map-tab`, `settings-tab`, and `form-tab` identifiers for admin tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b90c3d5f4483318c69e5eb691b1648