### PR TITLE
fix: prevent admin panel crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -5962,6 +5962,10 @@ document.addEventListener('keydown', e=>{
   }
 });
 
+function syncAdminControls(){
+  // Placeholder to prevent errors if admin sync logic is not loaded
+}
+
 function handleDocInteract(e){
   if(e.target.closest('.img-popup')) return;
   if(logoEls.some(el => el.contains(e.target))) return;


### PR DESCRIPTION
## Summary
- Define placeholder `syncAdminControls` to avoid errors when opening admin panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9121dca788331ae7a68ccb710966f