### PR TITLE
Align list panel with header/footer and remove scroll gutters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1321,9 +1321,9 @@ button[aria-expanded="true"] .results-arrow{
 .list-panel{
   position: fixed;
   top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top));
-  left: var(--gap);
+  bottom: var(--footer-h);
+  left: 0;
   width: var(--results-w);
-  height: calc(100vh - var(--header-h) - var(--subheader-h) - var(--footer-h) - var(--safe-top));
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -1368,7 +1368,6 @@ body.filters-active #filterBtn{
   flex: 1;
   min-height: 0;
   height: 100%;
-  scrollbar-gutter: stable;
 }
 
 .card{
@@ -1649,13 +1648,12 @@ body.filters-active #filterBtn{
 .post-panel{
   display:none;
   position: fixed;
-  top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top) + var(--gap) - 12px);
+  top: calc(var(--header-h) + var(--subheader-h) + var(--safe-top));
   bottom: var(--footer-h);
-  left: calc(var(--results-w) + var(--gap) * 2);
+  left: var(--results-w);
   right: var(--gap);
   overflow-y:scroll;
   overflow-x:hidden;
-  scrollbar-gutter:stable;
   padding:0;
   color:#000;
   background: rgba(0,0,0,0.5);
@@ -2541,7 +2539,6 @@ footer .foot-row .foot-item,
   max-height: 360px;
   overflow-y: auto;
   overflow-x: hidden;
-  scrollbar-gutter: stable;
   padding: 2px 6px 2px 2px;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- Stretch list panel between header and footer and pin it to the screen's left edge.
- Align post panel with the list panel and remove spacing between them.
- Drop all `scrollbar-gutter` styles to eliminate scrollbar gutters across the site.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b929d45c708331b3983709ee95b129