### PR TITLE
Restore panel positions on reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -5878,7 +5878,12 @@ function openPanel(m){
       content.style.top='50%';
       content.style.transform='translate(-50%, -50%)';
     }
-    if(m.id !== 'welcomePopup' && !['admin-panel','member-panel','filter-panel'].includes(m.id)) loadPanelState(m);
+    if(
+      m.id !== 'welcomePopup' &&
+      (window.innerWidth >= 450 || !['admin-panel','member-panel','filter-panel'].includes(m.id))
+    ){
+      loadPanelState(m);
+    }
   }
   if(!m.__bringToTopAdded){
     m.addEventListener('mousedown', ()=> bringToTop(m));


### PR DESCRIPTION
## Summary
- Preserve custom panel placement by restoring saved positions on load when panels reopen.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b937e21b748331a5e7ae4cebe7697b