### PR TITLE
Spin only for new users and streamline result panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1331,6 +1331,8 @@ button[aria-expanded="true"] .results-arrow{
   transition: width .3s ease, padding .3s ease;
   z-index: 2;
   pointer-events: auto;
+  overflow: auto;
+  min-height: 0;
 }
 
 body.hide-results .list-panel{
@@ -1361,13 +1363,6 @@ body.filters-active #filterBtn{
 .options-menu{ position:absolute; top:calc(100% + 4px); left:0; background:var(--dropdown-bg); color:var(--dropdown-text); border:1px solid var(--border); border-radius:var(--dropdown-radius); padding:10px; display:flex; flex-direction:column; gap:6px; box-shadow:0 2px 6px rgba(0,0,0,0.2); z-index:30; }
 .options-menu[hidden]{ display:none; }
 .options-menu label{ display:flex; align-items:center; gap:6px; white-space:nowrap; }
-
-.res-list{
-  overflow: auto;
-  flex: 1;
-  min-height: 0;
-  height: 100%;
-}
 
 .card{
   display: grid;
@@ -1425,7 +1420,7 @@ body.filters-active #filterBtn{
   text-overflow: ellipsis;
 }
 
-.res-list .info{
+.list-panel .info{
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
@@ -1437,7 +1432,7 @@ body.filters-active #filterBtn{
   gap: 4px;
 }
 
-.res-list .info > div{
+.list-panel .info > div{
   display: flex;
   align-items: center;
   gap: 4px;
@@ -2737,17 +2732,6 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
   display: -webkit-box;
 }
 
-.list-panel .res-list{
-  border-radius: inherit;
-  padding:0;
-  margin:0;
-  flex:1;
-  overflow:auto;
-  min-height:0;
-  scrollbar-gutter: stable;
-  height: calc(100vh - var(--header-h) - var(--footer-h) - var(--safe-top));
-}
-
 
 .ad-panel{
   position:fixed;
@@ -2936,9 +2920,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     <div id="map"></div>
   </section>
 
-  <section id="list-panel" class="list-panel" aria-label="Results">
-    <div class="res-list" id="results"></div>
-  </section>
+  <section id="results" class="list-panel" aria-label="Results"></section>
 
   <section id="post-panel" class="post-panel" aria-label="Closed Posts">
     <div class="posts" id="postsWide"></div>
@@ -3312,7 +3294,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 
       let map, geocoder, memberGeocoder, spinning = false, resultsWasHidden = null, expiredWasOn = false, dateStart = null, dateEnd = null,
           spinLoadStart = JSON.parse(localStorage.getItem('spinLoadStart') ?? 'true'),
-          spinLoadType = localStorage.getItem('spinLoadType') || 'all',
+          spinLoadType = localStorage.getItem('spinLoadType') || 'new',
           spinLogoClick = localStorage.getItem('spinLogoClick') === 'false' ? false : true,
           spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),
           spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
@@ -3421,7 +3403,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
     const footerH = parseFloat(rootStyles.getPropertyValue('--footer-h')) || 0;
     const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
     const availableHeight = window.innerHeight - headerH - footerH - safeTop;
-      document.querySelectorAll('.res-list, .posts').forEach(list=>{
+      document.querySelectorAll('.list-panel, .posts').forEach(list=>{
         list.style.height = `${availableHeight}px`;
         list.style.maxHeight = `${availableHeight}px`;
       });
@@ -4348,7 +4330,7 @@ function makePosts(){
         }, 310);
       });
 
-      const resList = $('.res-list');
+      const resList = $('.list-panel');
       resList && resList.addEventListener('click', e=>{
         const cardEl = e.target.closest('.card');
         if(cardEl){
@@ -6169,7 +6151,7 @@ document.addEventListener('pointerdown', handleDocInteract);
   const colorAreas = [
     {key:'header', label:'Header', selectors:{bg:['.header'], text:['.header'], btn:['.header button','.header .gear','.header a'], btnText:['.header button','.header .gear','.header a']}},
     {key:'body', label:'Body', selectors:{bg:['body'], border:[], hoverBorder:[], activeBorder:[]}},
-    {key:'list', label:'List', selectors:{bg:['.res-list'], text:['.res-list'], title:['.res-list .card .t','.res-list .card .title'], btn:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], btnText:['.res-list button','.res-list .sq','.res-list .tiny','.res-list .btn'], card:['.res-list .card']}},
+    {key:'list', label:'List', selectors:{bg:['.list-panel'], text:['.list-panel'], title:['.list-panel .card .t','.list-panel .card .title'], btn:['.list-panel button','.list-panel .sq','.list-panel .tiny','.list-panel .btn'], btnText:['.list-panel button','.list-panel .sq','.list-panel .tiny','.list-panel .btn'], card:['.list-panel .card']}},
     {key:'post-panel', label:'Closed Posts', selectors:{bg:['.post-panel'], text:['.post-panel','.post-panel .posts'], title:['.post-panel .card .t','.post-panel .card .title','.post-panel .open-posts .t','.post-panel .open-posts .title'], btn:['.post-panel button'], btnText:['.post-panel button'], card:['.post-panel .card','.post-panel .open-posts']}},
     {key:'open-posts', label:'Open Posts', selectors:{text:['.open-posts','.open-posts .venue-info','.open-posts .session-info'], title:['.open-posts .t','.open-posts .title'], btn:['.open-posts button'], btnText:['.open-posts button'], card:['.open-posts'], header:['.open-posts .detail-header'], image:['.open-posts .img-box'], menu:['.open-posts .venue-menu button','.open-posts .session-menu button']}},
     {key:'footer', label:'Footer', selectors:{bg:['footer'], text:['footer'], card:['footer .foot-row .foot-item']}},


### PR DESCRIPTION
## Summary
- Spin globe on load only for first-time visitors
- Merge res-list into list-panel to prevent excessive padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93b8e5df88331bf1998a77e8a5dfb