### PR TITLE
Refine calendar and map styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
         --dropdown-venue-text: #000000;
         --dropdown-radius: 8px;
         --calendar-width: 300px;
-        --calendar-height: 250px;
+        --calendar-height: 200px;
         --calendar-cell-w: calc(var(--calendar-width) / 7);
         --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
         --calendar-header-h: var(--calendar-cell-h);
@@ -676,8 +676,9 @@ button[aria-expanded="true"] .results-arrow{
   justify-content:center;
   text-align:center;
   font-family:inherit;
-  font-size:inherit;
-  color:inherit;
+  font-size:14px;
+  color:#fff;
+  background:#00008b;
 }
 .calendar .weekday,
 .calendar .day{
@@ -690,7 +691,7 @@ button[aria-expanded="true"] .results-arrow{
   font-family:inherit;
   font-size:inherit;
 }
-.calendar .weekday{font-weight:bold;}
+.calendar .weekday{font-weight:bold;font-size:10px;color:#d3d3d3;}
 .calendar .day{cursor:pointer;}
 .calendar .day.empty{cursor:default;background:var(--calendar-future-bg);}
 .calendar .day.past{background:var(--calendar-past-bg);color:#b3b3b3;}
@@ -1195,7 +1196,7 @@ button[aria-expanded="true"] .results-arrow{
 
 
 .cats{
-  margin:8px 0;
+  margin:16px 0 0;
 }
 
 .cat{
@@ -1561,18 +1562,18 @@ body.filters-active #filterBtn{
 
 .geocoder .mapboxgl-ctrl-group button + button{border-left:1px solid #ccc;}
 .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
-.mapboxgl-ctrl button svg,
-.mapboxgl-ctrl button span{
+#map .mapboxgl-ctrl button svg,
+#map .mapboxgl-ctrl button span{
   display:block;
   margin:0;
 }
 .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button svg,
-.mapboxgl-ctrl button svg{
+#map .mapboxgl-ctrl button svg{
   width:20px;
   height:20px;
 }
 .geocoder .mapboxgl-ctrl-group{border-radius:8px;overflow:hidden;}
-.mapboxgl-ctrl button{
+#map .mapboxgl-ctrl button{
   line-height:var(--control-h);
   text-align:center;
   border-radius:8px;
@@ -1585,9 +1586,8 @@ body.filters-active #filterBtn{
   margin:0;
   padding:0 !important;
 }
-.mapboxgl-ctrl-group{overflow:hidden;}
-.mapboxgl-ctrl-geolocate,
-.mapboxgl-ctrl-compass{
+#map .mapboxgl-ctrl-geolocate,
+#map .mapboxgl-ctrl-compass{
   width:var(--control-h);
   height:var(--control-h);
   overflow:hidden;
@@ -1599,9 +1599,9 @@ body.filters-active #filterBtn{
 }
 #map .mapboxgl-ctrl-geolocate{background:var(--control-geolocate-bg) !important;}
 #map .mapboxgl-ctrl-compass{background:var(--control-compass-bg) !important;}
-.mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon,
-.mapboxgl-ctrl-compass .mapboxgl-ctrl-icon,
-.mapboxgl-ctrl-compass .mapboxgl-ctrl-compass-arrow{
+#map .mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon,
+#map .mapboxgl-ctrl-compass .mapboxgl-ctrl-icon,
+#map .mapboxgl-ctrl-compass .mapboxgl-ctrl-compass-arrow{
   margin:0;
   width:20px;
   height:20px;
@@ -1629,10 +1629,10 @@ body.filters-active #filterBtn{
   border-radius:8px;
   overflow:hidden;
 }
-.mapboxgl-ctrl-top-left,
-.mapboxgl-ctrl-top-right,
-.mapboxgl-ctrl-bottom-left,
-.mapboxgl-ctrl-bottom-right{
+#map .mapboxgl-ctrl-top-left,
+#map .mapboxgl-ctrl-top-right,
+#map .mapboxgl-ctrl-bottom-left,
+#map .mapboxgl-ctrl-bottom-right{
   margin:0;
 }
 
@@ -4338,7 +4338,7 @@ function makePosts(){
 
       const s = document.createElement('script');
       s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
-      s.onload = ()=>{
+      s.onload = ()=>{ if(typeof mapboxgl !== 'undefined'){ mapboxgl.accessToken = MAPBOX_TOKEN; }
         const g = document.createElement('script');
         g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         g.onload = cb;
@@ -4430,7 +4430,7 @@ function makePosts(){
 
     function ensureControlSizes(){
       const style = document.createElement('style');
-      style.textContent = '.mapboxgl-ctrl button,.mapboxgl-ctrl-geolocate,.mapboxgl-ctrl-compass{width:var(--control-h)!important;height:var(--control-h)!important;}';
+      style.textContent = '#map .mapboxgl-ctrl button,#map .mapboxgl-ctrl-geolocate,#map .mapboxgl-ctrl-compass{width:var(--control-h)!important;height:var(--control-h)!important;}';
       document.head.appendChild(style);
     }
 


### PR DESCRIPTION
## Summary
- Limit Mapbox control button styles to main map and set access token on load
- Restyle calendar header and weekdays and shrink overall calendar height
- Add spacing to place category filters below date picker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94a0be0c0833182dd3056e689135b