### PR TITLE
Fix Mapbox token handling to restore calendars

### DIFF
--- a/index.html
+++ b/index.html
@@ -4316,7 +4316,12 @@ function makePosts(){
 
     // Mapbox
     function loadMapbox(cb){
-      if(window.mapboxgl && window.MapboxGeocoder) return cb();
+      if(window.mapboxgl && window.MapboxGeocoder){
+        if(!mapboxgl.accessToken && typeof MAPBOX_TOKEN !== 'undefined'){
+          mapboxgl.accessToken = MAPBOX_TOKEN;
+        }
+        return cb();
+      }
 
       function injectCleanCSS(url, fallback){
         fetch(url).then(r=>r.text()).then(css=>{
@@ -4339,6 +4344,9 @@ function makePosts(){
       const s = document.createElement('script');
       s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = ()=>{
+        if(typeof MAPBOX_TOKEN !== 'undefined'){
+          mapboxgl.accessToken = MAPBOX_TOKEN;
+        }
         const g = document.createElement('script');
         g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         g.onload = cb;
@@ -5404,14 +5412,19 @@ function makePosts(){
         if(venueBtn) venueBtn.innerHTML = `<span class="venue-name">${loc.venue}</span><span class="venue-address">${loc.address}</span>${p.locations.length>1?'<span class="results-arrow" aria-hidden="true"></span>':''}`;
         sessionHasMultiple = loc.dates.length > 1;
         if(!map){
-          map = new mapboxgl.Map({
-            container: mapEl,
-            style: 'mapbox://styles/mapbox/standard',
-            center: [loc.lng, loc.lat],
-            zoom: 10,
-            interactive: false
-          });
-          marker = new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).addTo(map);
+          if(typeof MAPBOX_TOKEN !== 'undefined' && !mapboxgl.accessToken){
+            mapboxgl.accessToken = MAPBOX_TOKEN;
+          }
+          if(mapboxgl.accessToken){
+            map = new mapboxgl.Map({
+              container: mapEl,
+              style: 'mapbox://styles/mapbox/standard',
+              center: [loc.lng, loc.lat],
+              zoom: 10,
+              interactive: false
+            });
+            marker = new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).addTo(map);
+          }
         } else {
           map.setCenter([loc.lng, loc.lat]);
           marker.setLngLat([loc.lng, loc.lat]);


### PR DESCRIPTION
## Summary
- Guard Mapbox initialization to set access token before any map usage
- Skip map creation when token missing so calendars still render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94ce8466c8331abb325dcd805af8e