### PR TITLE
Prevent map mode toggle when spin inactive

### DIFF
--- a/index.html
+++ b/index.html
@@ -4521,9 +4521,9 @@ function makePosts(){
       }
 
     function startSpin(fromCurrent=false){
-      if(mode!=='map') setMode('map');
       if(!spinEnabled || spinning || !map) return;
       if(map.getZoom() >= 5) return;
+      if(mode!=='map') setMode('map');
       if(typeof filterPanel !== 'undefined' && filterPanel) requestClosePanel(filterPanel);
       spinning = true;
       resultsWasHidden = document.body.classList.contains('hide-results');


### PR DESCRIPTION
## Summary
- check spin state before switching to map mode in `startSpin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9511890488331bef3281af5185851