### PR TITLE
Adjust geolocate fly-to pitch

### DIFF
--- a/index.html
+++ b/index.html
@@ -4465,7 +4465,7 @@ function makePosts(){
         map.flyTo({
           center: [e.coords.longitude, e.coords.latitude],
           zoom: Math.max(map.getZoom(), 12),
-          pitch: 45,
+          pitch: 10,
           essential: true
         });
       });


### PR DESCRIPTION
## Summary
- Lower map pitch to 10° when geolocate is used so landing view is nearly flat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b955e243dc83318e73d5a807823fea