### PR TITLE
Fix date picker container height

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,6 +510,13 @@ button[aria-expanded="true"] .results-arrow{
 .panel.visible{
   opacity:1;
 }
+#filter-panel{
+  display:block;
+  visibility:hidden;
+}
+#filter-panel.show{
+  visibility:visible;
+}
 .panel-content{
   position:absolute;
   border-radius:8px;


### PR DESCRIPTION
## Summary
- Keep filter panel rendered but hidden so the calendar container retains its height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9656e537083318a8e6cc81d7597d1