### PR TITLE
Ensure filter-panel date picker has initial height

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,6 +648,7 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filter-panel #datePicker{
   width:max-content;
+  height:100%;
 }
 #filter-panel .calendar{
   display:flex;


### PR DESCRIPTION
## Summary
- Keep filter-panel date picker visible by applying a full-height style to `#datePicker` so it no longer reports 0px height before the calendar is rendered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b970c528d48331b139a1c150e619cf