### PR TITLE
Refresh ad panel based on significant map movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -4959,7 +4959,7 @@ function makePosts(){
         if(renderResults) resultsEl.appendChild(card(p));
         postsWideEl.appendChild(card(p, true));
       });
-      buildAdPanel(arr);
+      maybeUpdateAdPanel(arr);
       if(renderResults && activePostId){
         const sel = resultsEl.querySelector(`[data-id="${activePostId}"]`);
         if(sel) sel.setAttribute('aria-selected','true');
@@ -4988,6 +4988,7 @@ function makePosts(){
     }
 
     let adInterval;
+    let lastAdUpdateCenter;
     function buildAdPanel(paid){
       const panel = $('#ad-panel');
       panel.innerHTML = '';
@@ -5029,6 +5030,16 @@ function makePosts(){
             activate(idx);
           },20000);
         }
+      }
+    }
+
+    function maybeUpdateAdPanel(paid){
+      if(!map) return;
+      const c = map.getCenter();
+      const current = {lng:c.lng, lat:c.lat};
+      if(!lastAdUpdateCenter || distKm(current, lastAdUpdateCenter) > 50){
+        buildAdPanel(paid);
+        lastAdUpdateCenter = current;
       }
     }
 


### PR DESCRIPTION
## Summary
- Only refresh ad panel after map center shifts over 50km
- Preserve ad panel content from click-triggered updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9784fb8b88331b2c0aada224a2b90