### PR TITLE
Fix date picker height to 200px

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filter-panel #datePicker{
   width:max-content;
-  height:100%;
+  height:200px;
 }
 #filter-panel .calendar{
   display:flex;


### PR DESCRIPTION
## Summary
- Set `#filter-panel #datePicker` height to a fixed 200px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97c07ee088331802398dac6f83ee1