### PR TITLE
Extend filter panel height

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,7 +584,7 @@ button[aria-expanded="true"] .results-arrow{
   }
   #filter-panel .panel-content{
     width:420px;
-    height:100vh;
+    height:2500px;
     padding:10px;
     box-sizing:border-box;
     background:#333333;


### PR DESCRIPTION
## Summary
- increase filter panel height to 2500px for expanded layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b97f7a69908331ba29c1220ab721a8