### PR TITLE
Remove flex layout from datepicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,14 +667,11 @@ button[aria-expanded="true"] .results-arrow{
   flex:0 0 auto;
   width:var(--calendar-width);
   height:var(--calendar-height);
-  display:flex;
-  flex-direction:column;
 }
 .calendar .month:not(:first-child){
   border-left:1px solid var(--calendar-past-bg);
 }
 .calendar .grid{
-  flex:1 1 auto;
   width:100%;
   height:calc(var(--calendar-height) - var(--calendar-header-h) - var(--scrollbar-h));
   display:grid;


### PR DESCRIPTION
## Summary
- eliminate flex container styling from calendar months to prevent vertical flex on the datepicker
- clean up grid styles for datepicker calendar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98b24ee9c8331a4db18d4f3623705