### PR TITLE
Remove flex from date picker calendar container

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,7 +656,6 @@ button[aria-expanded="true"] .results-arrow{
   height:200px;
 }
 #filter-panel .calendar{
-  display:flex;
   width:max-content;
   transform:scale(var(--calendar-scale));
   transform-origin:top left;


### PR DESCRIPTION
## Summary
- remove flex layout from date picker calendar container to restore stacked months

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99391c08c83319ddf85fcbc429d3d