### PR TITLE
Remove filter panel flex column

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,11 +603,15 @@ button[aria-expanded="true"] .results-arrow{
   border: none;
 }
 
-#filter-panel .panel-body,
 #member-panel .panel-body,
 #admin-panel .panel-body{
   display:flex;
   flex-direction:column;
+  align-items:flex-start;
+  gap:10px;
+}
+#filter-panel .panel-body{
+  display:flex;
   align-items:flex-start;
   gap:10px;
 }


### PR DESCRIPTION
## Summary
- prevent filter panel from using column-oriented flex layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b999128b348331880c7206b70907a4