### PR TITLE
Fix initial globe spin direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -4621,8 +4621,8 @@ function makePosts(){
       if(fromCurrent){
         requestAnimationFrame(step);
       }else{
-        map.easeTo({center:[0,0], zoom:startZoom, pitch:0, essential:true});
-        map.once('moveend', () => requestAnimationFrame(step));
+        map.jumpTo({center:[0,0], zoom:startZoom, pitch:0});
+        requestAnimationFrame(step);
       }
     }
     function stopSpin(){


### PR DESCRIPTION
## Summary
- eliminate reverse spin by starting the globe rotation without easing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a529c8588331949b782dbc85d70b