### PR TITLE
Update layout and controls styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,15 +58,15 @@
       --popup-bg: rgba(0,0,0,1);
       --popup-text: #ffffff;
       --dropdown-title: #000000;
-      --dropdown-selected-bg: rgba(224,224,224,1);
-      --dropdown-selected-text: #000000;
-      --dropdown-text: #000000;
-      --dropdown-bg: rgba(255,255,255,1);
-      --dropdown-hover-bg: rgba(224,224,224,1);
-      --dropdown-hover-text: #000000;
-        --dropdown-venue-text: #000000;
-        --dropdown-radius: 8px;
-        --calendar-width: 300px;
+      --dropdown-selected-bg: rgba(255,255,255,0.2);
+      --dropdown-selected-text: #ffffff;
+      --dropdown-text: #ffffff;
+      --dropdown-bg: rgba(0,0,0,0.9);
+      --dropdown-hover-bg: rgba(255,255,255,0.1);
+      --dropdown-hover-text: #ffffff;
+        --dropdown-venue-text: #ffffff;
+        --dropdown-radius: 4px;
+        --calendar-width: 400px;
         --calendar-height: 250px;
         --calendar-cell-w: calc(var(--calendar-width) / 7);
         --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
@@ -172,7 +172,7 @@ button:not([class^="mapboxgl-ctrl"]),
   padding: 0 10px;
   height: var(--control-h);
   min-width: 35px;
-  border-radius: 8px;
+  border-radius: 4px;
   opacity: 1;
   display: inline-flex;
   align-items: center;
@@ -311,6 +311,7 @@ input[type="checkbox"]{
     left: 0;
     right: 0;
     z-index: 20;
+    background: rgba(0,0,0,0.7);
   }
 
   .logo{
@@ -359,7 +360,7 @@ input[type="checkbox"]{
 .auth button,
 .options-menu button{
   height:35px;
-  border-radius:8px;
+  border-radius:4px;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -368,7 +369,7 @@ input[type="checkbox"]{
 }
 .header .gear,
 .header a{
-  border-radius:8px;
+  border-radius:4px;
 }
 
 
@@ -561,10 +562,11 @@ button[aria-expanded="true"] .results-arrow{
     width:420px;
     max-width:90%;
     max-height:90%;
-    background:#333333;
+    background:rgba(0,0,0,0.7);
     color:#fff;
     transition:transform 0.3s ease;
   }
+#filter-panel .panel-content{font-size:12px;}
 
 #filter-panel button,
 #filter-panel .sq,
@@ -588,6 +590,7 @@ button[aria-expanded="true"] .results-arrow{
   --calendar-height:200px;
   --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
   --calendar-header-h: var(--calendar-cell-h);
+  --panel-label-size:12px;
 }
 #filter-panel input[type="text"]{
   background: var(--panel-bg);
@@ -1054,10 +1057,14 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filter-panel #kwInput{
   background: var(--keyword-bg);
+  width:300px;
+  flex:none;
 }
 #filter-panel #dateInput{
   background: var(--date-range-bg);
   color: var(--date-range-text);
+  width:300px;
+  flex:none;
 }
 
 .input .down{
@@ -1177,6 +1184,7 @@ button[aria-expanded="true"] .results-arrow{
 
 .cats{
   margin:8px 0;
+  width:300px;
 }
 
 .cat{
@@ -1185,11 +1193,12 @@ button[aria-expanded="true"] .results-arrow{
   gap: 8px;
   align-items: center;
   margin: 8px 0;
+  width:300px;
 }
 
 .cat .bar{
   height: 36px;
-  border-radius: 8px;
+  border-radius: 4px;
   padding-left: 12px;
   display: flex;
   align-items: center;
@@ -1219,7 +1228,7 @@ button[aria-expanded="true"] .results-arrow{
   place-items: center;
   width: 38px;
   height: 36px;
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--btn);
   border: 1px solid var(--btn);
   cursor: pointer;
@@ -1350,6 +1359,7 @@ body.filters-active #filterBtn{
     height: calc(100vh - var(--header-h) - var(--footer-h) - var(--safe-top));
   }
 
+
 .card{
   display: grid;
   grid-template-columns:90px 1fr 36px;
@@ -1357,7 +1367,7 @@ body.filters-active #filterBtn{
   align-items: flex-start;
   background: var(--list-background);
   border: none;
-  border-radius:8px;
+  border-radius:4px;
   padding:12px;
   margin-bottom:12px;
   cursor:pointer;
@@ -1366,11 +1376,37 @@ body.filters-active #filterBtn{
 .thumb{
   width: 90px;
   height: 70px;
-  border-radius: 8px;
+  border-radius: 4px;
   object-fit: cover;
   display: block;
   background: var(--panel-bg);
   transition: filter .22s ease;
+}
+
+.res-list .card{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  padding:0;
+  overflow:hidden;
+}
+
+.res-list .card .thumb{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  border-radius:0;
+  z-index:-1;
+}
+
+.res-list .card .meta{
+  position:relative;
+  background:rgba(0,0,0,0.5);
+  color:#fff;
+  width:100%;
+  padding:12px;
+  box-sizing:border-box;
 }
 
 .thumb.lqip{
@@ -1507,15 +1543,15 @@ body.filters-active #filterBtn{
   position:static;
   transform:none;
   z-index:10;
-  min-width:240px;
+  min-width:300px;
   pointer-events:auto;
   display:flex;
   align-items:center;
   gap:6px;
-  width:100%;
+  width:300px;
   margin-bottom:var(--gap);
 }
-.geocoder .mapboxgl-ctrl-geocoder{position:relative;height:var(--control-h);min-width:240px !important;background:var(--control-text-bg) !important;border:1px solid #ccc !important;width:100%;flex:1;border-radius:8px;overflow:visible;font-size:16px;}
+.geocoder .mapboxgl-ctrl-geocoder{position:relative;height:var(--control-h);min-width:300px !important;background:var(--control-text-bg) !important;border:1px solid #ccc !important;width:300px;flex:none;border-radius:4px;overflow:visible;font-size:16px;}
 .geocoder .mapboxgl-ctrl-geocoder--suggestions,
 .geocoder .mapboxgl-ctrl-geocoder .suggestions{top:var(--control-h);}
 .geocoder .mapboxgl-ctrl-geocoder input{height:100%;line-height:var(--control-h);padding:0 var(--control-h) 0 10px;background:var(--control-text-bg) !important;color:#000;font-family:inherit;font-size:16px;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
@@ -1557,7 +1593,7 @@ body.filters-active #filterBtn{
   width:20px;
   height:20px;
 }
-.geocoder .mapboxgl-ctrl-group{border-radius:8px;overflow:hidden;}
+.geocoder .mapboxgl-ctrl-group{border-radius:4px;overflow:hidden;}
 .mapboxgl-ctrl button{
   line-height:var(--control-h);
   text-align:center;
@@ -1661,7 +1697,7 @@ body.hide-results .post-panel{
 }
 .map-area{
   position: fixed;
-  top: calc(var(--header-h) + var(--safe-top));
+  top: 0;
   left: 0;
   right: 0;
   bottom: 0;
@@ -2337,7 +2373,7 @@ footer{
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  background: var(--list-background);
+  background: rgba(0,0,0,0.7);
   position: fixed;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
## Summary
- make header and footer semi-transparent black and stretch map to top
- restyle list results cards with full-width thumbnails and square corners
- darken panels and dropdown menus; standardize control widths and text size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c3f8e49c83319ac50d438f7ed8eb