### PR TITLE
style: adjust datepicker calendar width and background

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,6 +587,7 @@ button[aria-expanded="true"] .results-arrow{
   height:35px;
 }
 #filter-panel{
+  --calendar-width:250px;
   --calendar-height:200px;
   --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
   --calendar-header-h: var(--calendar-cell-h);
@@ -597,7 +598,7 @@ button[aria-expanded="true"] .results-arrow{
   color: var(--panel-text);
 }
 #filter-panel .calendar-container{
-  background: var(--dropdown-bg);
+  background: #333333;
   position:relative;
   overflow-x:auto;
   overflow-y:hidden;
@@ -626,7 +627,7 @@ button[aria-expanded="true"] .results-arrow{
   width:max-content;
   transform:scale(var(--calendar-scale));
   transform-origin:top left;
-  background:var(--dropdown-bg);
+  background:#333333;
   color:var(--dropdown-text);
 }
 .calendar .month{


### PR DESCRIPTION
## Summary
- Set filter panel calendar width to 250px
- Give datepicker a consistent #333333 background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c88d5b708331819778a8eac43d07