### PR TITLE
Use thumbnails as list-card backgrounds with side image

### DIFF
--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@ body.filters-active #filterBtn{
 
 .card{
   display: grid;
-  grid-template-columns:90px 1fr 36px;
+  grid-template-columns:80px 1fr 36px;
   gap:12px;
   align-items: flex-start;
   background: var(--list-background);
@@ -1375,8 +1375,8 @@ body.filters-active #filterBtn{
 }
 
 .thumb{
-  width: 90px;
-  height: 70px;
+  width: 80px;
+  height: 80px;
   border-radius: 4px;
   object-fit: cover;
   display: block;
@@ -1386,19 +1386,9 @@ body.filters-active #filterBtn{
 
 .res-list .card{
   position:relative;
-  display:flex;
-  flex-direction:column;
-  padding:0;
   overflow:hidden;
-}
-
-.res-list .card .thumb{
-  position:absolute;
-  inset:0;
-  width:100%;
-  height:100%;
-  border-radius:0;
-  z-index:-1;
+  background-size:cover;
+  background-position:center;
 }
 
 .res-list .card .meta{
@@ -1406,7 +1396,7 @@ body.filters-active #filterBtn{
   background:rgba(0,0,0,0.5);
   color:#fff;
   width:100%;
-  padding:12px;
+  padding:0;
   box-sizing:border-box;
 }
 
@@ -2456,12 +2446,12 @@ footer .foot-row .foot-item,
 }
 
 .card .thumb{
-  flex: 0 0 90px;
-  width: 90px;
-  height: 70px;
+  flex: 0 0 80px;
+  width: 80px;
+  height: 80px;
   display: block;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: 4px;
 }
 
 .post-panel .card .thumb{
@@ -2671,6 +2661,7 @@ img.thumb{
   width: 80px;
   height: 80px;
   object-fit: cover;
+  border-radius: 4px;
 }
 
 #results .card > img, #results .card img.thumb{
@@ -2679,6 +2670,7 @@ img.thumb{
   aspect-ratio: 1/1;
   object-fit: cover;
   display: block;
+  border-radius: 4px;
 }
 
 footer .foot-row .foot-item > img, footer .foot-row .foot-item img{
@@ -5154,6 +5146,9 @@ function makePosts(){
       const el = document.createElement('article');
       el.className = 'card';
       el.dataset.id = p.id;
+      el.style.backgroundImage = `url(${imgThumb(p)})`;
+      el.style.backgroundSize = 'cover';
+      el.style.backgroundPosition = 'center';
       if(wide) el.style.gridTemplateColumns='80px 1fr 36px';
       const thumb = `<img class="thumb lqip" loading="lazy" src="${svgPlaceholder(p.id)}" data-src="${imgThumb(p)}" alt="" referrerpolicy="no-referrer" />`;
         el.innerHTML = `


### PR DESCRIPTION
## Summary
- Display list-card thumbnails as full-card background images
- Add visible 80x80px thumbnail column on the left of each card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c71a96d8833182fbd002b79f9b13