### PR TITLE
refactor: update lighting and card visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1317,7 +1317,7 @@ button[aria-expanded="true"] .results-arrow{
   display: flex;
   flex-direction: column;
   padding: 0;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0,0,0,0);
   transition: width .3s ease, padding .3s ease;
   z-index: 2;
   pointer-events: auto;
@@ -4584,9 +4584,9 @@ function makePosts(){
             attributionControl:true
           });
       updateSunLight = function(){
-        if(!map || typeof map.setLight !== 'function') return;
+        if(!map || typeof map.setLights !== 'function') return;
         if(!dynamicSun){
-          map.setLight({anchor:'map', position:[180,50]});
+          map.setLights([{anchor:'map', position:[180,50], type:'flat'}]);
           if(mapStyle.endsWith('/standard')){
             try{ map.setConfigProperty('basemap','lightPreset','day'); }catch{}
           }
@@ -4597,7 +4597,7 @@ function makePosts(){
         const pos = SunCalc.getPosition(new Date(), center.lat, center.lng);
         const azimuth = 180 + pos.azimuth * 180 / Math.PI;
         const altitude = 90 - pos.altitude * 180 / Math.PI;
-        map.setLight({anchor:'map', position:[azimuth, altitude]});
+        map.setLights([{anchor:'map', position:[azimuth, altitude], type:'flat'}]);
         if(mapStyle.endsWith('/standard')){
           const preset = pos.altitude <= 0 ? 'night' : 'day';
           try{ map.setConfigProperty('basemap','lightPreset', preset); }catch{}
@@ -5169,7 +5169,7 @@ function makePosts(){
       const el = document.createElement('article');
       el.className = 'card';
       el.dataset.id = p.id;
-      el.style.backgroundImage = `url(${imgThumb(p)})`;
+      el.style.backgroundImage = `linear-gradient(to bottom, rgba(0,0,0,0.6), rgba(0,0,0,0)), url(${imgThumb(p)})`;
       el.style.backgroundSize = 'cover';
       el.style.backgroundPosition = 'center';
       if(wide) el.style.gridTemplateColumns='80px 1fr 36px';


### PR DESCRIPTION
## Summary
- replace deprecated `map.setLight` with `map.setLights` using flat lighting
- make list panel background transparent and add gradient overlay to cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d03aafec83318e53663ed11f42c5