### PR TITLE
Ensure Mapbox CSS loads and defer sunlight updates until style ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" />
   <style>:root{
   --header-h: 75px;
   --panel-w: 300px;
@@ -4450,24 +4452,6 @@ function makePosts(){
     function loadMapbox(cb){
       if(window.mapboxgl && window.MapboxGeocoder) return cb();
 
-      function injectCleanCSS(url, fallback){
-        fetch(url).then(r=>r.text()).then(css=>{
-          css = css.replace(/-ms-high-contrast/g,'forced-colors');
-          const style = document.createElement('style');
-          style.textContent = css;
-          document.head.appendChild(style);
-        }).catch(()=>{
-          const link = document.createElement('link');
-          link.rel='stylesheet';
-          link.href = fallback || url;
-          document.head.appendChild(link);
-        });
-      }
-
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css');
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css',
-        'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
-
       const s = document.createElement('script');
       s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = ()=>{
@@ -4584,7 +4568,7 @@ function makePosts(){
             attributionControl:true
           });
       updateSunLight = function(){
-        if(!map || typeof map.setLights !== 'function') return;
+        if(!map || typeof map.setLights !== 'function' || !map.isStyleLoaded()) return;
         if(!dynamicSun){
           map.setLights([{anchor:'map', position:[180,50], type:'flat'}]);
           if(mapStyle.endsWith('/standard')){
@@ -4634,7 +4618,6 @@ function makePosts(){
         updateSunLight();
       });
       map.on('move', updateSunLight);
-      updateSunLight();
       setInterval(updateSunLight, 60000);
       map.on('load', ()=>{
         $$('.map-overlay').forEach(el=>el.remove());


### PR DESCRIPTION
## Summary
- Embed Mapbox GL JS and geocoder CSS via standard `<link>` tags
- Simplify Mapbox loader by removing runtime CSS injection
- Guard updateSunLight against executing before the map style is loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d1ddd5ec8331aaf561f69f07ccf1