### PR TITLE
Darken map and disable dynamic sunlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -1516,6 +1516,9 @@ body.filters-active #filterBtn{
   position: absolute;
   inset: 0;
 }
+#map .mapboxgl-canvas{
+  filter: brightness(0.7) contrast(1.3);
+}
 
 .map-overlay{
   position: absolute;
@@ -3010,7 +3013,7 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
               <button id="optionsBtn" aria-haspopup="true" aria-expanded="false">Title A - Z</button>
               <div id="optionsMenu" class="options-menu" hidden>
                 <button id="favToggle" aria-pressed="false">Favourites on top<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 17.3 6.2 21l1.6-6.7L2 9.3l6.9-.6L12 2l3.1 6.7 6.9.6-5.8 4.9L17.8 21 12 17.3z"/></svg></button>
-                <div class="sort-options" role="group" aria-label="Sort order" style="display:flex; flex-direction:column; gap:6px;">
+                <div class="sort-options" role="group" aria-label="Sort options" style="display:flex; flex-direction:column; gap:6px;">
                   <button class="sort-option" data-sort="az" aria-pressed="true">Title A - Z</button>
                   <button class="sort-option" data-sort="nearest" aria-pressed="false">Closest</button>
                   <button class="sort-option" data-sort="soon" aria-pressed="false">Soonest</button>
@@ -3359,9 +3362,9 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
           spinLogoClick = localStorage.getItem('spinLogoClick') === 'false' ? false : true,
           spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),
           spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
-          mapStyle = window.mapStyle = normalizeMapStyle(localStorage.getItem('mapStyle')) || 'mapbox://styles/mapbox/standard',
+          mapStyle = window.mapStyle = normalizeMapStyle(localStorage.getItem('mapStyle')) || 'mapbox://styles/mapbox/dark-v11',
           skyStyle = window.skyStyle = localStorage.getItem('skyStyle') || 'night',
-          dynamicSun = localStorage.getItem('dynamicSun') !== 'false',
+          dynamicSun = localStorage.getItem('dynamicSun') === 'true',
           clusterRadius = parseInt(localStorage.getItem('clusterRadius') || '52', 10),
           clusterMaxZoom = parseInt(localStorage.getItem('clusterMaxZoom') || '14', 10),
           clusterIconType = localStorage.getItem('clusterIconType') || 'circle',


### PR DESCRIPTION
## Summary
- Disable dynamic sunlight by default and switch default map theme to a darker style
- Remove "Sort order" wording from filter bar options
- Increase map contrast with darker appearance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d41bcc8c8331ba224f56f7b757b6