### PR TITLE
Add gradient overlay to list cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1392,10 +1392,19 @@ body.filters-active #filterBtn{
   background-size:cover;
   background-position:center;
 }
+.res-list .card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(to bottom,rgba(0,0,0,0.8),rgba(0,0,0,0.3));
+  pointer-events:none;
+  z-index:0;
+}
 
 .res-list .card .meta{
   position:relative;
-  background:rgba(0,0,0,0.5);
+  background:rgba(0,0,0,0);
+  z-index:1;
   color:#fff;
   width:100%;
   padding:0;


### PR DESCRIPTION
## Summary
- Add black-to-transparent gradient overlay covering entire list cards
- Remove meta background tint, keeping text unobstructed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d44222b08331ad101c3793b19eac