### PR TITLE
Ensure card visuals layer correctly and use header thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -1384,6 +1384,8 @@ body.filters-active #filterBtn{
   display: block;
   background: var(--panel-bg);
   transition: filter .22s ease;
+  position: relative;
+  z-index: 1;
 }
 
 .res-list .card{
@@ -1409,6 +1411,15 @@ body.filters-active #filterBtn{
   width:100%;
   padding:0;
   box-sizing:border-box;
+}
+
+.res-list .card .meta,
+.res-list .card .meta *{
+  text-shadow:0 2px 4px rgba(0,0,0,0.8);
+}
+
+.res-list .card .fav{
+  z-index:2;
 }
 
 .thumb.lqip{
@@ -1487,6 +1498,8 @@ body.filters-active #filterBtn{
   place-items: center;
   background: var(--btn);
   border: 1px solid var(--btn);
+  position: relative;
+  z-index: 2;
 }
 
 .fav svg{
@@ -1685,6 +1698,40 @@ body.filters-active #filterBtn{
 .post-panel .open-posts{background:var(--closed-card-bg);}
 .post-panel button{background:var(--btn);border-color:var(--btn);color:var(--ink);}
 .post-panel .open-posts{margin-top:12px}
+.post-panel .card{
+  position:relative;
+  overflow:hidden;
+  background-size:cover;
+  background-position:center;
+}
+.post-panel .card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(to bottom,rgba(0,0,0,0.8),rgba(0,0,0,0.3));
+  pointer-events:none;
+  z-index:0;
+}
+.post-panel .card .thumb{
+  position:relative;
+  z-index:1;
+}
+.post-panel .card .fav{
+  z-index:2;
+}
+.post-panel .card .meta{
+  position:relative;
+  background:rgba(0,0,0,0);
+  z-index:1;
+  color:#fff;
+  width:100%;
+  padding:0;
+  box-sizing:border-box;
+}
+.post-panel .card .meta,
+.post-panel .card .meta *{
+  text-shadow:0 2px 4px rgba(0,0,0,0.8);
+}
 .post-panel.ad-space{right:calc(400px + var(--gap) * 2);}
 
 body.hide-results .post-panel{
@@ -1721,6 +1768,7 @@ body.hide-results .post-panel{
 }
 
 .open-posts .detail-header{
+  position:relative;
   display:flex;
   justify-content:space-between;
   align-items:center;
@@ -1728,13 +1776,31 @@ body.hide-results .post-panel{
   opacity:1;
   border-top-left-radius:inherit;
   border-top-right-radius:inherit;
-  background:#3E5393;
+  background-size:cover;
+  background-position:center;
+  color:#fff;
+}
+.open-posts .detail-header::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(to bottom,rgba(0,0,0,0.8),rgba(0,0,0,0.3));
+  z-index:0;
+}
+.open-posts .detail-header .title-block,
+.open-posts .detail-header .fav{
+  position:relative;
+  z-index:1;
+}
+.open-posts .detail-header .fav{z-index:2;}
+.open-posts .detail-header .title-block,
+.open-posts .detail-header .title-block *{
+  text-shadow:0 2px 4px rgba(0,0,0,0.8);
 }
 .open-posts-sticky-header .open-posts .detail-header{
   position:sticky;
   top:0;
   z-index:3;
-  background:var(--list-background);
 }
 
 .open-posts .body{
@@ -5332,6 +5398,12 @@ function makePosts(){
             <div class="desc-wrap"><div class="desc">${p.desc}</div></div>
           </div>
         </div>`;
+      const header = wrap.querySelector('.detail-header');
+      if(header){
+        header.style.backgroundImage = `url(${imgThumb(p)})`;
+        header.style.backgroundSize = 'cover';
+        header.style.backgroundPosition = 'center';
+      }
         // progressive hero swap
         (function(){
           const img = wrap.querySelector('#hero-img');


### PR DESCRIPTION
## Summary
- Add text shadows and z-index tweaks so thumbnails and favourite buttons sit above gradients
- Mirror list panel card styling in the post panel for consistent gradients and text treatment
- Use each post's thumbnail as the open post header background with an 80/30 gradient overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d74810a88331b368985eafa6e5a9