### PR TITLE
style: use #0000E6 for calendar day boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
         --calendar-cell-w: calc(var(--calendar-width) / 7);
         --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
         --calendar-header-h: var(--calendar-cell-h);
-        --calendar-past-bg: #222222;
-        --calendar-future-bg: #222222;
+        --calendar-past-bg: #0000E6;
+        --calendar-future-bg: #0000E6;
         --session-available: #92D0F7;
         --session-selected: #009FFF;
         --today: #ff0000;
@@ -600,7 +600,7 @@ button[aria-expanded="true"] .results-arrow{
   color: var(--panel-text);
 }
 #filter-panel .calendar-container{
-  background: #333333;
+  background: #0000E6;
   position:relative;
   overflow-x:auto;
   overflow-y:hidden;
@@ -629,7 +629,7 @@ button[aria-expanded="true"] .results-arrow{
   width:max-content;
   transform:scale(var(--calendar-scale));
   transform-origin:top left;
-  background:#333333;
+  background:#0000E6;
   color:var(--dropdown-text);
 }
 .calendar .month{
@@ -2182,7 +2182,7 @@ body.hide-results .post-panel{
   overflow-y:hidden;
   padding-bottom:0;
   box-sizing:content-box;
-  background:var(--dropdown-bg);
+  background:#0000E6;
   border:1px solid var(--border);
   border-radius:8px;
   flex:1 1 auto;
@@ -2195,7 +2195,7 @@ body.hide-results .post-panel{
   height:100%;
   transform:scale(var(--calendar-scale));
   transform-origin:top left;
-  background:var(--dropdown-bg);
+  background:#0000E6;
   color:var(--dropdown-text);
 }
 .open-posts .post-calendar .month{


### PR DESCRIPTION
## Summary
- use #0000E6 as the default calendar day cell color
- apply the same blue background to both filter and post calendars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9db70b47c833196388fb1c4638935