### PR TITLE
Adjust session calendar styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         --dropdown-venue-text: #ffffff;
         --dropdown-radius: 4px;
         --calendar-width: 400px;
-        --calendar-height: 250px;
+        --calendar-height: 200px;
         --calendar-cell-w: calc(var(--calendar-width) / 7);
         --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
         --calendar-header-h: var(--calendar-cell-h);
@@ -2224,7 +2224,8 @@ body.hide-results .post-panel{
   align-items:center;
   justify-content:center;
   text-align:center;
-  font-weight:bold;
+  font-size:14px;
+  font-weight:normal;
 }
 .open-posts .post-calendar .weekday,
 .open-posts .post-calendar .day{
@@ -2233,6 +2234,9 @@ body.hide-results .post-panel{
   display:flex;
   align-items:center;
   justify-content:center;
+}
+.open-posts .post-calendar .weekday{
+  font-size:10px;
 }
 .open-posts .post-calendar .day{
   cursor:pointer;


### PR DESCRIPTION
## Summary
- set calendar container height to 200px
- resize session calendar header to 14px normal and adjust weekday/day text sizes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e0b9c55083318e5f1d9ed94531ba