### PR TITLE
Fix closed post image loading and square admin panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,6 +567,7 @@ button[aria-expanded="true"] .results-arrow{
     background:#222222;
     color:#fff;
     transition:transform 0.3s ease;
+    border-radius:0;
   }
 #filter-panel .panel-content{font-size:12px;}
 
@@ -5475,6 +5476,7 @@ function makePosts(){
       const detail = buildDetail(p);
       target.replaceWith(detail);
       hookDetailActions(detail, p);
+      prioritizeVisibleImages();
       if (typeof updateStickyImages === 'function') {
         updateStickyImages();
       }


### PR DESCRIPTION
## Summary
- Ensure closed post thumbnails load by re-running image prioritization when opening a post
- Remove rounded corners from admin, member, and filter panels for a sharper look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e2396ac88331988bf3dfc9b52de0