### PR TITLE
Enable sticky header and image behavior for open posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3591,12 +3591,14 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
           }
         }
       }
-      const stickyInput = document.getElementById('open-posts-sticky-images');
-      if(!(stickyInput && stickyInput.checked) || !body || !imgArea || !text){
+      if(!body || !imgArea || !text){
         root.classList.remove('open-posts-sticky-images');
+        root.classList.remove('open-posts-sticky-header');
         return;
       }
-      root.classList.toggle('open-posts-sticky-images', !isBelow);
+      const shouldStick = !isBelow;
+      root.classList.toggle('open-posts-sticky-images', shouldStick);
+      root.classList.toggle('open-posts-sticky-header', shouldStick);
     }
 
     window.updateStickyImages = updateStickyImages;


### PR DESCRIPTION
## Summary
- Ensure open post headers and images become sticky when posts display in multiple columns and disable stickiness in single-column layout.
- Remove reliance on absent user preference inputs for sticky behavior.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa38383308331ab6dd5d94e2d71ef