### PR TITLE
Ensure admin and member panels fill screen height

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,6 +571,12 @@ button[aria-expanded="true"] .results-arrow{
   }
 #filter-panel .panel-content{font-size:12px;}
 
+#admin-panel .panel-content,
+#member-panel .panel-content{
+  height:calc(100vh - var(--header-h) - var(--safe-top) - var(--footer-h));
+  max-height:none;
+}
+
 #filter-panel button,
 #filter-panel .sq,
 #filter-panel .tiny,


### PR DESCRIPTION
## Summary
- Stretch admin and member panels to fill viewport height using CSS so they reach the bottom of the screen regardless of content size.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baaf843cac8331a42b14f06b60f409