### PR TITLE
Avoid flashing results list during initial map spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -4747,7 +4747,6 @@ function makePosts(){
         $$('.map-overlay').forEach(el=>el.remove());
         addPostSource();
         if(spinEnabled){
-          document.body.classList.remove('hide-results');
           startSpin();
         }
         updatePostPanel();


### PR DESCRIPTION
## Summary
- Keep results panel hidden when the spinning globe effect starts so new users don't see the list appear then disappear.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab0646a2083318a51d767dda20d3b