### PR TITLE
Fix footer card layout and standardize padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@ input[type="checkbox"]{
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: var(--safe-top) 20px 0 20px;
+    padding: var(--safe-top) 10px 0 10px;
     position: fixed;
     top: 0;
     left: 0;
@@ -529,7 +529,7 @@ button[aria-expanded="true"] .results-arrow{
   flex:1 1 auto;
   overflow-y:auto;
   overflow-x:hidden;
-  padding:0 20px 20px;
+  padding:0 10px 10px;
   overscroll-behavior:contain;
 }
 #admin-panel #styleControls{
@@ -940,7 +940,7 @@ button[aria-expanded="true"] .results-arrow{
 .panel-header{
   position:sticky;
   top:0;
-  padding:10px 20px;
+  padding:10px;
   border-top-left-radius:8px;
   border-top-right-radius:8px;
   z-index:1;
@@ -2455,7 +2455,7 @@ footer{
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 10px;
   background: rgba(0,0,0,0.7);
   position: fixed;
   bottom: 0;
@@ -2514,38 +2514,42 @@ footer{
 footer .foot-row .foot-item{
   position:relative;
   flex:0 0 auto;
-  width:120px;
-  height:100%;
-  border-radius:8px;
-  overflow:hidden;
-  background-size:cover;
-  background-position:center;
   display:flex;
-  align-items:flex-end;
+  align-items:center;
+  gap:8px;
+  padding:10px;
+  background:var(--list-background);
+  border:1px solid var(--border);
+  border-radius:8px;
   color:#fff;
 }
 footer .foot-row .foot-item img{
-  position:absolute;
-  inset:0;
-  width:100%;
-  height:100%;
+  width:40px;
+  height:40px;
   object-fit:cover;
-  z-index:0;
+  border-radius:8px;
+  flex:0 0 auto;
+  position:relative;
+  z-index:1;
 }
 footer .foot-row .foot-item::before{
-  content:"";
-  position:absolute;
-  inset:0;
-  background:linear-gradient(to bottom,rgba(0,0,0,0.8),rgba(0,0,0,0.6));
-  z-index:1;
-  pointer-events:none;
+  display:none;
 }
 footer .foot-row .foot-item .t,
 footer .foot-row .foot-item .fav-star{
   position:relative;
-  z-index:2;
-  text-shadow:0 2px 4px rgba(0,0,0,0.8);
-  padding:6px;
+  z-index:1;
+  padding:0;
+  text-shadow:none;
+}
+footer .foot-row .foot-item .t{
+  flex:1;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+footer .foot-row .foot-item .fav-star{
+  margin-left:auto;
 }
 
 .card,


### PR DESCRIPTION
## Summary
- Standardize padding to 10px for header, panels, and footer
- Rework footer cards with side-by-side thumbnail, title, and favorite star

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac707252c8331bc618867613007ac