### PR TITLE
Fix footer overlay to cover padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2554,6 +2554,7 @@ footer .foot-row .foot-item{
   overflow:hidden;
   background-size:cover;
   background-position:center;
+  background-clip:padding-box;
 }
 footer .foot-row .foot-item img{
   width:30px;
@@ -2567,7 +2568,7 @@ footer .foot-row .foot-item img{
 footer .foot-row .foot-item::before{
   content:"";
   position:absolute;
-  inset:0;
+  inset:-5px;
   background:linear-gradient(to bottom,rgba(0,0,0,0.8),rgba(0,0,0,0.6));
   pointer-events:none;
   z-index:0;


### PR DESCRIPTION
## Summary
- Ensure footer recent-post items overlay matches background by clipping background to padding box and extending the ::before element

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baecd8e630833195ea8e196d905442