### PR TITLE
Ensure footer icons use 30px size

### DIFF
--- a/index.html
+++ b/index.html
@@ -2838,16 +2838,16 @@ img.thumb{
   border-radius: 4px;
 }
 
-footer .foot-row .foot-item > img, footer .foot-row .foot-item img{
-  width: 40px;
-  height: 40px;
+footer .foot-row .foot-item > img{
+  width: 30px;
+  height: 30px;
   aspect-ratio: 1/1;
   object-fit: cover;
   display: block;
   border-radius: 8px;
 }
 
-footer .chip-small img.mini, footer .foot-row .foot-item img{
+footer .chip-small img.mini{
   width: 40px;
   height: 40px;
   object-fit: cover;


### PR DESCRIPTION
## Summary
- remove 40px overrides that upscaled footer icons
- keep footer icon images at 30px while preserving chip-small thumbnails at 40px

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf02c88888331babb7aabe8216d11