### PR TITLE
Fix card image flicker and restore map attribution style

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,13 +207,6 @@ button.on:not([class^="mapboxgl-ctrl"]),
   border-color: var(--btn-active);
   color: var(--button-active-text);
 }
-
-.mapboxgl-ctrl-attrib-button,
-.mapboxgl-ctrl-attrib-button:hover,
-.mapboxgl-ctrl-attrib-button:active{
-  all: revert !important;
-}
-
 a{
   color: var(--primary);
 }
@@ -1646,20 +1639,20 @@ body.filters-active #filterBtn{
   width:20px;
   height:20px;
 }
-#map .mapboxgl-ctrl button{
+#map .mapboxgl-ctrl-group button{
   width:var(--control-h);
   height:var(--control-h);
   padding:0;
 }
-#map .mapboxgl-ctrl button:not(.mapboxgl-ctrl-geolocate):not(.mapboxgl-ctrl-compass){
+#map .mapboxgl-ctrl-group button:not(.mapboxgl-ctrl-geolocate):not(.mapboxgl-ctrl-compass){
   background:var(--control-text-bg);
 }
-#map .mapboxgl-ctrl button svg{
+#map .mapboxgl-ctrl-group button svg{
   width:20px;
   height:20px;
 }
-#map .mapboxgl-ctrl button:hover{filter:brightness(1.1);}
-#map .mapboxgl-ctrl button:active{filter:brightness(0.9);}
+#map .mapboxgl-ctrl-group button:hover{filter:brightness(1.1);}
+#map .mapboxgl-ctrl-group button:active{filter:brightness(0.9);}
 #map .mapboxgl-ctrl-group{
   background:var(--control-text-bg);
   border:1px solid #ccc;
@@ -1668,8 +1661,7 @@ body.filters-active #filterBtn{
 }
 .mapboxgl-ctrl-top-left,
 .mapboxgl-ctrl-top-right,
-.mapboxgl-ctrl-bottom-left,
-.mapboxgl-ctrl-bottom-right{
+.mapboxgl-ctrl-bottom-left{
   margin:0;
 }
 
@@ -5403,9 +5395,14 @@ function makePosts(){
       el.className = 'card';
       el.dataset.id = p.id;
       const gradient = 'linear-gradient(to bottom, rgba(0,0,0,0.6), rgba(0,0,0,0))';
-      el.dataset.bg = imgThumb(p);
-      el.dataset.gradient = gradient;
-      el.style.backgroundImage = gradient;
+      const url = imgThumb(p);
+      if(loadedThumbs.has(url)){
+        el.style.backgroundImage = `${gradient}, url(${url})`;
+      } else {
+        el.dataset.bg = url;
+        el.dataset.gradient = gradient;
+        el.style.backgroundImage = gradient;
+      }
       el.style.backgroundSize = 'cover';
       el.style.backgroundPosition = 'center';
       if(wide) el.style.gridTemplateColumns='80px 1fr 36px';


### PR DESCRIPTION
## Summary
- Prevent card background image flashing by reusing already-loaded images
- Limit Mapbox control styling to control groups so bottom-right attribution uses default styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf349f5348331912ccbabac798a2d