### PR TITLE
Scroll calendar to selected session month

### DIFF
--- a/index.html
+++ b/index.html
@@ -5977,7 +5977,7 @@ function makePosts(){
             if(cell) cell.classList.add('selected');
           }
         }
-        function selectSession(i){
+        function selectSession(i, scrollMonth=false){
           if(!sessMenu) return;
           selectedIndex = i;
           sessMenu.querySelectorAll('button').forEach(b=> b.classList.remove('selected'));
@@ -5988,6 +5988,15 @@ function makePosts(){
             sessionInfo.innerHTML = `<div><strong>${formatDate(dt)} ${dt.time}</strong></div><div>Adults $20, Kids $10, Pensioners $15</div><div>🎫 Buy at venue | ♿ Accessible | 👶 Kid-friendly</div>`;
             if(sessBtn) sessBtn.innerHTML = `<span class="session-date">${formatDate(dt)}</span><span class="session-time">${dt.time}</span>${sessionHasMultiple?'<span class="results-arrow" aria-hidden="true"></span>':''}`;
             markSelected();
+            if(scrollMonth && calScroll){
+              const cell = calendarEl.querySelector(`.day[data-iso="${dt.full}"]`);
+              if(cell){
+                const monthEl = cell.closest('.month');
+                if(monthEl){
+                  calScroll.scrollTo({left: monthEl.offsetLeft, behavior:'smooth'});
+                }
+              }
+            }
           } else {
             sessionInfo.innerHTML = '<div class="placeholder">💲 Price range | 📅 Date range</div>';
             if(sessBtn) sessBtn.innerHTML = sessionHasMultiple ? 'Select Session<span class="results-arrow" aria-hidden="true"></span>' : 'Select Session';
@@ -6031,7 +6040,7 @@ function makePosts(){
               }
             }
             sessMenu.querySelectorAll('button').forEach(btn=>{
-              btn.addEventListener('click', ()=> selectSession(parseInt(btn.dataset.index,10)));
+              btn.addEventListener('click', ()=> selectSession(parseInt(btn.dataset.index,10), true));
             });
           }
       }


### PR DESCRIPTION
## Summary
- Scroll calendar to the month of the session chosen from the session menu.
- Pass a flag from session menu selection to trigger calendar scrolling.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bafd72acb883319f0b4afd11672f07