### PR TITLE
Fix Mapbox console errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" />
   <style>:root{
   --header-h: 75px;
   --panel-w: 300px;
@@ -4635,7 +4637,10 @@ function makePosts(){
 
     // Mapbox
     function loadMapbox(cb){
-      if(window.mapboxgl && window.MapboxGeocoder) return cb();
+      if(window.mapboxgl && window.MapboxGeocoder){
+        mapboxgl.accessToken = MAPBOX_TOKEN;
+        return cb();
+      }
 
       function injectCleanCSS(url, fallback){
         fetch(url).then(r=>r.text()).then(css=>{
@@ -4658,6 +4663,7 @@ function makePosts(){
       const s = document.createElement('script');
       s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = ()=>{
+        mapboxgl.accessToken = MAPBOX_TOKEN;
         const g = document.createElement('script');
         g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         g.onload = cb;


### PR DESCRIPTION
## Summary
- Add Mapbox GL and geocoder stylesheets to the document head to satisfy runtime CSS checks
- Ensure Mapbox access token is set before invoking callbacks when loading Mapbox scripts

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb076860cc83318fe0d7d01a5cce20