### PR TITLE
Restrict wheel scrolling to active panels and wait for map spin to finish

### DIFF
--- a/index.html
+++ b/index.html
@@ -4060,13 +4060,20 @@ function makePosts(){
       return false;
     }
 
+    let wheelActive = null;
+    document.addEventListener('pointerdown', e => {
+      wheelActive = e.target.closest('[data-wheel-container]') || null;
+    });
     function setupHorizontalWheel(scroller){
       if(!scroller) return;
+      scroller.setAttribute('data-wheel-container','');
       scroller.addEventListener('wheel', e=>{
+        if(wheelActive !== scroller) return;
         const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
         if(delta !== 0){
           scroller.scrollLeft += delta;
           e.preventDefault();
+          e.stopPropagation();
         }
       }, {passive:false});
     }
@@ -4462,7 +4469,9 @@ function makePosts(){
 
       function injectCleanCSS(url, fallback){
         fetch(url).then(r=>r.text()).then(css=>{
-          css = css.replace(/-ms-high-contrast/g,'forced-colors');
+          css = css
+            .replace(/-ms-high-contrast/g,'forced-colors')
+            .replace(/-ms-high-contrast-adjust/g,'forced-color-adjust');
           const style = document.createElement('style');
           style.textContent = css;
           document.head.appendChild(style);
@@ -4644,9 +4653,10 @@ function makePosts(){
         addPostSource();
         if(spinEnabled){
           startSpin();
+        } else {
+          updatePostPanel();
+          applyFilters();
         }
-        updatePostPanel();
-        applyFilters();
       });
 
         ['mousedown','wheel','touchstart','dragstart','pitchstart','rotatestart','zoomstart'].forEach(ev=> map.on(ev, haltSpin));
@@ -4717,6 +4727,7 @@ function makePosts(){
       if(resultsToggle) resultsToggle.setAttribute('aria-pressed','true');
       if(listPanel) listPanel.setAttribute('aria-hidden','false');
     }
+    updatePostPanel();
     applyFilters();
   }
 
@@ -5916,17 +5927,18 @@ function makePosts(){
       });
     }
     function applyFilters(){
-      filtered = posts.filter(p => (spinning || inBounds(p)) && kwMatch(p) && dateMatch(p));
+      if(spinning || spinEnabled) return;
+      filtered = posts.filter(p => inBounds(p) && kwMatch(p) && dateMatch(p));
       renderLists(filtered);
       if(map && map.getSource('posts')){ map.getSource('posts').setData(postsToGeoJSON(filtered)); }
       const today = new Date(); today.setHours(0,0,0,0);
-      const total = posts.filter(p => (spinning || inBounds(p)) && p.dates.some(d => parseISODate(d) >= today)).length;
+      const total = posts.filter(p => inBounds(p) && p.dates.some(d => parseISODate(d) >= today)).length;
       const summary = $('#filterSummary');
       if(summary){ summary.textContent = `${filtered.length} results showing out of ${total} results in the area.`; }
       updateFilterBtnColor();
     }
 
-    applyFilters();
+    if(!spinEnabled) applyFilters();
     if(activePostId){
       openPost(activePostId, true);
     } else {


### PR DESCRIPTION
## Summary
- allow calendar and thumbnail sliders to scroll only when they are the most recently clicked element
- delay list/result rendering until globe spinning stops and update scroll logic
- replace deprecated `-ms-high-contrast` CSS with `forced-colors` equivalents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0fbd8d5c8331ba44928e1333131c