### PR TITLE
Ensure post clicks open selected entry directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -4405,7 +4405,7 @@ function makePosts(){
         const cardEl = e.target.closest('.card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id) { stopSpin(); openPost(id); }
+          if(id) { openPost(id); }
           return;
         }
         if(e.target === resList){
@@ -4423,7 +4423,7 @@ function makePosts(){
         const cardEl = e.target.closest('.card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id){ stopSpin(); openPost(id, true); }
+          if(id){ openPost(id, true); }
           return;
         }
         if(e.target === postsWide && postsWide.querySelector('.open-posts')){


### PR DESCRIPTION
## Summary
- Avoid calling `stopSpin()` before `openPost()` for result cards and wide post list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb140b88b48331aa2aaae58b04e35b