### PR TITLE
Ensure Mapbox CSS loads before map initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,6 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css" />
-  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" />
   <style>:root{
   --header-h: 75px;
   --panel-w: 300px;
@@ -4468,43 +4466,49 @@ function makePosts(){
       }
 
       function injectCleanCSS(url, fallback){
-        fetch(url).then(r=>r.text()).then(css=>{
+        return fetch(url).then(r=>r.text()).then(css=>{
           css = css
             .replace(/-ms-high-contrast/g,'forced-colors')
             .replace(/-ms-high-contrast-adjust/g,'forced-color-adjust');
           const style = document.createElement('style');
           style.textContent = css;
           document.head.appendChild(style);
-        }).catch(()=>{
+        }).catch(() => new Promise(resolve => {
           const link = document.createElement('link');
-          link.rel='stylesheet';
+          link.rel = 'stylesheet';
           link.href = fallback || url;
+          link.onload = resolve;
+          link.onerror = resolve;
           document.head.appendChild(link);
-        });
+        }));
       }
 
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css');
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css',
-        'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
-
-      const s = document.createElement('script');
-      s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
-      s.onload = ()=>{
-        mapboxgl.accessToken = MAPBOX_TOKEN;
-        const g = document.createElement('script');
-        g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
-        g.onload = cb;
-        g.onerror = ()=>{
-          const gf = document.createElement('script');
-          gf.src='https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.min.js';
-          gf.onload = cb;
-          gf.onerror = cb;
-          document.head.appendChild(gf);
+      Promise.all([
+        injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css'),
+        injectCleanCSS(
+          'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css',
+          'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css'
+        )
+      ]).then(() => {
+        const s = document.createElement('script');
+        s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
+        s.onload = () => {
+          mapboxgl.accessToken = MAPBOX_TOKEN;
+          const g = document.createElement('script');
+          g.src = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
+          g.onload = cb;
+          g.onerror = () => {
+            const gf = document.createElement('script');
+            gf.src = 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.min.js';
+            gf.onload = cb;
+            gf.onerror = cb;
+            document.head.appendChild(gf);
+          };
+          document.head.appendChild(g);
         };
-        document.head.appendChild(g);
-      };
-      s.onerror = cb;
-      document.head.appendChild(s);
+        s.onerror = cb;
+        document.head.appendChild(s);
+      }).catch(cb);
     }
     loadMapbox(initMap);
 


### PR DESCRIPTION
## Summary
- Remove hard-coded Mapbox CSS links to eliminate deprecated `-ms-high-contrast` warnings
- Load Mapbox CSS via `Promise.all` and initialize map only after styles are ready, preventing missing CSS warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb12c3f44c8331a86cf21a90f3139c