### PR TITLE
Prevent footer clicks from switching to map mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -7162,8 +7162,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const postsPanel = document.querySelector('.post-panel');
   const listPanel = document.querySelector('.list-panel');
   const header = document.querySelector('.header');
-  const footer = document.querySelector('footer');
-  [adPanelContainer, postsPanel, listPanel, header, footer].forEach(el => {
+  [adPanelContainer, postsPanel, listPanel, header].forEach(el => {
     if(el){
       el.addEventListener('click', e => {
         if(e.target === el) setMode('map');


### PR DESCRIPTION
## Summary
- Remove footer from DOMContentLoaded click listener list so interactions in `#footRow` don't trigger `setMode('map')`
- Preserve existing `#footRow` click handler for `.foot-item` navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb39bcf7488331bb867aa02e3fbe57