### PR TITLE
Reapply filters when expired toggle changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4353,6 +4353,8 @@ function makePosts(){
         expiredWasOn = expiredToggle.checked;
         updateRangeClasses();
         updateInput();
+        applyFilters();
+        updateClearButtons();
       });
       if(expiredToggle.checked){
         expiredToggle.dispatchEvent(new Event('change'));


### PR DESCRIPTION
## Summary
- ensure changing the expired filter re-applies results and reset button state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b564b988331b74ebbf58d0c8c0a