### PR TITLE
Fix footer card click to open posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5426,8 +5426,9 @@ function makePosts(){
       const item = e.target.closest('.foot-item');
       if(!item) return;
       e.stopPropagation();
-      const id = item.dataset.id;
-      const record = viewHistory.find(v => v.id === id);
+      const idStr = item.dataset.id;
+      const record = viewHistory.find(v => String(v.id) === idStr);
+      const id = record ? record.id : idStr;
       stopSpin();
       if(record && record.state) restoreState(record.state);
       openPost(id);


### PR DESCRIPTION
## Summary
- Ensure footer card clicks locate history entries by ID string
- Pass the proper post ID to open posts from footer selections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb3ecb02dc8331a2228224ba7a18f0