### PR TITLE
Standardize header buttons and fullscreen sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,8 +166,8 @@ textarea,
   user-select: text;
 }
 
-button:not([class^="mapboxgl-ctrl"]),
-[role="button"]:not([class^="mapboxgl-ctrl"]){
+button:not([class^="mapboxgl-ctrl"]):not(.fullscreen-btn),
+[role="button"]:not([class^="mapboxgl-ctrl"]):not(.fullscreen-btn){
   background: var(--btn);
   border: 1px solid var(--btn);
   color: var(--button-text);
@@ -498,11 +498,11 @@ button[aria-expanded="true"] .results-arrow{
 }
 
 .auth .auth-btn{
-  border: none;
+  border: 1px solid var(--btn);
   border-radius: 0;
   padding: 0;
-  background: rgba(255,255,255,0.2);
-  color: inherit;
+  background: var(--btn);
+  color: var(--button-text);
   font-weight: 600;
 }
 
@@ -2381,6 +2381,11 @@ footer{
     display:flex;
     align-items:center;
     justify-content:center;
+    background: var(--btn);
+    border: 1px solid var(--btn);
+    color: var(--button-text);
+    cursor: pointer;
+    transition: background .2s,border-color .2s,color .2s;
   }
 
 


### PR DESCRIPTION
## Summary
- Align admin/member header buttons with standard button styling
- Keep fullscreen control at 60x60px by excluding it from global button height rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb492c360883318011c8df2e9fb91a