### PR TITLE
Load Mapbox CSS without deprecated -ms-high-contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,6 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.css" />
-  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.1.0/mapbox-gl-geocoder.css" />
   <style>:root{
   --header-h: 75px;
   --panel-w: 300px;
@@ -4528,6 +4526,23 @@ function makePosts(){
         mapboxgl.accessToken = MAPBOX_TOKEN;
         return cb();
       }
+
+      function injectCleanCSS(url, fallback){
+        fetch(url).then(r=>r.text()).then(css=>{
+          css = css.replace(/-ms-high-contrast/g,'forced-colors');
+          const style = document.createElement('style');
+          style.textContent = css;
+          document.head.appendChild(style);
+        }).catch(()=>{
+          const link = document.createElement('link');
+          link.rel='stylesheet';
+          link.href = fallback || url;
+          document.head.appendChild(link);
+        });
+      }
+
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.css');
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.1.0/mapbox-gl-geocoder.css', 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.1.0/dist/mapbox-gl-geocoder.css');
 
       const s = document.createElement('script');
       s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.js';


### PR DESCRIPTION
## Summary
- fetch Mapbox CSS at runtime and replace deprecated `-ms-high-contrast` rules with `forced-colors`
- remove direct Mapbox stylesheet links to avoid deprecation warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4d977394833193a1aa29ec6f7c8e