### PR TITLE
Ensure footer post opens after UI settles

### DIFF
--- a/index.html
+++ b/index.html
@@ -5410,11 +5410,13 @@ function makePosts(){
         const favIcon = p && p.fav ? '<span class="fav-star" aria-hidden="true">★</span>' : '';
         el.innerHTML = `<img class="mini" src="${imgThumb(v.id)}" alt="" referrerpolicy="no-referrer"/><div class="t">${v.title}</div>${favIcon}`;
         if(v.id===activePostId) el.setAttribute('aria-selected','true');
-        el.addEventListener('click', e => {
+        el.addEventListener('click', async e => {
+          e.preventDefault();
           e.stopPropagation();
           stopSpin();
           if(v.state) restoreState(v.state);
-          openPost(v.id);
+          await nextFrame();
+          await openPost(v.id);
         });
         footRow.appendChild(el);
       }


### PR DESCRIPTION
## Summary
- Convert footer history item click handler to async, waiting for UI to settle before opening posts.
- Prevent default footer item click behavior and await DOM updates for smoother navigation.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb52b2f9408331b6ed17a872fad69c