### PR TITLE
fix: revert Mapbox versions and style

### DIFF
--- a/index.html
+++ b/index.html
@@ -3429,7 +3429,7 @@ footer .chip-small img.mini{
           spinLogoClick = localStorage.getItem('spinLogoClick') === 'false' ? false : true,
           spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),
           spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
-          mapStyle = window.mapStyle = normalizeMapStyle(localStorage.getItem('mapStyle')) || 'mapbox://styles/mapbox/standard',
+          mapStyle = window.mapStyle = normalizeMapStyle(localStorage.getItem('mapStyle')) || 'mapbox://styles/mapbox/streets-v12',
           skyStyle = window.skyStyle = localStorage.getItem('skyStyle') || 'night',
           dynamicSun = localStorage.getItem('dynamicSun') === 'true',
           clusterRadius = parseInt(localStorage.getItem('clusterRadius') || '52', 10),
@@ -4541,19 +4541,19 @@ function makePosts(){
         });
       }
 
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.css');
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.1.0/mapbox-gl-geocoder.css', 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.1.0/dist/mapbox-gl-geocoder.css');
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css');
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css', 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
 
       const s = document.createElement('script');
-      s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.js';
+      s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = () => {
         mapboxgl.accessToken = MAPBOX_TOKEN;
         const g = document.createElement('script');
-        g.src = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.1.0/mapbox-gl-geocoder.min.js';
+        g.src = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         g.onload = cb;
         g.onerror = () => {
           const gf = document.createElement('script');
-          gf.src = 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.1.0/dist/mapbox-gl-geocoder.min.js';
+          gf.src = 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.min.js';
           gf.onload = cb;
           gf.onerror = cb;
           document.head.appendChild(gf);
@@ -4595,7 +4595,7 @@ function makePosts(){
         }
       } else {
         const script = document.createElement('script');
-        script.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.1.0/mapbox-gl-geocoder.min.js';
+        script.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';
         script.onload = addGeocoder;
         script.onerror = ()=> console.error('Mapbox Geocoder failed to load');
         document.head.appendChild(script);


### PR DESCRIPTION
## Summary
- revert Mapbox GL JS and geocoder URLs to stable v3.5.1/v5.0.0
- default to a safer Streets style to avoid unsupported expression errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb544cb6d88331803bf011ab31102d