### PR TITLE
Load Mapbox CSS synchronously

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" />
   <style>:root{
   --header-h: 75px;
   --panel-w: 300px;
@@ -4526,24 +4528,6 @@ function makePosts(){
         mapboxgl.accessToken = MAPBOX_TOKEN;
         return cb();
       }
-
-      function injectCleanCSS(url, fallback){
-        fetch(url).then(r=>r.text()).then(css=>{
-          css = css.replace(/-ms-high-contrast/g,'forced-colors');
-          const style = document.createElement('style');
-          style.textContent = css;
-          document.head.appendChild(style);
-        }).catch(()=>{
-          const link = document.createElement('link');
-          link.rel='stylesheet';
-          link.href = fallback || url;
-          document.head.appendChild(link);
-        });
-      }
-
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css');
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css', 'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
-
       const s = document.createElement('script');
       s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = () => {


### PR DESCRIPTION
## Summary
- Load Mapbox GL JS and geocoder styles directly in the document head.
- Remove asynchronous CSS injection so map initialization occurs with styles preloaded.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5d55c59c8331bf266d9d10c0a922