### PR TITLE
style: adjust header button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@ input[type="checkbox"]{
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: var(--safe-top) 10px 0 10px;
+    padding: var(--safe-top) 0 0 0;
     position: fixed;
     top: 0;
     left: 0;
@@ -360,12 +360,12 @@ input[type="checkbox"]{
 
 .view-toggle{
   position: absolute;
-  left: 10px;
+  left: 0;
   top: 50%;
   transform: translateY(-50%);
   display: flex;
   height: 75px;
-  gap: 0;
+  gap: 1px;
 }
 
 .view-toggle button{
@@ -493,7 +493,7 @@ button[aria-expanded="true"] .results-arrow{
 .auth{
   display: flex;
   align-items: center;
-  gap: 0;
+  gap: 1px;
   margin-left: auto;
 }
 
@@ -504,6 +504,30 @@ button[aria-expanded="true"] .results-arrow{
   background: var(--btn);
   color: var(--button-text);
   font-weight: 600;
+}
+
+@media (max-width:600px){
+  .header{
+    padding-left:10px;
+    justify-content:flex-start;
+  }
+  .logo{
+    position:static;
+    left:auto;
+    top:auto;
+    transform:none;
+    margin-right:auto;
+  }
+  .view-toggle{
+    position:static;
+    left:auto;
+    top:auto;
+    transform:none;
+    margin-right:1px;
+  }
+  .auth{
+    margin-left:0;
+  }
 }
 
 .gear{


### PR DESCRIPTION
## Summary
- Remove horizontal padding and left offset to flush header buttons with screen edges
- Add 1px gaps and responsive layout so header buttons group on the right on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6121571c83319b85d9239b5d43f9