### PR TITLE
Ensure welcome popup loads content after refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -6347,7 +6347,11 @@ document.addEventListener('pointerdown', handleDocInteract);
   if(filterPanel) closePanel(filterPanel);
   [memberPanel, adminPanel, welcomePopup].forEach(m => {
     if (m && localStorage.getItem(`panel-open-${m.id}`) === 'true') {
-      openPanel(m);
+      if (m.id === 'welcomePopup') {
+        openWelcome();
+      } else {
+        openPanel(m);
+      }
     }
   });
   if (welcomePopup && !localStorage.getItem('welcome-seen')) {


### PR DESCRIPTION
## Summary
- Call `openWelcome()` when the welcome popup auto-opens from saved state so its content loads after a page refresh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb63ada6b88331abdd6e3c7cb7dc77