### PR TITLE
Fix favourite button opening post

### DIFF
--- a/index.html
+++ b/index.html
@@ -5252,6 +5252,8 @@ function makePosts(){
         </button>
       `;
       el.querySelector('.fav').addEventListener('click', (e)=>{
+        e.preventDefault();
+        e.stopPropagation();
         p.fav = !p.fav;
         document.querySelectorAll(`[data-id="${p.id}"] .fav`).forEach(btn=>{
           btn.setAttribute('aria-pressed', p.fav ? 'true' : 'false');


### PR DESCRIPTION
## Summary
- Stop favourite button clicks from bubbling so they don't open posts or reorder content prematurely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6cad756c8331ba2fe813eb18c5d8