### PR TITLE
Keep expired events visible when selecting a date

### DIFF
--- a/index.html
+++ b/index.html
@@ -4187,7 +4187,6 @@ function makePosts(){
       else { dateEnd = date; }
       updateRangeClasses();
       updateInput();
-      if(expiredToggle && expiredToggle.checked){ expiredToggle.checked = false; expiredWasOn = false; }
     }
 
     function buildFilterCalendar(minDate, maxDate){


### PR DESCRIPTION
## Summary
- Prevent date picker selection from disabling the "Show Expired Events" option
- Ensure past events remain visible for chosen dates when expired toggle is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6df411c08331abd35bf008b978de