### PR TITLE
Persist scroll positions for scrollable panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -7386,5 +7386,42 @@ document.addEventListener('DOMContentLoaded', () => {
   updateAdVisibility();
 });
 </script>
+<script>
+(function(){
+  const selectors = ['.res-list', '.post-panel'];
+
+  function savePositions(){
+    selectors.forEach(sel => {
+      document.querySelectorAll(sel).forEach(el => {
+        if(!el.id) return;
+        const key = `scroll-pos-${el.id}`;
+        const pos = {top: el.scrollTop, left: el.scrollLeft};
+        sessionStorage.setItem(key, JSON.stringify(pos));
+      });
+    });
+  }
+
+  function restorePositions(){
+    selectors.forEach(sel => {
+      document.querySelectorAll(sel).forEach(el => {
+        if(!el.id) return;
+        const key = `scroll-pos-${el.id}`;
+        const data = sessionStorage.getItem(key);
+        if(data){
+          try {
+            const {top, left} = JSON.parse(data);
+            if(typeof top === 'number') el.scrollTop = top;
+            if(typeof left === 'number') el.scrollLeft = left;
+          } catch {}
+          sessionStorage.removeItem(key);
+        }
+      });
+    });
+  }
+
+  window.addEventListener('beforeunload', savePositions);
+  document.addEventListener('DOMContentLoaded', restorePositions);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Save scrollTop/scrollLeft of `.res-list` and `.post-panel` before unloading and restore them on load
- Store positions in sessionStorage keyed by container IDs and clear entries after use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb94e2e5088331b9f920ee30414680