### PR TITLE
Adjust dropdown layout and panel sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,6 +523,8 @@ button[aria-expanded="true"] .results-arrow{
   overflow-x:hidden;
   padding:0 10px 10px;
   overscroll-behavior:contain;
+  width:100%;
+  height:100%;
 }
 #admin-panel #styleControls{
   display:flex;
@@ -878,8 +880,8 @@ button[aria-expanded="true"] .results-arrow{
   display:flex;
   flex-direction:column;
   gap:8px;
-  max-width:400px;
   width:100%;
+  height:100%;
 }
 #admin-panel .panel-field{margin:0;}
 #admin-panel h3{margin:0;}
@@ -1928,7 +1930,7 @@ body.hide-results .post-panel{
 }
 .filter-panel .options-dropdown{width:400px;}
 .filter-panel .options-dropdown > button{width:400px;}
-.options-dropdown .options-menu{min-width:380px;width:auto;}
+.options-dropdown .options-menu{width:100%;}
 .open-posts .session-dropdown > button.past{
   background:#800000;
   border-color:#800000;
@@ -3077,14 +3079,24 @@ footer .chip-small img.mini{
   align-items:center;
   justify-content:flex-start;
   gap:6px;
-  width:auto;
-  min-width:380px;
+  width:100%;
+}
+
+.sort-field .options-dropdown > button{
+  text-align:center;
+  justify-content:center;
+}
+
+.sort-field .options-menu button{
+  text-align:center;
+  justify-content:center;
 }
 
 .filter-panel .panel-body,
 .member-panel .panel-body,
 .admin-panel .panel-body{
-  width:400px;
+  width:100%;
+  height:100%;
   display:flex;
   flex-direction:column;
   gap:10px;
@@ -3094,7 +3106,8 @@ footer .chip-small img.mini{
 .member-panel .panel-field,
 .admin-panel .panel-field{
   margin:0;
-  width:400px;
+  width:100%;
+  height:100%;
   display:flex;
   justify-content:space-between;
 }


### PR DESCRIPTION
## Summary
- Center text in sort dropdown trigger and options while keeping venue dropdown options left-aligned
- Remove fixed minimum width from dropdown options so menus match the trigger width
- Expand panel body and panel field elements to 100% width and height for consistent sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb97bc5b188331a8345936a662824a