### PR TITLE
Remove balloon tool padding and width constraints

### DIFF
--- a/index.html
+++ b/index.html
@@ -3435,19 +3435,18 @@ footer .chip-small img.mini{
             <div class="panel-field">
               <div id="balloonTool">
                 <style>
-                  #balloonTool { padding: 10px; }
                   #balloonTool .t{font-family:Verdana;font-size:20px;}
-                  #balloonTool .shape-dropdown{position:relative;width:300px;height:35px;margin-bottom:8px;}
-                  #balloonTool .shape-dropdown > button{width:300px;height:35px;background:var(--btn);border:1px solid var(--btn);border-radius:var(--dropdown-radius);text-align:left;}
-                  #balloonTool .shape-menu{position:absolute;top:calc(100% + 4px);left:0;width:300px;max-height:400px;overflow-y:auto;background:var(--dropdown-bg);border:1px solid var(--border);border-radius:var(--dropdown-radius);padding:10px;display:flex;flex-direction:column;gap:6px;box-shadow:0 2px 6px rgba(0,0,0,0.2);z-index:30;overscroll-behavior:contain;}
+                  #balloonTool .shape-dropdown{position:relative;height:35px;margin-bottom:8px;}
+                  #balloonTool .shape-dropdown > button{height:35px;background:var(--btn);border:1px solid var(--btn);border-radius:var(--dropdown-radius);text-align:left;}
+                  #balloonTool .shape-menu{position:absolute;top:calc(100% + 4px);left:0;max-height:400px;overflow-y:auto;background:var(--dropdown-bg);border:1px solid var(--border);border-radius:var(--dropdown-radius);display:flex;flex-direction:column;gap:6px;box-shadow:0 2px 6px rgba(0,0,0,0.2);z-index:30;overscroll-behavior:contain;}
                   #balloonTool .shape-menu[hidden]{display:none;}
                   #balloonTool .shape-button{width:100%;height:35px;background:var(--btn);border:1px solid var(--btn);border-radius:var(--dropdown-radius);text-align:left;display:flex;align-items:center;gap:4px;padding:4px;cursor:pointer;}
                   #balloonTool .shape-button svg{width:24px;height:24px;vertical-align:middle;}
                   #balloonTool .shape-button.active{outline:2px solid var(--border);}
                   #balloonTool .size-control{margin-bottom:8px;}
                   #balloonTool .svg-output{display:flex;flex-direction:column;gap:8px;margin-bottom:8px;}
-                  #balloonTool .svg-output textarea{width:300px;height:200px;}
-                  #balloonTool #copySvgCode{width:300px;height:35px;}
+                  #balloonTool .svg-output textarea{height:200px;}
+                  #balloonTool #copySvgCode{height:35px;}
                   #balloonTool #balloonGrid{display:grid;grid-template-columns: repeat(10, 1fr); gap:4px;overflow-x:auto;}
                   #balloonTool #balloonGrid svg{cursor:pointer;}
                 </style>


### PR DESCRIPTION
## Summary
- remove hardcoded padding from the balloon tool container
- drop fixed pixel widths so balloon tool elements size automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb9d5df6b083319f9017ddb816d69b