### PR TITLE
Restore marker clustering controls and clean attribution button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ input[type="checkbox"]{
   border-radius: 8px;
 }
 
-button,
+button:not([class^="mapboxgl-ctrl"]),
 [role="button"]{
   display:inline-flex;
   align-items:center;
@@ -260,22 +260,22 @@ button,
   cursor:pointer;
   transition:background .2s,border-color .2s,color .2s;
 }
-button:hover:not(:disabled),
+button:not([class^="mapboxgl-ctrl"]):hover:not(:disabled),
 [role="button"]:hover:not([aria-disabled="true"]){
   background:var(--btn-hover);
   border-color:var(--btn-hover);
   color:var(--button-hover-text);
 }
-button:active:not(:disabled),
+button:not([class^="mapboxgl-ctrl"]):active:not(:disabled),
 [role="button"]:active:not([aria-disabled="true"]){
   background:var(--btn-active);
   border-color:var(--btn-active);
   color:var(--button-active-text);
 }
-button.selected,
-button[aria-pressed="true"],
-button[aria-current="page"],
-button[aria-selected="true"],
+button:not([class^="mapboxgl-ctrl"]).selected,
+button:not([class^="mapboxgl-ctrl"])[aria-pressed="true"],
+button:not([class^="mapboxgl-ctrl"])[aria-current="page"],
+button:not([class^="mapboxgl-ctrl"])[aria-selected="true"],
 [role="button"].selected,
 [role="button"][aria-pressed="true"],
 [role="button"][aria-current="page"],
@@ -284,10 +284,10 @@ button[aria-selected="true"],
   border-color:var(--active);
   color:var(--button-text);
 }
-button.selected:hover,
-button[aria-pressed="true"]:hover,
-button[aria-current="page"]:hover,
-button[aria-selected="true"]:hover,
+button:not([class^="mapboxgl-ctrl"]).selected:hover,
+button:not([class^="mapboxgl-ctrl"])[aria-pressed="true"]:hover,
+button:not([class^="mapboxgl-ctrl"])[aria-current="page"]:hover,
+button:not([class^="mapboxgl-ctrl"])[aria-selected="true"]:hover,
 [role="button"].selected:hover,
 [role="button"][aria-pressed="true"]:hover,
 [role="button"][aria-current="page"]:hover,
@@ -295,7 +295,7 @@ button[aria-selected="true"]:hover,
   background:#39448f;
   border-color:#39448f;
 }
-button:disabled,
+button:not([class^="mapboxgl-ctrl"]):disabled,
 [role="button"][aria-disabled="true"]{
   background:#777;
   border-color:#777;
@@ -303,7 +303,7 @@ button:disabled,
   cursor:not-allowed;
   opacity:0.5;
 }
-button:focus-visible,
+button:not([class^="mapboxgl-ctrl"]):focus-visible,
 [role="button"]:focus-visible{
   outline:2px solid var(--accent);
   outline-offset:2px;
@@ -3429,6 +3429,30 @@ footer .chip-small img.mini{
                   <span id="bearingVal"></span>
                 </div>
               </div>
+              <div class="panel-field">
+                <label>Markercluster</label>
+                <div class="marker-grid">
+                  <div class="marker-options">
+                    <label for="clusterRadius">Radius</label>
+                    <input type="number" id="clusterRadius" min="10" max="100" step="1" />
+                  </div>
+                  <div class="marker-options">
+                    <label for="clusterMaxZoom">Max Zoom</label>
+                    <input type="number" id="clusterMaxZoom" min="0" max="18" step="1" />
+                  </div>
+                  <div class="marker-options">
+                    <label for="clusterIconType">Icon Type</label>
+                    <select id="clusterIconType">
+                      <option value="circle">Circle</option>
+                      <option value="svg">SVG</option>
+                    </select>
+                  </div>
+                  <div class="marker-options" id="clusterSvgRow">
+                    <label for="clusterSvg">SVG Icon</label>
+                    <textarea id="clusterSvg" rows="3" placeholder="<svg>...</svg>"></textarea>
+                  </div>
+                </div>
+              </div>
             <div class="panel-field">
               <div class="option-label">
                 <span>Spin on Load</span>
@@ -5622,7 +5646,7 @@ function makePosts(){
             </div>
             <h2 class="title">${p.title}</h2>
             <div class="cat-line"><span class="sub-icon">${subcategoryIcons[p.subcategory]||''}</span> ${p.category} &gt; ${p.subcategory}</div>
-              <div class="author"><img src="${p.member.avatar}" alt="${p.member.username} avatar" width="50" height="50"/><span>Posted by ${p.member.username}</span></div>
+            ${p.member && p.member.avatar ? `<div class="author"><img src="${p.member.avatar}" alt="${p.member.username} avatar" width="50" height="50"/><span>Posted by ${p.member.username}</span></div>` : ''}
             <div id="venue-info-${p.id}" class="venue-info"></div>
             <div id="session-info-${p.id}" class="session-info">
               <div class="placeholder">💲 Price range | 📅 Date range</div>
@@ -6464,7 +6488,44 @@ document.addEventListener('keydown', e=>{
 });
 
 function syncAdminControls(){
-  // Placeholder to prevent errors if admin sync logic is not loaded
+  const themeSelect = document.getElementById('mapTheme');
+  if(themeSelect) themeSelect.value = mapStyle;
+  const skySelect = document.getElementById('skyTheme');
+  if(skySelect) skySelect.value = skyStyle;
+  const pitchInput = document.getElementById('mapPitch');
+  const pitchVal = document.getElementById('pitchVal');
+  if(pitchInput){
+    const p = (map && typeof map.getPitch === 'function') ? map.getPitch() : startPitch;
+    pitchInput.value = p;
+    if(pitchVal) pitchVal.textContent = p.toFixed(0);
+  }
+  const bearingInput = document.getElementById('mapBearing');
+  const bearingVal = document.getElementById('bearingVal');
+  if(bearingInput){
+    const b = (map && typeof map.getBearing === 'function') ? map.getBearing() : startBearing;
+    bearingInput.value = b;
+    if(bearingVal) bearingVal.textContent = b.toFixed(0);
+  }
+  const radiusInput = document.getElementById('clusterRadius');
+  if(radiusInput) radiusInput.value = clusterRadius;
+  const maxZoomInput = document.getElementById('clusterMaxZoom');
+  if(maxZoomInput) maxZoomInput.value = clusterMaxZoom;
+  const iconSelect = document.getElementById('clusterIconType');
+  if(iconSelect) iconSelect.value = clusterIconType;
+  const svgInput = document.getElementById('clusterSvg');
+  const svgRow = document.getElementById('clusterSvgRow');
+  if(svgInput) svgInput.value = clusterSvg;
+  if(svgRow) svgRow.style.display = clusterIconType === 'svg' ? 'flex' : 'none';
+  const calWidthInput = document.getElementById('calendar-width');
+  if(calWidthInput){
+    const w = getComputedStyle(document.documentElement).getPropertyValue('--calendar-width').trim();
+    calWidthInput.value = parseInt(w) || 0;
+  }
+  const calHeightInput = document.getElementById('calendar-height');
+  if(calHeightInput){
+    const h = getComputedStyle(document.documentElement).getPropertyValue('--calendar-height').trim();
+    calHeightInput.value = parseInt(h) || 0;
+  }
 }
 
 function handleDocInteract(e){
@@ -6698,6 +6759,11 @@ document.addEventListener('pointerdown', handleDocInteract);
           const pitchVal = document.getElementById("pitchVal");
           const bearingInput = document.getElementById("mapBearing");
           const bearingVal = document.getElementById("bearingVal");
+          const radiusInput = document.getElementById("clusterRadius");
+          const maxZoomInput = document.getElementById("clusterMaxZoom");
+          const iconSelect = document.getElementById("clusterIconType");
+          const svgInput = document.getElementById("clusterSvg");
+          const svgRow = document.getElementById("clusterSvgRow");
         if(themeSelect){
           themeSelect.value = mapStyle;
           themeSelect.addEventListener("change", ()=>{
@@ -6754,7 +6820,42 @@ document.addEventListener('pointerdown', handleDocInteract);
           bearingVal.textContent = val.toFixed(0);
         });
       }
-      /* marker cluster options removed */
+      if(radiusInput){
+        radiusInput.value = clusterRadius;
+        radiusInput.addEventListener("change", ()=>{
+          clusterRadius = parseInt(radiusInput.value,10) || 52;
+          localStorage.setItem("clusterRadius", String(clusterRadius));
+          addPostSource();
+        });
+      }
+      if(maxZoomInput){
+        maxZoomInput.value = clusterMaxZoom;
+        maxZoomInput.addEventListener("change", ()=>{
+          let val = parseInt(maxZoomInput.value,10);
+          if(isNaN(val)) val = 14;
+          clusterMaxZoom = Math.max(0, Math.min(18, val));
+          localStorage.setItem("clusterMaxZoom", String(clusterMaxZoom));
+          addPostSource();
+        });
+      }
+      if(iconSelect){
+        iconSelect.value = clusterIconType;
+        iconSelect.addEventListener("change", ()=>{
+          clusterIconType = iconSelect.value;
+          localStorage.setItem("clusterIconType", clusterIconType);
+          if(svgRow) svgRow.style.display = clusterIconType === "svg" ? "flex" : "none";
+          addPostSource();
+        });
+      }
+      if(svgInput){
+        svgInput.value = clusterSvg;
+        svgInput.addEventListener("change", ()=>{
+          clusterSvg = svgInput.value;
+          localStorage.setItem("clusterSvg", clusterSvg);
+          if(clusterIconType === "svg") addPostSource();
+        });
+        if(svgRow) svgRow.style.display = clusterIconType === "svg" ? "flex" : "none";
+      }
       if(loadStartChk){
         loadStartChk.checked = sg.spinLoadStart;
         loadStartChk.addEventListener("change", ()=>{


### PR DESCRIPTION
## Summary
- Exclude Mapbox control buttons from global button styles to avoid altering the attribution control
- Reintroduce marker clustering controls with radius, zoom, and SVG options
- Guard post detail avatar rendering to prevent console errors when member data is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb27ec31883318d7652b7b830b377