### PR TITLE
fix: restore base colors for selected elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,14 +116,17 @@ fieldset{
   border-color: var(--border-active);
 }
 
-*[aria-pressed="true"],
-*[aria-current="page"],
-*[aria-selected="true"],
-.selected,
-.on{
-  border-color: var(--border-active);
-  color: var(--active);
-}
+  *[aria-pressed="true"],
+  *[aria-current="page"],
+  *[aria-selected="true"]{
+    border-color: var(--border-active);
+    color: var(--active);
+  }
+
+  .selected,
+  .on{
+    border-color: var(--border-active);
+  }
 
 html,body{
   height: 100%;


### PR DESCRIPTION
## Summary
- prevent `.selected` and `.on` classes from forcing active text color
- keep active color for explicit ARIA-selected elements only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb4de053c8331a2561d6b6b6f7981