### PR TITLE
Downgrade Mapbox GL JS to v3.5.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css" />
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css" />
   <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" />
   <style>:root{
   --header-h: 75px;
@@ -4743,7 +4743,7 @@ function makePosts(){
         return cb();
       }
       const s = document.createElement('script');
-      s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.js';
+      s.src = 'https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
       s.onload = () => {
         mapboxgl.accessToken = MAPBOX_TOKEN;
         const g = document.createElement('script');


### PR DESCRIPTION
## Summary
- Switch Mapbox GL JS CSS and script to v3.5.1 to avoid console warnings in Mapbox Standard style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc196bc1d883318a48a0fd2679a11e