### PR TITLE
style: expand boards with additional cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,12 +46,23 @@
     #postBoard{position:absolute;top:80px;bottom:80px;left:0;right:420px;z-index:4;display:flex;flex-direction:column;gap:10px;overflow:auto;transition:left .3s,transform .3s;}
     #quickBoard.open~#postBoard{left:520px;}
     #postBoard.closed{transform:translateX(-520px);}
-    .post-card{width:500px;border-radius:4px;overflow:hidden;position:relative;}
-    .post-card .post-header{height:50px;display:flex;align-items:center;font-weight:bold;}
-    .post-card .post-body{display:grid;gap:10px;}
-    @media(min-width:1000px){.post-card .post-body{grid-template-columns:repeat(3,1fr);}}
-    @media(max-width:999px) and (min-width:700px){.post-card .post-body{grid-template-columns:repeat(2,1fr);}}
-    @media(max-width:699px){.post-card .post-body{grid-template-columns:1fr;}}
+    .post-card{width:auto;border-radius:4px;overflow:hidden;position:relative;}
+    .post-card .post-header{height:50px;font-weight:bold;position:sticky;top:80px;z-index:1;line-height:50px;padding-left:10px;background:#222;}
+    .post-card .post-body{display:grid;grid-template-columns:400px 400px 400px;column-gap:10px;row-gap:10px;}
+    .post-card .col1{position:sticky;top:130px;}
+    .post-card .rect{width:400px;height:300px;background:#444;display:grid;place-items:center;}
+    .post-card .post-text{grid-column:2/4;}
+    @media(max-width:1219px){
+      .post-card .post-body{grid-template-columns:400px 400px;}
+      .post-card .col3{grid-column:2;}
+      .post-card .post-text{grid-column:2;}
+    }
+    @media(max-width:819px){
+      .post-card .post-body{grid-template-columns:400px;}
+      .post-card .col2{grid-column:1;}
+      .post-card .col3{grid-column:1;}
+      .post-card .post-text{grid-column:1;}
+    }
     #adBoard{position:absolute;top:80px;bottom:80px;right:0;width:420px;z-index:5;transform:translateX(100%);transition:transform .3s;}
     #adBoard.open{transform:translateX(0);}
     #adBoard .ad-card{width:400px;border-radius:4px;overflow:hidden;position:relative;}
@@ -160,14 +171,392 @@
         </div>
       </div>
     </div>
+      <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div id="postBoard" class="scrollable">
-    <div class="post-card">
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card open">
       <div class="post-header">Post Title</div>
       <div class="post-body">
-        <div>Column 1</div>
-        <div>Column 2</div>
-        <div>Column 3</div>
+        <div class="col1"><div class="rect">Images</div></div>
+        <div class="col2"><div class="rect">Map</div></div>
+        <div class="col3"><div class="rect">Calendar</div></div>
+        <div class="post-text">Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit amet consectetur adipiscing elit Lorem ipsum dolor sit </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-card quick-card">
+      <div class="content">
+        <img class="thumb" src="assets/welcome 001.jpg" alt="thumb">
+        <div>
+          <div style="font-weight:bold;">Sample Post</div>
+          <div class="info">
+            <div class="subcat-row">Cat &gt; Subcat</div>
+            <div class="venue-row">Venue Location</div>
+            <div class="daterange-row">Mon 31 Jan, 2024 - Thu 25 Jul, 2026</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -313,6 +702,9 @@
     const postBoard=document.getElementById('postBoard');
     document.getElementById('quickToggle').addEventListener('click',e=>{quickBoard.classList.toggle('open');e.target.classList.toggle('selected');});
     document.getElementById('postToggle').addEventListener('click',e=>{postBoard.classList.toggle('closed');e.target.classList.toggle('selected');});
+    document.querySelectorAll('#postBoard .post-card.quick-card').forEach(card=>{
+      card.addEventListener('click',()=>{document.querySelector('#postBoard .post-card.open').scrollIntoView({behavior:'smooth'});});
+    });
     document.getElementById('filterToggle').addEventListener('click',()=>{document.getElementById('filterPanel').classList.toggle('open');});
     document.getElementById('memberToggle').addEventListener('click',()=>{document.getElementById('memberPanel').classList.toggle('open');});
     document.getElementById('adminToggle').addEventListener('click',()=>{document.getElementById('adminPanel').classList.toggle('open');});


### PR DESCRIPTION
## Summary
- Lay out post-card columns at 400px with sticky header and image
- Add 19 quick cards and 10 closed post cards around the open post
- Scroll to open post when a closed post card is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc58510a6483319c5c5492ffbe411e