### PR TITLE
chore: upgrade mapbox-gl-js to 3.14.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -4695,12 +4695,12 @@ function makePosts(){
         });
       }
 
-      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css');
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css');
       injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css',
         'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
 
       const s = document.createElement('script');
-      s.src='https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.js';
+      s.src='https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.js';
       s.onload = ()=>{
         const g = document.createElement('script');
         g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';


### PR DESCRIPTION
## Summary
- bump Mapbox GL JS CDN from v3.5.1 to v3.14.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7329da2883318a23257716b732cc