### PR TITLE
Handle missing cluster IDs gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -3774,7 +3774,7 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
         const page = 50; const out = [];
         function step(offset){
           src.getClusterLeaves(clusterId, page, offset, (err, leaves)=>{
-            if(err){ reject(err); return; }
+            if(err){ resolve([]); return; }
             out.push(...leaves);
             if(leaves.length < page) resolve(out);
             else step(offset + page);


### PR DESCRIPTION
## Summary
- avoid uncaught errors when Mapbox cluster ID is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8577a09083319d862bc09bdf2d85