### PR TITLE
Remove theme system and rely on global styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -2925,211 +2925,6 @@ footer .chip-small img.mini, footer .foot-row .foot-item img{
 }
 
 </style>
-<style id="theme-default">
-:root{--primary:#000000;--secondary:#000000;--accent:#000000;--button-hover-text:#000000;--btn:#3E5393;--panel-bg:rgba(0,0,0,1);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--placeholder-text:gray;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--border:rgba(173,173,173,0.31);--border-hover:rgba(255,136,0,0.43);--border-active:rgba(255,200,0,0.45);--session-available:#808080;--session-selected:#008000;}
-.header{background-color:#1d2744;}
-.header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.header button{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
-.header .gear{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
-.header a{background-color:#292929;border-color:#292929;box-shadow:0 0 0px #000000;}
-.header button{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.header .gear{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.header a{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-body{background-color:rgba(41,41,41,1);}
-.res-list{background-color:rgba(0,0,0,0);}
-.res-list .card{background-color:rgba(41,41,41,1);box-shadow:0 0 0px #000000;}
-.res-list{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.res-list .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.res-list button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .sq{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .tiny{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .btn{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .sq{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .tiny{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .btn{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.closed-posts{background-color:rgba(0,0,0,0);}
-.closed-posts .card{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;}
-.closed-posts .open-posts{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;}
-.closed-posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.closed-posts .posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.closed-posts .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts .open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.closed-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts{background-color:rgba(0,0,0,0.52);box-shadow:0 0 0px #000000;}
-.open-posts{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.open-posts .title{color:#ffffff;font-family:Verdana;font-size:20px;font-weight:bold;text-shadow:0px 0px 0px #000000;margin:8px 0 4px;}
-.open-posts button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.open-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .detail-header{background-color:#3E5393;}
-.open-posts .img-box{background-color:#000000;}
-footer{background-color:rgba(0,0,0,0.5);}
-footer .foot-row .foot-item{background-color:rgba(0,0,0,0.32);box-shadow:0 0 0px #000000;}
-footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-  .map-area{background-color:rgba(0,0,0,1);}
-.mapboxgl-popup .mapboxgl-popup-content{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;}
-.mapboxgl-popup .hover-card{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .chip{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .chip-small{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .multi-item{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .hover-card .t,
-.mapboxgl-popup .hover-card .title,
-.mapboxgl-popup .chip .t,
-.mapboxgl-popup .chip .title,
-.mapboxgl-popup .chip-small .t,
-.mapboxgl-popup .chip-small .title,
-.mapboxgl-popup .multi-item .t,
-.mapboxgl-popup .multi-item .title{color:var(--popup-text);}
-#filterPanel .panel-content{background-color:rgba(0,0,0,0.7);}
-#filterPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .panel-content .t{color:#ffffff;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .panel-content .title{color:#ffffff;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel button{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
-#filterPanel .sq{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
-#filterPanel .tiny{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
-#filterPanel .btn{background-color:#601a7a;border-color:#601a7a;box-shadow:0 0 0px #000000;}
-#filterPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .sq{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .tiny{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .btn{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel .panel-content{background-color:rgba(0,0,0,0.7);}
-#adminPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel .panel-content .t{color:#ffffff;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel .panel-content .title{color:#ffffff;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel button{background-color:#165d6f;border-color:#165d6f;box-shadow:0 0 0px #000000;}
-#adminPanel #spinType span{background-color:#165d6f;border-color:#165d6f;box-shadow:0 0 0px #000000;}
-#adminPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel #spinType span{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel .panel-content{background-color:rgba(0,0,0,0.7);}
-#memberPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel .panel-content .t{color:#ffffff;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel .panel-content .title{color:#ffffff;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
-#memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list{padding-top:12px;margin-top:0px;padding-right:12px;margin-right:0px;padding-bottom:12px;margin-bottom:0px;padding-left:12px;margin-left:0px;}
-.res-list .thumb{width:80px;height:80px;}
-@media (min-width:450px){.closed-posts .posts{padding:12px;margin:0;}}
-.closed-posts .thumb{width:80px;height:80px;padding:0;}
-
-
-
-
-
-</style>
-<style id="theme-blue" disabled>
-:root{--primary:#000000;--secondary:#000000;--accent:#000000;--btn:#3E5393;--panel-bg:rgba(0,0,0,1);--panel-text:#000000;--scrollbar-track:rgba(0,0,0,0);--scrollbar-thumb:rgba(0,0,0,0.3);--scrollbar-thumb-hover:rgba(0,0,0,0.5);--list-background:rgba(0,0,0,0.37);--closed-card-bg:rgba(0,0,0,0.37);--placeholder-text:#000000;--filter-placeholder-text:#000000;--dropdown-title:#000000;--dropdown-selected-bg:rgba(224,224,224,1);--dropdown-selected-text:#000000;--dropdown-text:#000000;--dropdown-bg:rgba(255,255,255,1);--dropdown-hover-bg:rgba(224,224,224,1);--dropdown-hover-text:#000000;--dropdown-venue-text:#000000;--keyword-bg:rgba(255,255,255,1);--date-range-bg:rgba(255,255,255,1);--date-range-text:#000000;--session-available:#90d9fe;--session-selected:#0c86e4;--today:#ff0000;--border:rgba(173,173,173,0);--border-hover:rgba(173,173,173,0);--border-active:rgba(173,173,173,0);--calendar-width:300px;--calendar-height:200px;}
-.open-posts-sticky-header .open-posts .detail-header{position:sticky;top:0;z-index:3;background:var(--list-background);}
-.header{background-color:rgba(62,83,147,1);}
-.header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.header button{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-.header .gear{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-.header a{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-.header button{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.header .gear{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.header a{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.options-dropdown > button{background-color:#3a3a3a;border-color:#3a3a3a;box-shadow:0 0 0px #000000;}
-.options-dropdown > button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.options-menu{background-color:rgba(255,255,255,1);}
-body{background-color:rgba(41,41,41,1);}
-.res-list{background-color:rgba(0,0,0,0.5);}
-.res-list .card{background-color:rgba(62,83,147,1);box-shadow:0 0 0px #000000;}
-.res-list{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.res-list .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.res-list button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .sq{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .tiny{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list .btn{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.res-list button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .sq{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .tiny{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.res-list .btn{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.closed-posts{background-color:rgba(0,0,0,0.5);}
-.closed-posts .card{background-color:rgba(62,83,147,1);box-shadow:0 0 0px #000000;}
-.closed-posts .open-posts{background-color:rgba(62,83,147,1);box-shadow:0 0 0px #000000;}
-.closed-posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.closed-posts .posts{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.closed-posts .card .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts .card .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts .open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts .open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.closed-posts button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.closed-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts{background-color:rgba(62,83,147,1);box-shadow:0 0 0px #000000;}
-.open-posts{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .venue-info{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .session-info{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .t{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.open-posts .title{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-.open-posts button{background-color:#3E5393;border-color:#3E5393;box-shadow:0 0 0px #000000;}
-.open-posts button{color:#ffffff;font-family:Verdana;font-size:14px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.open-posts .detail-header{background-color:#3e5393;}
-.open-posts .img-box{background-color:#000000;}
-.open-posts .venue-menu button{background-color:#000000;}
-.open-posts .session-menu button{background-color:#000000;}
-footer{background-color:rgba(0,0,0,0.5);}
-footer .foot-row .foot-item{background-color:rgba(0,0,0,0.32);box-shadow:0 0 0px #000000;}
-footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.map-area{background-color:rgba(0,0,0,1);}
-.mapboxgl-popup .mapboxgl-popup-content{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;}
-.mapboxgl-popup .hover-card{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .chip{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .chip-small{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .multi-item{background-color:var(--popup-bg);box-shadow:0 0 0px #000000;color:var(--popup-text);}
-.mapboxgl-popup .hover-card .t,
-.mapboxgl-popup .hover-card .title,
-.mapboxgl-popup .chip .t,
-.mapboxgl-popup .chip .title,
-.mapboxgl-popup .chip-small .t,
-.mapboxgl-popup .chip-small .title,
-.mapboxgl-popup .multi-item .t,
-.mapboxgl-popup .multi-item .title{color:var(--popup-text);}
-#filterPanel .panel-content{background-color:rgba(145,145,145,1);}
-#filterPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel button{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-#filterPanel .sq{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-#filterPanel .tiny{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-#filterPanel .btn{background-color:#3e5393;border-color:#3e5393;box-shadow:0 0 0px #000000;}
-#filterPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .sq{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .tiny{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#filterPanel .btn{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.calendar{background-color:rgba(255,255,255,1);}
-.calendar .day{color:#000000;font-family:Verdana;font-size:12px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.calendar .weekday{color:#a3a3a3;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.calendar .calendar-header{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-.calendar .calendar-header{background-color:#3e5393;}
-#adminPanel .panel-content{background-color:rgba(145,145,145,1);}
-#adminPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel .panel-content .t{color:#ffffff;font-family:Verdana;font-size:20px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-#adminPanel .panel-content .title{color:#ffffff;font-family:Verdana;font-size:20px;font-weight:bold;text-shadow:0px 0px 0px #000000;}
-#adminPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
-#adminPanel #spinType span{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
-#adminPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adminPanel #spinType span{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#welcomePopup .panel-content{background-color:rgba(0,0,0,0.48);}
-#welcomePopup .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#welcomePopup .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#welcomePopup .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#welcomePopup button{background-color:#000000;border-color:#000000;box-shadow:0 0 0px #000000;}
-#welcomePopup button{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel .panel-content{background-color:rgba(145,145,145,1);}
-#memberPanel .panel-content{color:#ffffff;font-family:Verdana;font-size:16px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel .panel-content .t{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel .panel-content .title{color:#000000;font-family:Verdana;font-size:10px;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#memberPanel button{background-color:#16596a;border-color:#16596a;box-shadow:0 0 0px #000000;}
-#memberPanel button{color:#ffffff;font-family:Arial;font-weight:normal;text-shadow:0px 0px 0px #000000;}
-#adPanel{background-color:var(--ad-panel-bg);}
-.img-popup{background-color:rgba(0,0,0,1);}
-
-</style>
 </head>
 <body class="mode-map" style="padding-bottom:var(--footer-h);">
   <header class="header" role="banner">
@@ -3302,51 +3097,13 @@ footer{color:#ffffff;font-family:Verdana;font-size:12px;font-weight:normal;text-
           </div>
         </div>
         <div class="tab-bar">
-          <button type="button" class="tab-btn" data-tab="theme" aria-selected="true">Theme</button>
-          <button type="button" class="tab-btn" data-tab="map">Map</button>
+          <button type="button" class="tab-btn" data-tab="map" aria-selected="true">Map</button>
           <button type="button" class="tab-btn" data-tab="settings">Settings</button>
           <button type="button" class="tab-btn" data-tab="forms">Forms</button>
         </div>
       </div>
       <form id="adminForm" class="panel-body">
-        <div id="tab-theme" class="tab-panel active">
-          <div id="themePresetsContainer" class="admin-section">
-            <h3 class="title">Theme Presets</h3>
-            <div class="panel-field">
-              <label for="themePreset">Themes</label>
-              <div class="preset-select">
-                <select id="themePreset" style="width:250px"></select>
-                <button type="button" id="refreshTheme">Refresh</button>
-              </div>
-            </div>
-            <div class="preset-actions">
-              <input id="newPresetName" type="text" placeholder="Name of your new theme" />
-              <button type="button" id="savePreset">Save Theme</button>
-              <button type="button" id="downloadCss">Download CSS</button>
-            </div>
-          </div>
-          <div id="themeBuilderContainer" class="admin-section">
-            <h3 class="title">Theme Builder</h3>
-            <div id="styleControls">
-              <div id="undo-row" class="history-group">
-                <button type="button" id="undoBtn">Undo</button>
-                <button type="button" id="redoBtn">Redo</button>
-              </div>
-              <div id="autoTheme-row">
-                <button type="button" id="autoThemeBtn">AutoTheme</button>
-                <input type="color" id="baseColor" value="#336699" />
-              </div>
-            </div>
-          </div>
-          <div id="backupRestoreContainer" class="admin-section">
-            <div class="panel-field">
-              <label for="themeRestore">Restore Backup</label>
-              <select id="themeRestore" style="width:250px"></select>
-              <button type="button" data-restore="theme">Restore</button>
-            </div>
-          </div>
-        </div>
-          <div id="tab-map" class="tab-panel">
+        <div id="tab-map" class="tab-panel active">
             <div class="panel-field">
               <label for="mapTheme">Theme</label>
               <select id="mapTheme">
@@ -6838,9 +6595,7 @@ document.addEventListener('pointerdown', handleDocInteract);
         document.documentElement.classList.toggle('open-posts-sticky-header', stickyHeaderInput.checked);
         const data = collectThemeValues();
         currentState = JSON.parse(JSON.stringify(data));
-        localStorage.setItem('currentTheme', JSON.stringify(data));
-        updateHistoryButtons();
-      });
+        localStorage.setItem('currentTheme', JSON.stringify(data));      });
     }
     const stickyImageInput = document.getElementById('open-posts-sticky-images');
     if(stickyImageInput){
@@ -7721,9 +7476,7 @@ document.addEventListener('pointerdown', handleDocInteract);
   function savePreset(name){
     const stored = JSON.parse(localStorage.getItem('themePresets')||'[]');
     stored.push({name,data: collectThemeValues()});
-    localStorage.setItem('themePresets', JSON.stringify(stored));
-    loadPresets();
-  }
+    localStorage.setItem('themePresets', JSON.stringify(stored));  }
 
   function loadSavedTheme(){
     const cssTheme = localStorage.getItem('selectedCssTheme');
@@ -7746,16 +7499,10 @@ document.addEventListener('pointerdown', handleDocInteract);
       applyPresetData(saved);
     }
   }
-
-
-  buildStyleControls();
   syncAdminControls();
   applyAdmin();
-  defaultTheme = collectThemeValues();
-  loadPresets();
-  loadSavedTheme();
   currentState = collectThemeValues();
-  updateHistoryButtons();
+
 
     const adminForm = document.getElementById('adminForm');
     if(adminForm){
@@ -7901,7 +7648,7 @@ document.addEventListener('pointerdown', handleDocInteract);
     const saveBtn = document.getElementById('saveNow');
     const discardBtn = document.getElementById('discardChanges');
     const adminClose = document.querySelector('#adminPanel .close-panel');
-    const tabPanels = ['theme','map','settings'];
+    const tabPanels = ['map','settings'];
     const savedData = {};
 
     function toHex(val){


### PR DESCRIPTION
## Summary
- Drop per-theme style sheets and the admin panel's theme tab so the site uses only global styles.
- Initialize admin logic with global settings and remove theme preset handling.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc886152c08331b160b598528b87c8