### PR TITLE
Set panel backgrounds and button colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,15 +564,20 @@ button[aria-expanded="true"] .results-arrow{
     max-height:90%;
   }
 
+  #adminPanel .panel-content{
+    background:#222222;
+    color:#fff;
+  }
+
   #memberPanel .panel-content{
-    background:rgba(0,0,0,0.7);
+    background:#222222;
     color:#fff;
   }
 #filterPanel .panel-content{
   width:350px;
   max-width:600px;
   max-height:90%;
-  background:rgba(0,0,0,0.7);
+  background:#222222;
   color:#fff;
 }
 
@@ -582,7 +587,7 @@ button[aria-expanded="true"] .results-arrow{
 #filterPanel .btn,
 #adminPanel button,
 #memberPanel button{
-  background: var(--btn);
+  background:#333333;
   color: var(--ink);
   border: none;
 }


### PR DESCRIPTION
## Summary
- Set member, filter, and admin panel backgrounds to opaque `#222222` for consistent dark styling.
- Updated related button styles to use `#333333` backgrounds.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9bd7fce48331b903bfa43c9c28a8