### PR TITLE
Defer Mapbox CSS for faster post loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css" />
   <style>:root{
   --header-h: 75px;
   --subheader-h: 0;
@@ -4492,6 +4491,7 @@ function makePosts(){
         });
       }
 
+      injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css');
       injectCleanCSS('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css',
         'https://unpkg.com/@mapbox/mapbox-gl-geocoder@5.0.0/dist/mapbox-gl-geocoder.css');
 


### PR DESCRIPTION
## Summary
- remove render-blocking Mapbox GL stylesheet from `<head>`
- dynamically inject Mapbox and geocoder CSS within `loadMapbox`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6bd9d26083318bf9e30c9184f42e