### PR TITLE
feat: gate openPost and refactor modal triggers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4527,7 +4527,7 @@ function makePosts(){
         const cardEl = e.target.closest('.quick-card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id) { stopSpin(); openPost(id); }
+          if(id) { stopSpin(); }
           return;
         }
         if(e.target === resList){
@@ -4545,7 +4545,7 @@ function makePosts(){
         const cardEl = e.target.closest('.post-card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id){ stopSpin(); openPost(id, true); }
+          if(id){ stopSpin(); }
           return;
         }
         if(e.target === postsWide && postsWide.querySelector('.open-posts')){
@@ -4952,7 +4952,7 @@ function makePosts(){
         const close = ()=>{ if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } lockMap(false); };
         root.addEventListener('click', (ev)=> ev.stopPropagation(), {capture:true});
         root.querySelectorAll('.multi-item.map-card').forEach(n => n.addEventListener('click', ()=>{
-          const id = n.getAttribute('data-id'); close(); stopSpin(); openPost(id);
+        const id = n.getAttribute('data-id'); close(); stopSpin();
         }));
         const btn = root.querySelector('[data-act="close"]'); if(btn) btn.addEventListener('click', close);
         lockMap(true); lastListOpenAt = Date.now();
@@ -4981,7 +4981,7 @@ function makePosts(){
             const root = hoverPopup.getElement();
             const close = ()=>{ if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } lockMap(false); };
             root.addEventListener('click', (ev)=> ev.stopPropagation(), {capture:true});
-            root.querySelectorAll('.multi-item.map-card').forEach(n => n.addEventListener('click', (e)=>{ e.stopPropagation(); const id = n.getAttribute('data-id'); close(); stopSpin(); openPost(id); }));
+            root.querySelectorAll('.multi-item.map-card').forEach(n => n.addEventListener('click', (e)=>{ e.stopPropagation(); const id = n.getAttribute('data-id'); close(); stopSpin(); }));
             const btn = root.querySelector('[data-act="close"]'); if(btn) btn.addEventListener('click', close);
             lockMap(true);
             (function(){
@@ -4992,7 +4992,7 @@ function makePosts(){
                   var row = (ev.target && ev.target.closest) ? ev.target.closest('.multi-item.map-card') : null;
                   if(row){
                     var pid = row.getAttribute('data-id');
-                    if(pid){ if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } lockMap(false); stopSpin(); openPost(pid); return; }
+                    if(pid){ if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } lockMap(false); stopSpin(); return; }
                   }
                 }, {capture:true});
               }
@@ -5007,7 +5007,6 @@ function makePosts(){
           if(touchMarker === id){
             touchMarker = null;
             if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; }
-            openPost(id);
             return;
           } else {
             touchMarker = id;
@@ -5019,12 +5018,10 @@ function makePosts(){
               registerPopup(hoverPopup);
               const cardEl = hoverPopup.getElement().querySelector('.hover-card');
               if(cardEl){
-                cardEl.addEventListener('click', (e)=>{ e.stopPropagation(); touchMarker=null; openPost(id); });
+                cardEl.addEventListener('click', (e)=>{ e.stopPropagation(); touchMarker=null; });
               }
             }
           }
-        } else {
-          openPost(id);
         }
       });
 
@@ -5071,7 +5068,7 @@ function makePosts(){
               var row = (ev.target && ev.target.closest) ? ev.target.closest('.multi-item.map-card') : null;
               if(row){
                 var pid = row.getAttribute('data-id');
-                if(pid){ if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } stopSpin(); openPost(pid); return; }
+                if(pid){ if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } stopSpin(); return; }
               }
             }, {capture:true});
           }
@@ -5104,7 +5101,7 @@ function makePosts(){
           if(__el){
             __el.addEventListener('click', function(ev){
               ev.stopPropagation();
-              try{ stopSpin(); openPost(id); }catch(e){ console.warn('openPost id missing', e); }
+              try{ stopSpin(); }catch(e){ console.warn('id missing', e); }
             }, {capture:true});
           }
         })();
@@ -5260,7 +5257,7 @@ function makePosts(){
         </div>`;
       slide.appendChild(img);
       slide.appendChild(cap);
-      slide.addEventListener('click', e => { e.stopPropagation(); openPost(p.id); });
+      slide.addEventListener('click', e => { e.stopPropagation(); });
       img.decode().catch(() => {}).then(() => {
         panel.appendChild(slide);
         requestAnimationFrame(()=> slide.classList.add('active'));
@@ -5332,7 +5329,7 @@ function makePosts(){
         if(v.id===activePostId) el.setAttribute('aria-selected','true');
         el.addEventListener('click', e=>{
           e.stopPropagation();
-          openPost(v.id);
+          openPost(v.id, true);
         });
         footRow.appendChild(el);
       }
@@ -5417,7 +5414,8 @@ function makePosts(){
         return wrap;
     }
 
-    async function openPost(id){
+    async function openPost(id, allowed = false){
+      if(!allowed) return;
       touchMarker = null;
       if(hoverPopup){ hoverPopup.remove(); hoverPopup = null; }
       spinEnabled = false;
@@ -5454,7 +5452,7 @@ function makePosts(){
       const card = ev.target.closest('.mapboxgl-popup.map-card .hover-card');
       if(card){
         const pid = card.getAttribute('data-id') || (card.closest('.multi-item.map-card') && card.closest('.multi-item.map-card').getAttribute('data-id'));
-        if(pid){ touchMarker = null; stopSpin(); openPost(pid); }
+        if(pid){ touchMarker = null; stopSpin(); }
       }
     });
 
@@ -5839,7 +5837,7 @@ function makePosts(){
     applyFilters();
     setMode('map');
     const initialPost = new URLSearchParams(window.location.search).get('post');
-    if(initialPost) openPost(initialPost);
+    if(initialPost) openPost(initialPost, true);
   })();
   
 // 0577 helpers (safety)


### PR DESCRIPTION
## Summary
- Add `allowed` flag to `openPost` to prevent unauthorized modal launches.
- Only footer history and URL query can open posts by passing `true` to `openPost`.
- Remove automatic modal opening from quick-board, posts list, and map card interactions.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc651920c8331bd4b4fae8859b111