### PR TITLE
Remove custom navigation handling for post cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -4536,8 +4536,6 @@ function makePosts(){
       resList && resList.addEventListener('click', e=>{
         const cardEl = e.target.closest('.quick-card');
         if(cardEl){
-          const id = cardEl.getAttribute('data-id');
-          if(id) { stopSpin(); openPost(id, true); }
           return;
         }
         if(e.target === resList){
@@ -4555,7 +4553,7 @@ function makePosts(){
         const cardEl = e.target.closest('.post-card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id){ stopSpin(); openPost(id, true); }
+          if(id){ stopSpin(); }
           return;
         }
         if(e.target === postsWide && postsWide.querySelector('.open-posts')){


### PR DESCRIPTION
## Summary
- Remove custom openPost navigation for quick-board results so anchors navigate natively
- Drop openPost call on #postsWide cards, leaving spinner stop only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdd2fc31388331bc6bbf400101db11