### PR TITLE
fix: remove openPost call from ad slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -5270,7 +5270,7 @@ function makePosts(){
         </div>`;
       slide.appendChild(img);
       slide.appendChild(cap);
-      slide.addEventListener('click', e => { e.stopPropagation(); openPost(p.id, true); });
+      slide.addEventListener('click', e => { e.stopPropagation(); });
       img.decode().catch(() => {}).then(() => {
         panel.appendChild(slide);
         requestAnimationFrame(()=> slide.classList.add('active'));


### PR DESCRIPTION
## Summary
- remove openPost invocation from ad slide click handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd301bd788331ba8fb15bd4d5b709