### PR TITLE
Refactor hash routing into handleHash function

### DIFF
--- a/index.html
+++ b/index.html
@@ -5636,18 +5636,27 @@ function makePosts(){
       location.hash = '';
     }
 
+    function handleHash(){
+      if(!location.hash){
+        closePostModal();
+        return;
+      }
+      const m = location.hash.match(/\/post\/([^\/]+)-([^\/]+)$/);
+      if(!m || !(Array.isArray(posts) && posts.length)) return;
+      const slug = decodeURIComponent(m[1]);
+      const created = m[2];
+      const post = posts.find(x=>x.slug===slug && x.created===created);
+      if(post){ openPostModal(post.id); }
+    }
+
+    window.addEventListener('hashchange', handleHash);
+
     document.addEventListener('DOMContentLoaded', ()=>{
       const container = document.getElementById('post-modal-container');
       if(container){
         container.addEventListener('click', e=>{ if(e.target===container) closePostModal(); });
       }
-      const m = location.hash.match(/\/post\/([^\/]+)-([^\/]+)$/);
-      if(m){
-        const slug = decodeURIComponent(m[1]);
-        const created = m[2];
-        const post = posts.find(x=>x.slug===slug && x.created===created);
-        if(post){ openPostModal(post.id); }
-      }
+      handleHash();
     });
 
     document.addEventListener('click', (ev)=>{


### PR DESCRIPTION
## Summary
- Move hash parsing logic into new `handleHash` function
- Invoke `handleHash` on DOMContentLoaded and on `hashchange`
- Ensure empty hash closes modal and safely handle missing posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde66c90548331b61ec0d9c34bcf7d