### PR TITLE
feat: make setMode skip filters when opening posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4776,7 +4776,7 @@ function makePosts(){
       });
 
 
-      function setMode(m){
+      function setMode(m, skipFilters = false){
         mode = m;
       document.body.classList.remove('mode-map','mode-posts','hide-posts-ui');
       document.body.classList.add('mode-'+m);
@@ -4796,7 +4796,7 @@ function makePosts(){
         localStorage.setItem('spinGlobe','false');
         stopSpin();
       }
-      applyFilters();
+      if(!skipFilters) applyFilters();
       if(window.updateAdVisibility) updateAdVisibility();
     }
     window.setMode = setMode;
@@ -5716,7 +5716,7 @@ function makePosts(){
       $$('footer .foot-row .footer-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
       $$('.mapboxgl-popup.map-card .hover-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
       if(mode !== 'posts'){
-        setMode('posts');
+        setMode('posts', true);
         await nextFrame();
       }
 


### PR DESCRIPTION
## Summary
- allow `setMode` to skip calling `applyFilters` via a new `skipFilters` parameter
- avoid filter refresh when `openPost` switches the UI to posts mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be30d06f2c833195778a892adda917