### PR TITLE
fix: swap quick and post card open behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4749,7 +4749,7 @@ function makePosts(){
         const cardEl = e.target.closest('.quick-card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id) { stopSpin(); openPost(id); }
+          if(id) { stopSpin(); openPost(id, true); }
           return;
         }
         if(e.target === resList){
@@ -4767,7 +4767,7 @@ function makePosts(){
         const cardEl = e.target.closest('.post-card');
         if(cardEl){
           const id = cardEl.getAttribute('data-id');
-          if(id){ stopSpin(); openPost(id, true); }
+          if(id){ stopSpin(); openPost(id); }
           return;
         }
         if(e.target === postsWide && postsWide.querySelector('.open-posts')){
@@ -5704,7 +5704,7 @@ function makePosts(){
         return wrap;
     }
 
-    async function openPost(id, fromPosts=false){
+    async function openPost(id, fromQuick=false){
       touchMarker = null;
       if(hoverPopup){ hoverPopup.remove(); hoverPopup = null; }
       spinEnabled = false;
@@ -5758,7 +5758,12 @@ function makePosts(){
       }
 
       if(container){
-        ensureGap(container, detail);
+        if(fromQuick){
+          const pad = parseInt(getComputedStyle(container).paddingTop, 10) || 0;
+          container.scrollTo({top: detail.offsetTop - pad - 12, behavior:'smooth'});
+        } else {
+          ensureGap(container, detail);
+        }
       } else if(window.innerWidth > 450) {
         (header || detail).scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
@@ -5865,7 +5870,10 @@ function makePosts(){
     function ensureGap(container, el){
   const pad = parseInt(getComputedStyle(container).paddingTop, 10) || 0;
   const desired = el.offsetTop - pad - 12;
-  if(container.scrollTop > desired){
+  const viewTop = container.scrollTop;
+  const viewBottom = viewTop + container.clientHeight;
+  const elBottom = el.offsetTop + el.offsetHeight + 12;
+  if(viewTop > desired || viewBottom < elBottom){
     container.scrollTo({top: Math.max(desired, 0), behavior:'smooth'});
   }
 }


### PR DESCRIPTION
## Summary
- ensure quick card opens scroll to post
- ensure post card opens in place
- keep opened post in view when navigating to lower cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3741de24833197488fc94d7d39f0