### PR TITLE
fix: restrict ensureGap to upward scroll only

### DIFF
--- a/index.html
+++ b/index.html
@@ -5520,9 +5520,7 @@ function makePosts(){
   const pad = parseInt(getComputedStyle(container).paddingTop, 10) || 0;
   const desired = el.offsetTop - pad - 12;
   const viewTop = container.scrollTop;
-  const viewBottom = viewTop + container.clientHeight;
-  const elBottom = el.offsetTop + el.offsetHeight + 12;
-  if(viewTop > desired || viewBottom < elBottom){
+  if(viewTop > desired){
     container.scrollTo({top: Math.max(desired, 0), behavior:'smooth'});
   }
 }


### PR DESCRIPTION
## Summary
- prevent `ensureGap` from scrolling down so opening post cards doesn't shift view
- keep quick-card behavior using `container.scrollTo` for deliberate navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4a1f45b48331bf0f28b5223430bb