### PR TITLE
fix: remove post-board auto scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -5406,14 +5406,7 @@ function makePosts(){
         header.style.scrollMarginTop = h + 'px';
       }
 
-      if(container){
-        if(fromQuick){
-          const pad = parseInt(getComputedStyle(container).paddingTop, 10) || 0;
-          container.scrollTo({top: detail.offsetTop - pad - 12, behavior:'smooth'});
-        } else {
-          ensureGap(container, detail);
-        }
-      } else if(window.innerWidth > 450) {
+      if(!container && window.innerWidth > 450){
         (header || detail).scrollIntoView({block:'start', inline:'nearest', behavior:'auto'});
       }
 
@@ -5520,9 +5513,7 @@ function makePosts(){
   const pad = parseInt(getComputedStyle(container).paddingTop, 10) || 0;
   const desired = el.offsetTop - pad - 12;
   const viewTop = container.scrollTop;
-  const viewBottom = viewTop + container.clientHeight;
-  const elBottom = el.offsetTop + el.offsetHeight + 12;
-  if(viewTop > desired || viewBottom < elBottom){
+  if(viewTop > desired){
     container.scrollTo({top: Math.max(desired, 0), behavior:'smooth'});
   }
 }


### PR DESCRIPTION
## Summary
- stop auto scrolling when opening post cards so board remains stationary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4a1f45b48331bf0f28b5223430bb