### PR TITLE
Use picsum photos for member avatars

### DIFF
--- a/index.html
+++ b/index.html
@@ -3849,7 +3849,7 @@ function uniqueTitle(seed, cityName, idx){
   }
 
   function randomAvatar(seed){
-    return `https://api.dicebear.com/7.x/identicon/png?seed=${encodeURIComponent(seed)}`;
+    return `https://picsum.photos/seed/${encodeURIComponent(seed)}-a/100/100`;
   }
 
   function slugify(str){


### PR DESCRIPTION
## Summary
- Load member avatars from picsum.photos to match post image source

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be54c550f8833183a2014267abfa46