### PR TITLE
Remove vertical flex from calendar elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,14 +699,11 @@ button[aria-expanded="true"] .results-arrow{
   flex:0 0 auto;
   width:var(--calendar-width);
   height:var(--calendar-height);
-  display:flex;
-  flex-direction:column;
 }
 .calendar .month:not(:first-child){
   border-left:1px solid var(--calendar-past-bg);
 }
 .calendar .grid{
-  flex:1 1 auto;
   width:100%;
   height:calc(var(--calendar-height) - var(--calendar-header-h) - var(--scrollbar-h));
   display:grid;
@@ -716,9 +713,6 @@ button[aria-expanded="true"] .results-arrow{
 .calendar .calendar-header{
   height:var(--calendar-header-h);
   line-height:var(--calendar-header-h);
-  display:flex;
-  align-items:center;
-  justify-content:center;
   text-align:center;
   font-family:inherit;
   font-size:inherit;
@@ -729,10 +723,8 @@ button[aria-expanded="true"] .results-arrow{
 .calendar .day{
   width:var(--calendar-cell-w);
   height:var(--calendar-cell-h);
-  display:flex;
-  align-items:center;
-  justify-content:center;
   line-height:var(--calendar-cell-h);
+  text-align:center;
   font-family:inherit;
   font-size:inherit;
 }


### PR DESCRIPTION
## Summary
- remove flex-based vertical layout from calendar month, headers, and day cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be8d7703848331b8fab7945f402d2a