### PR TITLE
Remove column flex from filter panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1057,8 +1057,6 @@ button[aria-expanded="true"] .results-arrow{
 
 
 .filters-col{
-  display: flex;
-  flex-direction: column;
   min-height: 0;
 }
 


### PR DESCRIPTION
## Summary
- remove display:flex column layout from `.filters-col` in filter panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9038f1b483318dc61a89ca6b2434