### PR TITLE
Remove vertical flex from filter panel container

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,6 +638,7 @@ button[aria-expanded="true"] .results-arrow{
   max-height:90%;
   background:#222222;
   color:#fff;
+  display:block;
 }
 
 #filterPanel button,


### PR DESCRIPTION
## Summary
- Replace flex layout of the filter panel's main container with a block layout to eliminate unintended vertical flexing while keeping sort menu layout intact.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be933828c88331a49bac8690457bdc