### PR TITLE
style: set post selection container dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1476,6 +1476,19 @@ body.hide-results .quick-list-board{
   padding:10px;
 }
 
+.post-venue-selection-container,
+.post-session-selection-container{
+  width:100%;
+  height:250px; /* 200px map/calendar + 50px menu */
+}
+
+.post-details-title-container,
+.post-details-member-container,
+.post-details-info-container,
+.post-details-description-container{
+  width:100%;
+}
+
 .ad-board{
   width:440px;
   padding:10px;


### PR DESCRIPTION
## Summary
- define 250px height for post venue and session selection containers to accommodate map/calendar and menu
- ensure all post details sections stretch the full column width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf181fc3ec8331966c00e2d5358ff7