### PR TITLE
feat: rotate sponsored ads and link to posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,6 +1505,29 @@ body.hide-results .quick-list-board{
   width:420px;
   height:100%;
   margin:0 auto;
+  position:relative;
+  overflow:hidden;
+}
+
+.ad-panel .ad-slide{
+  position:absolute;
+  inset:0;
+  opacity:0;
+  transition:opacity 1.5s ease-in-out;
+}
+
+.ad-panel .ad-slide.active{opacity:1;}
+
+.ad-panel .ad-slide img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  animation:adZoom 20s linear forwards;
+}
+
+@keyframes adZoom{
+  from{transform:scale(1);}
+  to{transform:scale(1.1);}
 }
 
 
@@ -3505,6 +3528,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
     // 'Post Panel' is defined as the current map bounds
     let postPanel = null;
     let posts = [], filtered = [];
+    let adPosts = [], adIndex = -1, adTimer = null;
     let favToTop = false, currentSort = 'az';
     let selection = { cats: new Set(), subs: new Set() };
     let viewHistory = loadHistory();
@@ -4074,6 +4098,7 @@ function makePosts(){
       postsLoaded = true;
       addPostSource();
       applyFilters();
+      initAdPanel();
     }
 
     function checkLoadPosts(){
@@ -6008,6 +6033,48 @@ function makePosts(){
       const summary = $('#filterSummary');
       if(summary){ summary.textContent = `${filtered.length} results showing out of ${total} results in the area.`; }
       updateFilterBtnColor();
+    }
+
+    function initAdPanel(){
+      const panel = document.querySelector('.ad-panel');
+      adPosts = posts.filter(p => p.sponsored);
+      if(!panel || !adPosts.length) return;
+      function showNextAd(){
+        adIndex = (adIndex + 1) % adPosts.length;
+        const p = adPosts[adIndex];
+        const slide = document.createElement('div');
+        slide.className = 'ad-slide';
+        slide.dataset.id = p.id;
+        const img = new Image();
+        img.src = heroUrl(p);
+        img.alt = '';
+        img.decode().catch(()=>{}).then(()=>{
+          slide.appendChild(img);
+          panel.appendChild(slide);
+          requestAnimationFrame(()=> slide.classList.add('active'));
+          const slides = panel.querySelectorAll('.ad-slide');
+          if(slides.length > 1){
+            const old = slides[0];
+            old.classList.remove('active');
+            setTimeout(()=> old.remove(),1500);
+          }
+        });
+      }
+      showNextAd();
+      adTimer = setInterval(showNextAd,20000);
+      panel.addEventListener('click', e => {
+        const slide = e.target.closest('.ad-slide');
+        if(!slide) return;
+        const id = slide.dataset.id;
+        const postCard = document.querySelector(`.post-board .post-card[data-id="${id}"]`);
+        if(postCard){ postCard.scrollIntoView({behavior:'smooth', block:'center'}); }
+        document.querySelectorAll('.quick-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
+        const quickCard = document.querySelector(`.quick-list-board .quick-card[data-id="${id}"]`);
+        if(quickCard){
+          quickCard.setAttribute('aria-selected','true');
+          quickCard.scrollIntoView({behavior:'smooth', block:'nearest'});
+        }
+      });
     }
 
     // applyFilters();


### PR DESCRIPTION
## Summary
- cycle ad panel images from sponsored posts with fade and zoom transitions
- scroll to post card and highlight quick card when an ad is clicked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf19993dd88331a74e0bae24e6ce68