### PR TITLE
feat: add sticky positioning for tall image container

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,7 +1435,8 @@ body.hide-results .quick-list-board{
   z-index:1;
 }
 
-.post-board.two-columns .short-image-container{
+.post-board.two-columns .short-image-container,
+.post-board.two-columns .tall-image-container{
   position:sticky;
   top:calc(var(--post-header-h,0px) + var(--gap));
 }


### PR DESCRIPTION
## Summary
- keep post header sticky when two-column layout is active
- ensure tall image container uses sticky positioning below the header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf29a0f42c8331972e2dcf03dfed49