### PR TITLE
feat: respect board priority on narrow viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -4561,21 +4561,6 @@ function makePosts(){
       const adBoard = $('.ad-board');
       const boardsContainer = $('.post-mode-boards');
       const postBoard = $('.post-board');
-
-      document.body.classList.add('hide-results');
-      quickBtn.setAttribute('aria-pressed','false');
-      quickListBoard.setAttribute('aria-hidden','true');
-      adBtn.setAttribute('aria-pressed','true');
-      window.addEventListener('resize', ()=>{
-        if(window.innerWidth < 650){
-          if(!document.body.classList.contains('hide-results')){
-            document.body.classList.add('hide-results');
-            quickBtn.setAttribute('aria-pressed','false');
-            quickListBoard.setAttribute('aria-hidden','true');
-            localStorage.setItem('resultsHidden','true');
-          }
-        }
-      });
       function adjustBoards(){
         const small = window.innerWidth < 1200;
         const quickHidden = document.body.classList.contains('hide-results');


### PR DESCRIPTION
## Summary
- allow admin-selected board priority to control which side board is visible on small screens
- ensure post board margin and header button states update with viewport size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf312afa108331a7ad2f10c5d37c45