### PR TITLE
style: pin side boards and adjust selection layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1387,6 +1387,8 @@ button[aria-expanded="true"] .results-arrow{
   bottom:var(--footer-h);
   left:0;
   right:0;
+  padding-left:440px;
+  padding-right:440px;
   display:flex;
   justify-content:center;
   gap:var(--gap);
@@ -1394,13 +1396,20 @@ button[aria-expanded="true"] .results-arrow{
   pointer-events:none;
 }
 
+body.hide-results .post-mode-boards{padding-left:0;}
+body.hide-ads .post-mode-boards{padding-right:0;}
+
 .quick-list-board{
-  flex:0 0 440px;
+  position:fixed;
+  top:var(--header-h);
+  bottom:var(--footer-h);
+  left:0;
   width:440px;
   padding:10px;
   overflow:auto;
   background:rgba(0,0,0,0.5);
   pointer-events:auto;
+  z-index:2;
 }
 
 body.hide-results .quick-list-board{
@@ -1408,7 +1417,7 @@ body.hide-results .quick-list-board{
 }
 
 .post-board{
-  flex:0 0 440px;
+  flex:1;
   max-width:970px;
   min-width:360px;
   padding:0;
@@ -1502,11 +1511,15 @@ body.hide-results .quick-list-board{
 }
 
 .ad-board{
-  flex:0 0 440px;
+  position:fixed;
+  top:var(--header-h);
+  bottom:var(--footer-h);
+  right:0;
   width:440px;
   padding:10px;
   background:rgba(0,0,0,0.5);
   pointer-events:auto;
+  z-index:2;
 }
 
 body.hide-ads .ad-board{display:none;}
@@ -2719,8 +2732,18 @@ footer .foot-row .footer-card{
 }
 
 .quick-card[aria-selected="true"]{
-  background-color:#2e3a72 !important;
-  background-image:none !important;
+  position:relative;
+  z-index:0;
+  background:none;
+}
+
+.quick-card[aria-selected="true"]::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background-color:#2e3a72;
+  border-radius:8px;
+  z-index:-1;
 }
 
 .hover-card{


### PR DESCRIPTION
## Summary
- Pin quick list board to left edge and ad board to right edge with fixed 440px widths
- Pad central board to accommodate side panels and keep second post panel responsive
- Render quick-card selection highlight beneath text content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0436fc58083318e25d4b731f53da2