### PR TITLE
fix: respect board toggles and map ad visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -4630,15 +4630,27 @@ function makePosts(){
             quickBtn.setAttribute('aria-pressed', quickHidden ? 'false' : 'true');
           } else {
             document.body.classList.add('hide-results');
-            document.body.classList.remove('hide-ads');
+            if(document.body.classList.contains('mode-map')){
+              document.body.classList.add('hide-ads');
+            } else {
+              document.body.classList.remove('hide-ads');
+            }
             boardsContainer.style.justifyContent = 'flex-start';
             postBoard.style.marginLeft = '10px';
             postBoard.style.marginRight = '';
             quickBtn.setAttribute('aria-pressed','false');
           }
         } else {
-          document.body.classList.remove('hide-results');
-          document.body.classList.remove('hide-ads');
+          if(quickHidden){
+            document.body.classList.add('hide-results');
+          } else {
+            document.body.classList.remove('hide-results');
+          }
+          if(document.body.classList.contains('mode-map')){
+            document.body.classList.add('hide-ads');
+          } else {
+            document.body.classList.remove('hide-ads');
+          }
           boardsContainer.style.justifyContent = 'space-between';
           postBoard.style.marginLeft = '';
           postBoard.style.marginRight = '';


### PR DESCRIPTION
## Summary
- ensure quick list toggle hides the results board on large screens
- keep advertisement board hidden when switching to map mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0527d27ac8331b7d373472ff01145