### PR TITLE
feat: fix calendar dimensions and colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
   --results-w: 440px;
   --gap: 10px;
     --media-h: 200px;
-    --calendar-scale: 1;
     --ink: #ffffff;
     --ink-d: #ececec;
     --gold: #ffc107;
@@ -72,14 +71,14 @@
       --dropdown-hover-text: #000000;
         --dropdown-venue-text: #000000;
         --dropdown-radius: 8px;
-        --calendar-width: 300px;
-        --calendar-height: 250px;
+        --calendar-width: 250px;
+        --calendar-height: 200px;
+        --calendar-header-h: 30px;
         --calendar-cell-w: calc(var(--calendar-width) / 7);
-        --calendar-cell-h: calc((var(--calendar-height) - var(--scrollbar-h)) / 8);
-        --calendar-header-h: var(--calendar-cell-h);
+        --calendar-cell-h: calc((var(--calendar-height) - var(--calendar-header-h) - var(--scrollbar-h)) / 7);
         --calendar-past-bg: #f0f0f0;
         --calendar-future-bg: #ffffff;
-        --session-available: #333333;
+        --session-available: #555555;
         --session-selected: #2e3a72;
         --today: #ff0000;
         --image-panel-bg: rgba(0,0,0,0.7);
@@ -676,8 +675,8 @@ button[aria-expanded="true"] .results-arrow{
   overflow-y:hidden;
   padding-bottom:0;
   box-sizing:content-box;
-  width:calc(var(--calendar-width) * var(--calendar-scale));
-  height:calc(var(--calendar-height) * var(--calendar-scale));
+  width:var(--calendar-width);
+  height:var(--calendar-height);
   border:1px solid var(--border);
   border-radius:8px;
 }
@@ -697,8 +696,6 @@ button[aria-expanded="true"] .results-arrow{
 #filterPanel .calendar{
   display:flex;
   width:max-content;
-  transform:scale(var(--calendar-scale));
-  transform-origin:top left;
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
 }
@@ -1425,6 +1422,7 @@ body.hide-results .quick-list-board{
   max-width:970px;
   min-width:360px;
   padding:0;
+  margin:0 auto;
   overflow:auto;
   display:flex;
   flex-direction:column;
@@ -2023,7 +2021,7 @@ body.mode-map .map-control-row{
   .open-posts .post-calendar,
   .open-posts .venue-dropdown,
   .open-posts .session-dropdown{
-    min-width:200px;
+    min-width:250px;
     width:400px;
   }
   body.mode-posts footer{
@@ -2086,8 +2084,8 @@ body.mode-map .map-control-row{
   display:flex;
   flex-direction:column;
   gap:var(--gap);
-  flex:1 1 200px;
-  min-width:200px;
+  flex:1 1 250px;
+  min-width:250px;
   width:auto;
   height:200px;
 }
@@ -2101,7 +2099,7 @@ body.mode-map .map-control-row{
   height:100%;
   border:1px solid var(--border);
   border-radius:8px;
-  min-width:200px;
+  min-width:250px;
   min-height:200px;
 }
 
@@ -2109,7 +2107,7 @@ body.mode-map .map-control-row{
 .open-posts .venue-dropdown,
 .open-posts .session-dropdown{
   position:relative;
-  min-width:200px;
+  min-width:250px;
   width:400px;
 }
 
@@ -2181,7 +2179,7 @@ body.mode-map .map-control-row{
   top:calc(100% + 4px);
   left:0;
   width:100%;
-  min-width:200px;
+  min-width:250px;
   box-sizing:border-box;
   max-height:250px;
   overflow-y:auto;
@@ -2250,11 +2248,11 @@ body.mode-map .map-control-row{
   gap:var(--gap);
   position:relative;
   align-items:flex-start;
-  flex:1 1 200px;
-  min-width:200px;
-  width:100%;
-  max-width:calc(var(--calendar-width) * var(--calendar-scale));
-  height:200px;
+  flex:0 0 var(--calendar-width);
+  min-width:var(--calendar-width);
+  width:var(--calendar-width);
+  max-width:var(--calendar-width);
+  height:var(--calendar-height);
 }
 .open-posts .location-section .options-menu{
   width:100%;
@@ -2266,12 +2264,13 @@ body.mode-map .map-control-row{
   display:none;
 }
 .open-posts .post-calendar{
+  --calendar-height:200px;
   width:var(--calendar-width);
   height:var(--calendar-height);
   position:relative;
   font-size:14px;
   font-family: Verdana;
-  min-width:200px;
+  min-width:var(--calendar-width);
 }
 
 
@@ -2293,8 +2292,6 @@ body.mode-map .map-control-row{
   display:flex;
   width:max-content;
   height:100%;
-  transform:scale(var(--calendar-scale));
-  transform-origin:top left;
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
 }
@@ -2347,7 +2344,7 @@ body.mode-map .map-control-row{
   font-weight:bold;
 }
 .open-posts .post-calendar .day.available-day.selected{
-  background:#555555;
+  background:#2e3a72;
   color:#fff;
 }
 .open-posts .post-calendar .day.today{color:var(--today) !important;}
@@ -4321,19 +4318,6 @@ function makePosts(){
       if(!scroller) return;
       scroller.setAttribute('tabindex','0');
       setupHorizontalWheel(scroller);
-      const container = scroller.closest('.calendar-container');
-      const adjustScale = () => {
-        if(!container) return;
-        const base = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--calendar-width')) || 0;
-        const available = container.parentElement ? container.parentElement.clientWidth : container.clientWidth;
-        const scale = base ? Math.min(1, available / base) : 1;
-        container.style.setProperty('--calendar-scale', scale);
-      };
-      if('ResizeObserver' in window && container){
-        const ro = new ResizeObserver(adjustScale);
-        ro.observe(container);
-      }
-      adjustScale();
       scroller.addEventListener('keydown', e=>{
         if(e.key==='ArrowLeft' || e.key==='ArrowRight'){
           const m = scroller.querySelector('.month') || scroller.querySelector('.month-item');


### PR DESCRIPTION
## Summary
- fix calendar size at 250x200 with rows/columns sized from header and scrollbar offsets
- remove responsive scaling to keep calendar dimensions stable
- update date box colors (#555555 available, #2e3a72 selected)

## Testing
- `npm test`
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c056dc9304833197025c39ef411afc