### PR TITLE
feat: add post mode background controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,8 @@
       --panel-title-font: Verdana;
       --panel-title-size: 16px;
       --panel-title-color: #ffffff;
+      --post-mode-bg-color: 0,0,0;
+      --post-mode-bg-opacity: 0.5;
       --safe-top: env(safe-area-inset-top, 0px);
 }
 
@@ -1376,7 +1378,7 @@ button[aria-expanded="true"] .results-arrow{
   bottom:var(--footer-h);
   left:0;
   right:0;
-  background:rgba(0,0,0,0.5);
+  background: rgba(var(--post-mode-bg-color), var(--post-mode-bg-opacity));
   z-index:1;
   pointer-events:none;
 }
@@ -3425,6 +3427,14 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
           <div class="panel-field">
             <label for="aColor">Color</label>
             <input type="color" id="aColor" data-mode="hex" value="#000000" />
+          </div>
+          <div class="panel-field">
+            <label for="postModeBgColor">Post Mode Background</label>
+            <div class="color-group">
+              <input type="color" id="postModeBgColor">
+              <input type="range" id="postModeBgOpacity" min="0" max="1" step="0.01">
+              <span id="postModeBgOpacityVal">0.50</span>
+            </div>
           </div>
           <div class="panel-field">
             <label for="welcomeMessageEditor">Welcome Message</label>
@@ -6967,6 +6977,46 @@ document.addEventListener('DOMContentLoaded', () => {
     slider.className = 'slider';
     cb.after(slider);
   });
+});
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const colorInput = document.getElementById('postModeBgColor');
+  const opacityInput = document.getElementById('postModeBgOpacity');
+  const opacityVal = document.getElementById('postModeBgOpacityVal');
+  const root = document.documentElement;
+  const settings = JSON.parse(localStorage.getItem('admin-settings-current') || '{}');
+
+  function hexToRgb(hex){
+    const r = parseInt(hex.slice(1,3),16);
+    const g = parseInt(hex.slice(3,5),16);
+    const b = parseInt(hex.slice(5,7),16);
+    return `${r},${g},${b}`;
+  }
+
+  function apply(){
+    const color = colorInput.value || '#000000';
+    const opacity = opacityInput.value;
+    root.style.setProperty('--post-mode-bg-color', hexToRgb(color));
+    root.style.setProperty('--post-mode-bg-opacity', opacity);
+    opacityVal.textContent = Number(opacity).toFixed(2);
+  }
+
+  if(colorInput && opacityInput && opacityVal){
+    colorInput.value = settings.postModeBgColor || '#000000';
+    opacityInput.value = settings.postModeBgOpacity ?? 0.5;
+    apply();
+    const save = () => {
+      settings.postModeBgColor = colorInput.value;
+      settings.postModeBgOpacity = opacityInput.value;
+      localStorage.setItem('admin-settings-current', JSON.stringify(settings));
+    };
+    colorInput.addEventListener('input', () => { apply(); save(); });
+    opacityInput.addEventListener('input', () => { apply(); save(); });
+    const prev = window.saveAdminChanges;
+    window.saveAdminChanges = () => { save(); if(typeof prev === 'function') prev(); };
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- allow admin to set post mode background color and opacity
- persist post mode background settings in local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c06b01458c83319962dcaadcc02d29