### PR TITLE
fix: keep selected quick card text visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,11 +120,14 @@ fieldset{
 
 *[aria-pressed="true"],
 *[aria-current="page"],
-*[aria-selected="true"],
 .selected,
 .on{
   border-color: var(--border-active) !important;
   color: var(--active);
+}
+
+*[aria-selected="true"]{
+  border-color: var(--border-active) !important;
 }
 
 html,body{


### PR DESCRIPTION
## Summary
- stop global `aria-selected` rule from forcing active text color
- keep border highlight for selected elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0571788a08331be6ac86400c27733