### PR TITLE
Trigger post-board layout recalculation on mode switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -4692,6 +4692,15 @@ function makePosts(){
           document.body.classList.remove('hide-ads');
         }
         adjustBoards();
+        if(m === 'posts'){
+          const boardEl = document.querySelector('.post-board');
+          if(boardEl){
+            boardEl.style.width = '';
+          }
+          if(window.adjust){
+            window.adjust();
+          }
+        }
         const toggle = $('#postBtn');
         if(toggle){
           toggle.textContent = m === 'map' ? 'Show Posts' : 'Show Map';
@@ -7177,10 +7186,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if(twoCols){
         document.documentElement.style.setProperty('--post-header-h', postHeader.offsetHeight + 'px');
       } else {
-        document.documentElement.style.removeProperty('--post-header-h');
+      document.documentElement.style.removeProperty('--post-header-h');
       }
     }
 
+  window.adjust = adjust;
   adjust();
   window.addEventListener('resize', adjust);
 


### PR DESCRIPTION
## Summary
- Recalculate post-board columns when switching to posts mode
- Expose `adjust` globally and reset board width to maintain fixed layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1a24bf48331a5a06353ac064406