### PR TITLE
Expand post-board to 970px and recalc on mode switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1429,7 +1429,7 @@ body.hide-results .quick-list-board{
 }
 
 .post-board{
-  width:880px;
+  width:970px;
   padding:0;
   margin:0 auto;
   overflow:auto;
@@ -1439,7 +1439,7 @@ body.hide-results .quick-list-board{
   pointer-events:auto;
   transition:margin 0.3s ease;
 }
-@media (max-width:879px){
+@media (max-width:969px){
   .post-board{width:440px;}
 }
 .post-board .post-card{
@@ -1449,7 +1449,7 @@ body.hide-results .quick-list-board{
 .post-board .post-body{
   display:flex;
 }
-@media (max-width:879px){
+@media (max-width:969px){
   .post-board .post-body{flex-direction:column;}
 }
 
@@ -1510,8 +1510,9 @@ body.hide-results .quick-list-board{
 }
 
 .second-post-column{
-  flex:1 1 440px;
-  min-width:440px;
+  flex:0 0 530px;
+  width:530px;
+  max-width:530px;
   padding:0;
 }
 
@@ -2614,14 +2615,14 @@ footer{
   }
   #post-modal-container.hidden{display:none;}
   #post-modal-container .post-modal{
-    width:880px;
+    width:970px;
     max-width:100%;
     height:90%;
     overflow:auto;
     background:var(--list-background);
     border-radius:8px;
   }
-  @media (max-width:879px){
+  @media (max-width:969px){
     #post-modal-container .post-modal{width:440px;}
   }
 
@@ -4692,6 +4693,15 @@ function makePosts(){
           document.body.classList.remove('hide-ads');
         }
         adjustBoards();
+        if(m === 'posts'){
+          const boardEl = document.querySelector('.post-board');
+          if(boardEl){
+            boardEl.style.width = '';
+          }
+          if(window.adjust){
+            window.adjust();
+          }
+        }
         const toggle = $('#postBtn');
         if(toggle){
           toggle.textContent = m === 'map' ? 'Show Posts' : 'Show Map';
@@ -7146,7 +7156,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const boardStyles = getComputedStyle(board);
       const padding = parseFloat(boardStyles.paddingLeft) + parseFloat(boardStyles.paddingRight);
       const secondWidth = board.offsetWidth - mainCol.offsetWidth - padding;
-      if(secondWidth < 440){
+      if(secondWidth < 530){
         if(secondCol.style.display !== 'none'){
           secondCol.style.display = 'none';
           postImages.insertAdjacentElement('afterend', details);
@@ -7177,10 +7187,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if(twoCols){
         document.documentElement.style.setProperty('--post-header-h', postHeader.offsetHeight + 'px');
       } else {
-        document.documentElement.style.removeProperty('--post-header-h');
+      document.documentElement.style.removeProperty('--post-header-h');
       }
     }
 
+  window.adjust = adjust;
   adjust();
   window.addEventListener('resize', adjust);
 


### PR DESCRIPTION
## Summary
- Recalculate post-board columns when switching to posts mode
- Expand post-board and post modal to 970px to allow a 530px second column

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a1a24bf48331a5a06353ac064406