### PR TITLE
Fix post column layout for wide viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1883,7 +1883,7 @@ body.mode-map .map-control-row{
   display:flex;
   flex-wrap:wrap;
   gap:10px;
-  align-items:flex-start;
+  align-items:stretch;
   align-content:flex-start;
 }
 
@@ -7157,7 +7157,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const boardStyles = getComputedStyle(board);
       const padding = parseFloat(boardStyles.paddingLeft) + parseFloat(boardStyles.paddingRight);
       const secondWidth = board.offsetWidth - mainCol.offsetWidth - padding;
-      if(secondWidth < 530){
+      if(secondWidth < 440){
         if(secondCol.style.display !== 'none'){
           secondCol.style.display = 'none';
           postImages.insertAdjacentElement('afterend', details);


### PR DESCRIPTION
## Summary
- Stretch main post column to match content height
- Move post details to second column when at least 440px is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0dd6e697c8331b9b4369736ee45af