### PR TITLE
Initialize post board adjustments on load and resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -7152,9 +7152,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const selectedImageBox = postImages ? postImages.querySelector('.selected-image') : null;
   const imageModalContainer = document.querySelector('.image-modal-container');
   const imageModal = imageModalContainer ? imageModalContainer.querySelector('.image-modal') : null;
-  if(!board || !mainCol || !secondCol || !details || !postImages || !postHeader || !imageModalContainer || !imageModal) return;
 
   function adjust(){
+      if(!board || !mainCol || !secondCol || !details || !postImages || !postHeader) return;
       const boardStyles = getComputedStyle(board);
       const padding = parseFloat(boardStyles.paddingLeft) + parseFloat(boardStyles.paddingRight);
       const secondWidth = board.offsetWidth - mainCol.offsetWidth - padding;
@@ -7195,9 +7195,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   window.adjust = adjust;
   adjust();
+  window.addEventListener('load', adjust);
+  const boardObserver = new ResizeObserver(() => adjust());
+  if(board) boardObserver.observe(board);
   window.addEventListener('resize', adjust);
 
   function openImageModal(src){
+    if(!imageModalContainer || !imageModal) return;
     imageModal.innerHTML='';
     const img = document.createElement('img');
     img.src = src;


### PR DESCRIPTION
## Summary
- allow layout adjust to initialize even if some elements are absent
- recalc layout on window load and post board width changes via ResizeObserver

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0f66fc3648331b15791541fb1b2fa