### PR TITLE
Observe board size for adjust recalculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7195,8 +7195,7 @@ document.addEventListener('DOMContentLoaded', () => {
   window.adjust = adjust;
   adjust();
   window.addEventListener('load', adjust);
-  const boardObserver = new ResizeObserver(() => adjust());
-  if(board) boardObserver.observe(board);
+  new ResizeObserver(() => adjust()).observe(board);
   window.addEventListener('resize', adjust);
 
   function openImageModal(src){


### PR DESCRIPTION
## Summary
- Ensure `adjust` is registered to run when images load and whenever the post board resizes.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10262c6f0833190e058c634946456