### PR TITLE
Wrap panel contents with fixed-width containers

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,12 +607,21 @@ button[aria-expanded="true"] .results-arrow{
   flex:1 1 auto;
   overflow-y:auto;
   overflow-x:hidden;
-  padding:0 20px 20px;
+  padding:0 0 20px;
   overscroll-behavior:contain;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
 }
 .panel-body > *{
-  width:440px;
-  max-width:440px;
+  width:420px !important;
+  max-width:420px !important;
+  box-sizing:border-box;
+  padding:0 10px;
+}
+.panel-body > * > *{
+  width:400px !important;
+  max-width:400px !important;
 }
 #adminPanel #styleControls{
   display:flex;
@@ -1830,7 +1839,7 @@ body.mode-map .map-control-row{
 .map-control-row #geolocateBtn{flex:0 0 35px;margin-left:20px;}
 .map-control-row #compassBtn{flex:0 0 35px;margin-left:10px;}
 
-#filterPanel .panel-body > *{width:400px;max-width:400px;}
+#filterPanel .panel-body > *{width:420px !important;max-width:420px !important;}
 
 
 


### PR DESCRIPTION
## Summary
- Ensure consistent panel layout by constraining `.panel-body` children to 420 px containers with 400 px inner content, preserving the 440 px panel width.
- Align filter panel contents with the same nested container pattern for uniform styling.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c8badb5c8331b8db43bc929f5140