### PR TITLE
Refine layout and footer styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1453,7 +1453,7 @@ body.hide-results .quick-list-board{
 }
 .post-content{
   max-width:900px;
-  margin:0 auto;
+  margin:0;
 }
 @media (max-width:969px){
   .post-board{width:440px;}
@@ -1464,6 +1464,7 @@ body.hide-results .quick-list-board{
 
 .post-board .post-body{
   display:flex;
+  padding-bottom:10px;
 }
 @media (max-width:969px){
   .post-board .post-body{flex-direction:column;}
@@ -1500,6 +1501,9 @@ body.hide-results .quick-list-board{
 
 .image-thumbnail-row{
   display:flex;
+  width:440px;
+  padding:0 10px;
+  box-sizing:border-box;
   gap:5px;
 }
 
@@ -1568,7 +1572,7 @@ body.hide-ads .ad-board{
   pointer-events:none;
 }
 
-.ad-board-container{
+.ad-panel{
   width:100%;
   height:100%;
   position:relative;
@@ -1576,7 +1580,7 @@ body.hide-ads .ad-board{
   border-radius:4px;
 }
 
-.ad-board-container .ad-slide{
+.ad-panel .ad-slide{
   position:absolute;
   inset:0;
   opacity:0;
@@ -1584,16 +1588,16 @@ body.hide-ads .ad-board{
   cursor:pointer;
 }
 
-.ad-board-container .ad-slide.active{opacity:1;}
+.ad-panel .ad-slide.active{opacity:1;}
 
-.ad-board-container .ad-slide img{
+.ad-panel .ad-slide img{
   width:100%;
   height:100%;
   object-fit:cover;
   animation:adZoom 20s linear forwards;
 }
 
-.ad-board-container .ad-slide .info{
+.ad-panel .ad-slide .info{
   position:absolute;
   left:0;
   right:0;
@@ -1827,9 +1831,10 @@ body.mode-map .map-control-row{
   position:fixed;
   top:calc(var(--header-h) + 10px);
   left:50%;
+  transform:translateX(-50%);
   display:flex;
   align-items:center;
-  width:400px;
+  width:440px;
 }
 .map-control-row #geocoder{flex:1 1 auto;}
 .map-control-row #geolocateBtn{flex:0 0 35px;margin-left:20px;}
@@ -1898,7 +1903,7 @@ body.mode-map .map-control-row{
 }
 
 .open-posts .post-body{
-  padding:0;
+  padding:0 0 10px;
   display:flex;
   flex-wrap:wrap;
   gap:10px;
@@ -1961,7 +1966,9 @@ body.mode-map .map-control-row{
 .open-posts .thumbnail-row{
   display:flex;
   flex-direction:row;
-  width:400px;
+  width:440px;
+  padding:0 10px;
+  box-sizing:border-box;
   height:auto;
   overflow-x:auto;
   gap:4px;
@@ -2551,7 +2558,7 @@ footer{
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 10px;
   background: rgba(0,0,0,0.7);
   position: fixed;
   bottom: 0;
@@ -2670,6 +2677,8 @@ footer .foot-row .footer-card{
   align-items:center;
   gap:8px;
   max-width:240px;
+  padding:10px;
+  border-radius:4px;
 }
 
 footer .foot-row .footer-card .t{
@@ -3120,7 +3129,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
       </div>
     </section>
     <section class="ad-board" aria-label="Ad Board">
-      <div class="ad-board-container">
+      <div class="ad-panel">
       </div>
     </section>
   </div>
@@ -3159,7 +3168,6 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
             </div>
           </div>
           <div class="field sort-field">
-            <label for="optionsBtn">Sort Results</label>
             <div class="options-dropdown">
               <button id="optionsBtn" aria-haspopup="true" aria-expanded="false">Title A - Z</button>
               <div id="optionsMenu" class="options-menu" hidden>
@@ -6071,6 +6079,11 @@ function makePosts(){
             sessionInfo.innerHTML = `<div><strong>${formatDate(dt)} ${dt.time}</strong></div><div>Adults $20, Kids $10, Pensioners $15</div><div>🎫 Buy at venue | ♿ Accessible | 👶 Kid-friendly</div>`;
             if(sessBtn) sessBtn.innerHTML = `<span class="session-date">${formatDate(dt)}</span><span class="session-time">${dt.time}</span>${sessionHasMultiple?'<span class="results-arrow" aria-hidden="true"></span>':''}`;
             markSelected();
+            const cell = calendarEl.querySelector(`.day[data-iso="${dt.full}"]`);
+            if(cell && calScroll){
+              const monthEl = cell.closest('.month');
+              if(monthEl) calScroll.scrollTo({left:monthEl.offsetLeft, behavior:'smooth'});
+            }
           } else {
             sessionInfo.innerHTML = defaultInfoHTML;
             if(sessBtn) sessBtn.innerHTML = sessionHasMultiple ? 'Select Session<span class="results-arrow" aria-hidden="true"></span>' : 'Select Session';
@@ -6232,7 +6245,7 @@ function makePosts(){
     }
 
     function initAdBoard(){
-      adPanel = document.querySelector('.ad-board-container');
+      adPanel = document.querySelector('.ad-panel');
       adPosts = filtered.filter(p => p.sponsored);
       if(!adPanel || !adPosts.length) return;
       showNextAd();


### PR DESCRIPTION
## Summary
- Add bottom padding to post bodies and align thumbnail rows to 440px with side padding
- Rename ad-board container to ad panel and center map control row
- Scroll calendar to selected session date and streamline filter panel text; update footer padding and card styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d71e906883319095abb1617a4947