### PR TITLE
Align post board container width with board content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1442,7 +1442,7 @@ body.hide-results .quick-list-board{
 }
 
 .post-board{
-  width:970px;
+  width:440px;
   padding:0;
   margin:0;
   overflow:auto;
@@ -1455,9 +1455,6 @@ body.hide-results .quick-list-board{
 .post-content{
   max-width:900px;
   margin:0;
-}
-@media (max-width:969px){
-  .post-board{width:440px;}
 }
 .post-board .post-card{
   width:100%;


### PR DESCRIPTION
## Summary
- Set `.post-board` width to 440px so container matches board column
- Removed redundant media query overriding width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c297298b088331a12406fe05dc8b05