### PR TITLE
Refine map controls and panel spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,6 @@ input[type="checkbox"]{
     letter-spacing: .4px;
     user-select: none;
     cursor: pointer;
-    padding-right:10px;
   }
 
 .logo img{
@@ -394,7 +393,7 @@ input[type="checkbox"]{
 
   .view-toggle{
   position: absolute;
-  left: 80px;
+  left: 78px;
   right: auto;
   top: 50%;
   transform: translateY(-50%);
@@ -662,6 +661,7 @@ button[aria-expanded="true"] .results-arrow{
   display:flex;
   flex-direction:column;
   overflow-y:auto;
+  padding-bottom:10px;
 }
 
 #filterPanel button,
@@ -780,7 +780,6 @@ button[aria-expanded="true"] .results-arrow{
   height:auto;
   margin-bottom:10px;
 }
-#welcome-controls{display:flex;flex-wrap:wrap;justify-content:center;gap:var(--gap);margin-top:var(--gap);}
 #welcome-modal{background:rgba(0,0,0,0.7);}
 #welcome-modal .modal-content{
   position:absolute;
@@ -793,7 +792,6 @@ button[aria-expanded="true"] .results-arrow{
   overflow:hidden;
   pointer-events:auto;
 }
-#memberPanel .location-info{margin-top:4px;font-size:14px;}
   @media (max-width:600px){
   #adminPanel .panel-content,
   #memberPanel .panel-content,
@@ -1350,16 +1348,13 @@ button[aria-expanded="true"] .results-arrow{
 }
 
 .reset-box{
-  display: grid;
-  grid-template-columns: 1fr 38px;
-  gap: 8px;
-  align-items: center;
   margin:8px 0;
 }
 
 .reset-box .btn{
+  width:100%;
   height: 36px;
-  border-radius: 999px;
+  border-radius: 4px;
   background: var(--btn);
   border: 1px solid var(--btn);
   display: flex;
@@ -2973,6 +2968,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
     max-width:none;
     max-height:none;
     border-radius:0;
+    padding-bottom:10px;
   }
   #filterPanel .panel-content .resizer,
   #filterPanel .panel-actions .move-left,
@@ -3136,11 +3132,6 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
         </div>
       </div>
       <div class="panel-body">
-        <div class="map-control-row">
-          <div id="geocoder" class="geocoder"></div>
-          <div id="geolocateBtn"></div>
-          <div id="compassBtn"></div>
-        </div>
         <section class="filters-col" aria-label="Filters">
           <div id="filterSummary" class="filter-summary"></div>
           <div class="reset-box">
@@ -3213,10 +3204,13 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
           <label for="mDate">Date</label>
           <input type="date" id="mDate" />
         </div>
-        <div class="panel-field">
-          <label for="mLocation">Location</label>
-          <div id="mLocation" class="geocoder"></div>
-          <div id="mLocationInfo" class="location-info"></div>
+        <div class="panel-field" id="mLocationField">
+          <label for="geocoder">Location</label>
+          <div class="map-control-row">
+            <div id="geocoder" class="geocoder"></div>
+            <div id="geolocateBtn"></div>
+            <div id="compassBtn"></div>
+          </div>
         </div>
         <div class="panel-field">
           <label for="mColor">Color</label>
@@ -3397,7 +3391,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
             <div class="color-group">
               <input type="color" id="postModeBgColor">
               <input type="range" id="postModeBgOpacity" min="0" max="1" step="0.01">
-              <span id="postModeBgOpacityVal">0.50</span>
+              <span id="postModeBgOpacityVal">0.00</span>
             </div>
           </div>
           <div class="panel-field">
@@ -3448,7 +3442,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
   </div>
 
   <script>
-  let startPitch, startBearing, logoEls = [], movedControls = [], mapControlRow;
+  let startPitch, startBearing, logoEls = [], mapControlRow;
 
   function placeMapControlsInPanel(panel){
     if(!mapControlRow) return;
@@ -3461,13 +3455,19 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
     mapControlRow.style.width='';
     mapControlRow.style.display='flex';
     mapControlRow.style.alignItems='center';
+    mapControlRow.style.zIndex='';
     const geo = mapControlRow.querySelector('#geocoder');
     const geoBtn = mapControlRow.querySelector('#geolocateBtn');
     const compassBtn = mapControlRow.querySelector('#compassBtn');
     if(geo) geo.style.flex='1 1 auto';
     if(geoBtn){ geoBtn.style.flex='0 0 35px'; geoBtn.style.marginLeft='20px'; }
     if(compassBtn){ compassBtn.style.flex='0 0 35px'; compassBtn.style.marginLeft='10px'; }
-    body.insertBefore(mapControlRow, body.firstChild);
+    if(panel.id === 'memberPanel'){
+      const locField = panel.querySelector('#mLocationField');
+      if(locField) locField.appendChild(mapControlRow);
+    } else {
+      body.insertBefore(mapControlRow, body.firstChild);
+    }
   }
 
   function placeMapControlsAtTop(){
@@ -3475,6 +3475,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
     mapControlRow.style.display='flex';
     mapControlRow.style.alignItems='center';
     mapControlRow.style.position='fixed';
+    mapControlRow.style.zIndex='5';
     const rootStyles = getComputedStyle(document.documentElement);
     const headerH = parseFloat(rootStyles.getPropertyValue('--header-h')) || 0;
     const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
@@ -3494,11 +3495,11 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
   function updateMapControlsLocation(){
     if(!mapControlRow) return;
     const memberPanel = document.getElementById('memberPanel');
-    const filterPanel = document.getElementById('filterPanel');
+    const welcomeModal = document.getElementById('welcome-modal');
     if(memberPanel && memberPanel.classList.contains('show')){
       placeMapControlsInPanel(memberPanel);
-    } else if(filterPanel && filterPanel.classList.contains('show')){
-      placeMapControlsInPanel(filterPanel);
+    } else if(welcomeModal && welcomeModal.classList.contains('show')){
+      placeMapControlsInPanel(welcomeModal);
     } else if(document.body.classList.contains('mode-map')){
       placeMapControlsAtTop();
     } else {
@@ -3539,7 +3540,7 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
       }
     }
 
-      let map, geocoder, memberGeocoder, spinning = false, resultsWasHidden = null, expiredWasOn = false, dateStart = null, dateEnd = null,
+      let map, geocoder, spinning = false, resultsWasHidden = null, expiredWasOn = false, dateStart = null, dateEnd = null,
           spinLoadStart = JSON.parse(localStorage.getItem('spinLoadStart') ?? 'true'),
           spinLoadType = localStorage.getItem('spinLoadType') || 'all',
           spinLogoClick = localStorage.getItem('spinLogoClick') === 'false' ? false : true,
@@ -3594,15 +3595,6 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
         if(!/\<img/i.test(msg)){
           body.insertAdjacentHTML('afterbegin', '<img src="https://raw.githubusercontent.com/Zxen1/Events-Platform/refs/heads/main/assets/funmap-logo-big.png" alt="FunMap logo" />');
         }
-        const ctrlWrap = document.createElement('div');
-        ctrlWrap.id = 'welcome-controls';
-        ['.mapboxgl-ctrl-top-left','.mapboxgl-ctrl-top-right','.mapboxgl-ctrl-bottom-left','.mapboxgl-ctrl-bottom-right'].forEach(sel=>{
-          document.querySelectorAll(`#map ${sel} > *`).forEach(el=>{
-            movedControls.push({el,parent:el.parentElement});
-            ctrlWrap.appendChild(el);
-          });
-        });
-        body.appendChild(ctrlWrap);
         openPanel(popup);
         body.style.padding = '20px';
       }
@@ -4867,39 +4859,6 @@ function makePosts(){
       }
     }
 
-    function addMemberGeocoder(){
-      if(typeof MapboxGeocoder !== 'undefined'){
-        memberGeocoder = new MapboxGeocoder({
-          accessToken: mapboxgl.accessToken,
-          mapboxgl,
-          marker:false,
-          placeholder:'Location'
-        });
-        memberGeocoder.on('result', e=>{
-          const info = document.getElementById('mLocationInfo');
-          if(info){
-            const place = e.result;
-            info.innerHTML = `<strong>${place.text}</strong><br>${place.place_name}`;
-          }
-        });
-        memberGeocoder.on('clear', ()=>{
-          const info = document.getElementById('mLocationInfo');
-          if(info) info.innerHTML='';
-        });
-        const container = document.getElementById('mLocation');
-        if(container){
-          const control = memberGeocoder.onAdd(map);
-          container.appendChild(control);
-          const input = control.querySelector('input[type="text"]');
-          if(input) input.setAttribute('autocomplete','street-address');
-          const geo = new mapboxgl.GeolocateControl({ positionOptions:{ enableHighAccuracy:true }, trackUserLocation:false });
-          container.appendChild(geo.onAdd(map));
-          const nav = new mapboxgl.NavigationControl({ showZoom:false });
-          container.appendChild(nav.onAdd(map));
-        }
-      }
-    }
-
     function initMap(){
       if(typeof mapboxgl === 'undefined'){
         console.error('Mapbox GL failed to load');
@@ -4918,7 +4877,6 @@ function makePosts(){
           });
       map.on('zoomend', checkLoadPosts);
       addGeocoder();
-      addMemberGeocoder();
       const geolocate = new mapboxgl.GeolocateControl({ positionOptions:{ enableHighAccuracy:true }, trackUserLocation:false });
       geolocate.on('geolocate', (e)=>{
         spinEnabled = false; localStorage.setItem('spinGlobe','false'); stopSpin();
@@ -6468,10 +6426,6 @@ function closePanel(m){
       localStorage.setItem(`panel-open-${m.id}`,'false');
       const idx = panelStack.indexOf(m);
       if(idx!==-1) panelStack.splice(idx,1);
-      if(m.id==='welcome-modal' && movedControls.length){
-        movedControls.forEach(({el,parent})=> parent.appendChild(el));
-        movedControls = [];
-      }
       if(map && typeof map.resize === 'function') setTimeout(()=> map.resize(),0);
       updateMapControlsLocation();
     }, {once:true});
@@ -6481,10 +6435,6 @@ function closePanel(m){
     localStorage.setItem(`panel-open-${m.id}`,'false');
     const idx = panelStack.indexOf(m);
     if(idx!==-1) panelStack.splice(idx,1);
-    if(m.id==='welcome-modal' && movedControls.length){
-      movedControls.forEach(({el,parent})=> parent.appendChild(el));
-      movedControls = [];
-    }
     if(map && typeof map.resize === 'function') setTimeout(()=> map.resize(),0);
     updateMapControlsLocation();
   }
@@ -7103,7 +7053,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if(colorInput && opacityInput && opacityVal){
     colorInput.value = settings.postModeBgColor || '#000000';
-    opacityInput.value = settings.postModeBgOpacity ?? 0.5;
+    opacityInput.value = settings.postModeBgOpacity ?? 0;
     apply();
     const save = () => {
       settings.postModeBgColor = colorInput.value;


### PR DESCRIPTION
## Summary
- Default post-mode background set to 0 opacity.
- Revamped reset filters button styling and behavior.
- Relocated map controls to member panel and welcome modal; keep visible over map.
- Adjusted header spacing and filter panel padding.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a08d8fa083319f0f81ffab7588b9