### PR TITLE
Refine map control layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1817,6 +1817,50 @@ body.filters-active #filterBtn{
   margin-bottom:var(--gap);
 }
 
+.map-control-row{
+  display:flex;
+  align-items:center;
+  gap:var(--gap);
+}
+
+.map-control-row #geocoder{flex:1 1 auto;}
+
+.map-control-row #geolocateBtn,
+.map-control-row #compassBtn{
+  flex:0 0 var(--control-h);
+  width:var(--control-h);
+  height:var(--control-h);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.map-control-row #geolocateBtn .mapboxgl-ctrl-geolocate,
+.map-control-row #compassBtn .mapboxgl-ctrl-compass{
+  width:100%;
+  height:100%;
+}
+
+.map-control-row .mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon,
+.map-control-row .mapboxgl-ctrl-compass .mapboxgl-ctrl-icon{
+  width:100%;
+  height:100%;
+  margin:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
+#filterPanel .map-control-row,
+#filterPanel .map-control-row input{
+  color:#000;
+}
+#filterPanel .map-control-row button{
+  background:#fff;
+  color:#000;
+  border:0;
+}
+
 
 #filterPanel .panel-body > *{width:420px !important;max-width:420px !important;}
 
@@ -3453,10 +3497,19 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
     const geo = mapControlRow.querySelector('#geocoder');
     const geoBtn = mapControlRow.querySelector('#geolocateBtn');
     const compassBtn = mapControlRow.querySelector('#compassBtn');
-    if(geo) geo.style.flex='1 1 auto';
-    if(geoBtn){ geoBtn.style.flex='0 0 35px'; geoBtn.style.marginLeft='20px'; }
-    if(compassBtn){ compassBtn.style.flex='0 0 35px'; compassBtn.style.marginLeft='10px'; }
-    body.insertBefore(mapControlRow, body.firstChild);
+    if(geo) geo.style.flex='';
+    if(geoBtn){ geoBtn.style.flex=''; geoBtn.style.marginLeft=''; }
+    if(compassBtn){ compassBtn.style.flex=''; compassBtn.style.marginLeft=''; }
+    if(panel.id === 'welcome-modal'){
+      const logo = body.querySelector('img');
+      if(logo){
+        logo.insertAdjacentElement('afterend', mapControlRow);
+      } else {
+        body.insertBefore(mapControlRow, body.firstChild);
+      }
+    } else {
+      body.insertBefore(mapControlRow, body.firstChild);
+    }
   }
 
   function placeMapControlsAtTop(){
@@ -3475,9 +3528,9 @@ footer .footer-card img.mini, footer .foot-row .footer-card img{
     const geo = mapControlRow.querySelector('#geocoder');
     const geoBtn = mapControlRow.querySelector('#geolocateBtn');
     const compassBtn = mapControlRow.querySelector('#compassBtn');
-    if(geo) geo.style.flex='1 1 auto';
-    if(geoBtn){ geoBtn.style.flex='0 0 35px'; geoBtn.style.marginLeft='20px'; }
-    if(compassBtn){ compassBtn.style.flex='0 0 35px'; compassBtn.style.marginLeft='10px'; }
+    if(geo) geo.style.flex='';
+    if(geoBtn){ geoBtn.style.flex=''; geoBtn.style.marginLeft=''; }
+    if(compassBtn){ compassBtn.style.flex=''; compassBtn.style.marginLeft=''; }
     document.body.appendChild(mapControlRow);
   }
 


### PR DESCRIPTION
## Summary
- Move map control row below the welcome logo
- Standardize 10px spacing and square button layout for map controls
- Reset filter panel map control colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b803f4d883319c9f91006b211646