### PR TITLE
Refine post background controls and layout gaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,6 +812,31 @@ button[aria-expanded="true"] .results-arrow{
 #adminPanel .control-row{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:6px;padding:8px 0;width:440px;}
 #adminPanel .control-row label:first-child{min-width:80px;font-size:14px;cursor:pointer;user-select:none;}
 .control-row > *:last-child{margin-left:auto;width:200px;}
+#post-mode-background-row{
+  display:flex;
+  align-items:center;
+  width:400px;
+  height:40px;
+  gap:8px;
+}
+#post-mode-background-row label{
+  min-width:140px;
+  cursor:pointer;
+  user-select:none;
+}
+#post-mode-background-row input[type="color"]{
+  width:40px;
+  height:40px;
+  padding:0;
+  border-radius:8px;
+}
+#post-mode-background-row input[type="range"]{
+  flex:1 1 auto;
+}
+#post-mode-background-row span{
+  width:40px;
+  text-align:center;
+}
 #adminPanel .color-group{
   flex:0 0 200px;
   width:100%;
@@ -1469,6 +1494,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 
 .post-images{
   margin-top:0;
+  padding-top:10px;
   width:100%;
   display:flex;
   flex-direction:column;
@@ -1483,7 +1509,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 .post-board.two-columns .post-images,
 .post-board.two-columns .tall-image-container{
   position:sticky;
-  top:calc(var(--post-header-h,0px) + var(--gap));
+  top:var(--post-header-h,0px);
   align-self:flex-start;
 }
 
@@ -1939,7 +1965,7 @@ body.filters-active #filterBtn{
   padding:0 0 10px;
   display:flex;
   flex-wrap:wrap;
-  gap:10px;
+  gap:0;
   align-items:stretch;
   align-content:flex-start;
 }
@@ -3331,13 +3357,11 @@ img.thumb{
             </div>
         </div>
         <div id="tab-settings" class="tab-panel">
-          <div class="panel-field">
+          <div id="post-mode-background-row" class="panel-field">
             <label for="postModeBgColor">Post Mode Background</label>
-            <div class="color-group">
-              <input type="color" id="postModeBgColor">
-              <input type="range" id="postModeBgOpacity" min="0" max="1" step="0.01">
-              <span id="postModeBgOpacityVal">0.00</span>
-            </div>
+            <input type="color" id="postModeBgColor">
+            <input type="range" id="postModeBgOpacity" min="0" max="1" step="0.01">
+            <span id="postModeBgOpacityVal">0.00</span>
           </div>
           <div class="panel-field">
             <label for="welcomeMessageEditor">Welcome Message</label>
@@ -6911,6 +6935,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const opacityVal = document.getElementById('postModeBgOpacityVal');
   const root = document.documentElement;
   const settings = JSON.parse(localStorage.getItem('admin-settings-current') || '{}');
+  const themeSelect = document.getElementById('mapTheme');
+  const skySelect = document.getElementById('skyTheme');
+  if(themeSelect) themeSelect.value = mapStyle;
+  if(skySelect) skySelect.value = skyStyle;
 
   function hexToRgb(hex){
     const r = parseInt(hex.slice(1,3),16);


### PR DESCRIPTION
## Summary
- consolidate post mode background settings into a single 400x40 row with square color picker
- remove column and header-body gaps in posts and add padding above images
- ensure admin map and sky theme selectors show current selections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2fde4661c8331b91d8e87ca6fa86c