### PR TITLE
fix: reference sibling header for sticky images

### DIFF
--- a/index.html
+++ b/index.html
@@ -3555,7 +3555,7 @@ img.thumb{
       const body = document.querySelector('.open-post .post-body');
       const imgArea = body ? body.querySelector('.post-images') : null;
       const secondColumn = body ? body.querySelector('.second-post-column') : null;
-      const header = body ? body.querySelector('.post-header') : null;
+      const header = document.querySelector('.open-post .post-header');
       const board = document.querySelector('.post-board');
       if(stickyScrollHandler && board){
         board.removeEventListener('scroll', stickyScrollHandler);


### PR DESCRIPTION
## Summary
- ensure sticky image header lookup references sibling `.post-header`
- maintain early-return while setting `--open-post-header-h` from the corrected header

## Testing
- `npm test`
- `node /tmp/stickyTest.js`


------
https://chatgpt.com/codex/tasks/task_e_68c30000b7cc8331a8e79edd3655fa46