### PR TITLE
fix: remove gap under post header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1494,7 +1494,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 
 .post-images{
   margin-top:0;
-  padding-top:10px;
+  padding-top:0;
   width:100%;
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- remove extra padding above post images to eliminate space beneath post header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3043950408331a86c70db70a1bafe