### PR TITLE
Hide post background outside posts mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1455,6 +1455,11 @@ button[aria-expanded="true"] .results-arrow{
   background: rgba(var(--post-mode-bg-color), var(--post-mode-bg-opacity));
   z-index:1;
   pointer-events:none;
+  display:none;
+}
+
+.mode-posts .post-mode-background{
+  display:block;
 }
 
 .post-mode-boards{


### PR DESCRIPTION
## Summary
- Show the post mode background only when viewing posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c30fed15f883318d177cca3deb58c8