### PR TITLE
Fix sticky post images and admin panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@ html,body{
     touch-action: manipulation;
   }
 
-  body, .post-board, .panel-content, .options-menu, .calendar-scroll{overscroll-behavior: contain;}
+  body, .post-board, .second-post-column, .panel-content, .options-menu, .calendar-scroll{overscroll-behavior: contain;}
 
   h1, h2, h3, h4, h5, h6{
     font-size: 16px;
@@ -632,8 +632,8 @@ button[aria-expanded="true"] .results-arrow{
   padding-bottom:0;
 }
 .panel-body > * > *{
-  width:400px !important;
-  max-width:400px !important;
+  width:420px !important;
+  max-width:420px !important;
 }
 #adminPanel #styleControls{
   display:flex;
@@ -1506,6 +1506,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   pointer-events:auto;
   transition:margin 0.3s ease;
 }
+.post-board.two-columns{overflow:hidden;}
 .post-board .post-card{
   width:100%;
 }
@@ -1591,6 +1592,8 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   padding:0;
   display:flex;
   flex-direction:column;
+  overflow-y:auto;
+  max-height:calc(100vh - var(--header-h) - var(--subheader-h) - var(--footer-h));
 }
 
 .post-venue-selection-container,
@@ -3414,6 +3417,7 @@ img.thumb{
             </div>
             <div id="balloonGrid"></div>
           </div>
+        </div>
         <div id="tab-settings" class="tab-panel">
         <div id="post-mode-background-field" class="panel-field">
           <label for="postModeBgColor">Post Mode Background</label>


### PR DESCRIPTION
## Summary
- Keep main post images sticky by scrolling details column independently
- Restore visibility of admin settings/forms tabs
- Set admin map containers to 420px width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c327dbbee883319758a77543b2b181