### PR TITLE
Ensure post board is scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1934,7 +1934,7 @@ body.filters-active #filterBtn{
 
 
 
-.post-board .posts{overflow-y:auto;padding:0;margin:0;}
+.post-board .posts{overflow:auto;padding:0;margin:0;}
 .post-board{color:#fff;}
 .post-board .post-card,
 .post-board .open-post{


### PR DESCRIPTION
## Summary
- Replace `.post-board .posts` overflow setting with `overflow:auto` to allow independent scrolling.
- Confirm surrounding `.post-board` keeps `overflow:auto` and height bounds for consistent scrollbar behavior.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3698d5470833182b64c7f96f8546a