### PR TITLE
chore: allow default mapbox control styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1921,14 +1921,6 @@ body.filters-active #filterBtn{
 }
 
 .map-control-row .geocoder{flex:1 1 auto;margin:0;}
-
-#filterPanel .map-control-row input,
-#filterPanel .map-control-row button{
-  background:#fff;
-  color:#000;
-  border:0;
-}
-
 #filterPanel .panel-body > *{width:420px !important;max-width:420px !important;}
 
 


### PR DESCRIPTION
## Summary
- remove custom filter map-control button/input styling to let Mapbox controls use default dimensions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c36af4716483318cdab268d1d3fc53