### PR TITLE
Handle missing map style images with subcategory markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4912,6 +4912,16 @@ function makePosts(){
             bearing: startBearing,
             attributionControl:true
           });
+      map.on('styleimagemissing', (e)=>{
+        const svg = subcategoryMarkers[e.id];
+        if(svg){
+          const img = new Image();
+          img.onload = ()=>{ if(!map.hasImage(e.id)) map.addImage(e.id, img); };
+          img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+        }else{
+          console.warn('Unknown image ID:', e.id);
+        }
+      });
       map.on('zoomend', checkLoadPosts);
       addControls();
       try{


### PR DESCRIPTION
## Summary
- dynamically add missing style images from `subcategoryMarkers`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c372394d4c8331bcaea41bad248b52