### PR TITLE
fix: ensure markers initialized before loading posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4165,7 +4165,7 @@ function makePosts(){
       if(postsLoaded) return;
       posts = makePosts().filter(p => Number.isFinite(p.lng) && Number.isFinite(p.lat));
       postsLoaded = true;
-      addPostSource();
+      if(Object.keys(subcategoryMarkers).length) addPostSource();
       initAdBoard();
       applyFilters();
     }
@@ -6942,6 +6942,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       subcategoryMarkers[sub] = createBalloon(shape, color, 40).outerHTML;
     });
   });
+  if(postsLoaded) addPostSource();
 })();
 </script>
 <script>


### PR DESCRIPTION
## Summary
- avoid calling addPostSource before subcategory markers are built
- refresh post source once markers exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c37230bfbc83319bae96f7741d0324