### PR TITLE
Fix post source loading and board scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1521,7 +1521,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   pointer-events:auto;
   transition:margin 0.3s ease;
 }
-.post-board.two-columns{overflow:hidden;}
+.post-board.two-columns{overflow:auto;}
 .post-board .post-card{
   width:100%;
 }
@@ -4191,7 +4191,8 @@ function makePosts(){
 
     function checkLoadPosts(){
       if(!map) return;
-      loadPosts();
+      if(!postsLoaded) loadPosts();
+      if(postsLoaded) addPostSource();
       applyFilters();
     }
 


### PR DESCRIPTION
## Summary
- ensure Mapbox posts source is added after the map initializes
- allow scrolling on the post board in two-column layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3790bc1788331b4506bb52b0e6d72