### PR TITLE
Fix console errors for categories and map style references

### DIFF
--- a/index.html
+++ b/index.html
@@ -3731,12 +3731,12 @@ img.thumb{
     function lockMap(lock){
       listLocked = lock;
       const fn = lock ? 'disable' : 'enable';
-      try{ map.dragPan[fn](); }catch{}
-      try{ map.scrollZoom[fn](); }catch{}
-      try{ map.boxZoom[fn](); }catch{}
-      try{ map.keyboard[fn](); }catch{}
-      try{ map.doubleClickZoom[fn](); }catch{}
-      try{ map.touchZoomRotate[fn](); }catch{}
+      try{ map.dragPan[fn](); }catch(e){}
+      try{ map.scrollZoom[fn](); }catch(e){}
+      try{ map.boxZoom[fn](); }catch(e){}
+      try{ map.keyboard[fn](); }catch(e){}
+      try{ map.doubleClickZoom[fn](); }catch(e){}
+      try{ map.touchZoomRotate[fn](); }catch(e){}
     }
     function getClusterLeavesAll(sourceId, clusterId){
       return new Promise((resolve, reject)=>{
@@ -4980,8 +4980,8 @@ function makePosts(){
       try{
         map.scrollZoom.setWheelZoomRate(1/240);
         map.scrollZoom.setZoomRate(1/240);
-      }catch{}
-          map.on('style.load', () => {
+      }catch(e){}
+      map.on('style.load', () => {
             if(!map.getSource('terrain-dem')){
               map.addSource('terrain-dem', {
                 type:'raster-dem',
@@ -5196,7 +5196,7 @@ function makePosts(){
         openListPopupAtPoint(e.point, buildClusterListHTML(items));
 
         (function(){
-          function consume(ev){ try{ ev.preventDefault(); }catch{} try{ ev.stopPropagation(); }catch{} }
+          function consume(ev){ try{ ev.preventDefault(); }catch(e){} try{ ev.stopPropagation(); }catch(e){} }
           const _root = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
           if(_root){
             ['pointerdown','mousedown','mouseup','click'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
@@ -5311,7 +5311,7 @@ function makePosts(){
           openListPopupAtPoint(e.point, buildClusterListHTML(multi));
 
         (function(){
-          function consume(ev){ try{ ev.preventDefault(); }catch{} try{ ev.stopPropagation(); }catch{} }
+          function consume(ev){ try{ ev.preventDefault(); }catch(e){} try{ ev.stopPropagation(); }catch(e){} }
           const _root = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
           if(_root){
             ['pointerdown','mousedown','mouseup','click'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
@@ -5347,7 +5347,7 @@ function makePosts(){
           registerPopup(hoverPopup);
 
         (function(){
-          function consume(ev){ try{ ev.preventDefault(); }catch{} try{ ev.stopPropagation(); }catch{} }
+          function consume(ev){ try{ ev.preventDefault(); }catch(e){} try{ ev.stopPropagation(); }catch(e){} }
           const _root = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
           if(_root){
             ['pointerdown','mousedown','mouseup','click'].forEach(t=> _root.addEventListener(t, consume, {capture:true}));
@@ -7021,7 +7021,8 @@ document.addEventListener('pointerdown', handleDocInteract);
 (function(){
   const shapeList = Object.keys(SHAPES);
   let colorIdx = 0;
-  categories.forEach((cat, idx) => {
+  const cats = window.categories || [];
+  cats.forEach((cat, idx) => {
     const shape = shapeList[idx % shapeList.length];
     categoryShapes[cat.name] = shape;
     cat.subs.forEach(sub => {
@@ -7160,8 +7161,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const settings = JSON.parse(localStorage.getItem('admin-settings-current') || '{}');
   const themeSelect = document.getElementById('mapTheme');
   const skySelect = document.getElementById('skyTheme');
-  if(themeSelect) themeSelect.value = mapStyle;
-  if(skySelect) skySelect.value = skyStyle;
+  if(themeSelect) themeSelect.value = window.mapStyle;
+  if(skySelect) skySelect.value = window.skyStyle;
 
   function hexToRgb(hex){
     const r = parseInt(hex.slice(1,3),16);


### PR DESCRIPTION
## Summary
- Safely handle try blocks by adding catch parameters
- Load category shapes using `window.categories`
- Set theme selectors with global map and sky style values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c489ba0830833195eac77ec506a707