### PR TITLE
Fix stray catch causing syntax error in prioritizeVisibleImages

### DIFF
--- a/index.html
+++ b/index.html
@@ -5501,13 +5501,8 @@ function makePosts(){
             }
           });
         }
-        });
-        } catch (err) {
-          console.error('addPostSource failed', err);
-        } finally {
-          addingPostSource = false;
-        }
-      }
+      });
+    }
 
     function card(p, wide=false){
       const el = document.createElement('article');


### PR DESCRIPTION
## Summary
- remove extraneous catch/finally and close prioritizeVisibleImages function properly to eliminate syntax error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49a74cf408331847370cbb74d8c8e