### PR TITLE
Fix open post width and details column placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,10 @@ html,body{
     touch-action: manipulation;
   }
 
-  body, .post-board, .second-post-column, .panel-content, .options-menu, .calendar-scroll{
+  body, .post-board, .second-post-column{
+    overscroll-behavior: contain;
+  }
+  .panel-content, .options-menu, .calendar-scroll{
     overscroll-behavior: contain;
     scrollbar-gutter: stable;
   }
@@ -1618,8 +1621,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 .thumbnail-row{
   display:flex;
   width:440px;
-  padding-left:0;
-  padding-right:10px;
+  padding:0;
   box-sizing:border-box;
   gap:5px;
 }
@@ -2104,7 +2106,7 @@ body.filters-active #filterBtn{
   display:flex;
   flex-direction:row;
   width:440px;
-  padding:0 10px;
+  padding:0;
   box-sizing:border-box;
   height:auto;
   overflow-x:auto;
@@ -3679,6 +3681,7 @@ img.thumb{
           }
         }
         const imgArea = body ? body.querySelector('.post-images') : null;
+        const mainColumn = body ? body.querySelector('.main-post-column') : null;
         const secondColumn = body ? body.querySelector('.second-post-column') : null;
         const header = document.querySelector('.open-post .post-header');
         const board = document.querySelector('.post-board');
@@ -3696,6 +3699,14 @@ img.thumb{
           }
           if(sessionDropdownEl && sessionContainer && sessionDropdownEl.parentElement !== sessionContainer){
             sessionContainer.appendChild(sessionDropdownEl);
+          }
+          const details = body.querySelector('.post-details');
+          if(details && mainColumn && secondColumn){
+            if(isColumnBelow && details.parentElement !== mainColumn){
+              mainColumn.appendChild(details);
+            } else if(!isColumnBelow && details.parentElement !== secondColumn){
+              secondColumn.appendChild(details);
+            }
           }
         }else{
           if(venueDropdownEl && venueDropdownParent && venueDropdownEl.parentElement !== venueDropdownParent){


### PR DESCRIPTION
## Summary
- Remove scrollbar gutters from main post containers to preserve exact column widths
- Drop thumbnail row padding so images span the full 440 px
- Dynamically relocate post details between columns when layout switches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4af38386c8331ab7a6b0b4ccbecfa