### PR TITLE
Load subcategory icons and map markers from assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -3864,29 +3864,21 @@ function buildClusterListHTML(items){
       { name:"Buy and Sell", subs:["Wanted","For Sale","Freebies"] },
       { name:"For Hire", subs:["Performers","Staff","Goods and Services"] }
     ];
-    const subcategorySvgs = window.subcategorySvgs = {
-      'live-gigs': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff6b00" stroke="#000" stroke-width="1"><path d="M0,-30 C-30,-70 -70,-20 -35,15 Q0,55 35,15 C70,-20 30,-70 0,-30Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'live-theatre': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#dbff00" stroke="#000" stroke-width="1"><rect x="-45" y="-45" width="90" height="90" rx="20" ry="20"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'screenings': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff0000" stroke="#000" stroke-width="1"><circle cx="0" cy="0" r="50"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'artwork': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ffd600" stroke="#000" stroke-width="1"><path d="M0,55 L50,-45 L-50,-45 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'live-sport': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff0f00" stroke="#000" stroke-width="1"><circle cx="0" cy="0" r="50"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'other': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#fff500" stroke="#000" stroke-width="1"><rect x="-35" y="-55" width="70" height="110" rx="20" ry="20"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'stage-auditions': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#adff00" stroke="#000" stroke-width="1"><path d="M0,-55 L45,0 0,55 -45,0 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'screen-auditions': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ebff00" stroke="#000" stroke-width="1"><rect x="-45" y="-45" width="90" height="90" rx="20" ry="20"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'clubs': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff7a00" stroke="#000" stroke-width="1"><path d="M0,-30 C-30,-70 -70,-20 -35,15 Q0,55 35,15 C70,-20 30,-70 0,-30Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'jobs': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#9eff00" stroke="#000" stroke-width="1"><path d="M0,-55 L45,0 0,55 -45,0 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'volunteers': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#bdff00" stroke="#000" stroke-width="1"><path d="M0,-55 L45,0 0,55 -45,0 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'competitions': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff9900" stroke="#000" stroke-width="1"><path d="M0,-30 C-30,-70 -70,-20 -35,15 Q0,55 35,15 C70,-20 30,-70 0,-30Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'tutors': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff8a00" stroke="#000" stroke-width="1"><path d="M0,-30 C-30,-70 -70,-20 -35,15 Q0,55 35,15 C70,-20 30,-70 0,-30Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'education-centres': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ffe600" stroke="#000" stroke-width="1"><path d="M0,55 L50,-45 L-50,-45 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'courses': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ffc700" stroke="#000" stroke-width="1"><path d="M0,-55 L14,-17 L47,-17 L23,5 L35,45 L0,25 L-35,45 L-23,5 L-47,-17 L-14,-17 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'wanted': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff2e00" stroke="#000" stroke-width="1"><circle cx="0" cy="0" r="50"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'for-sale': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ebff00" stroke="#000" stroke-width="1"><rect x="-45" y="-45" width="90" height="90" rx="20" ry="20"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'freebies': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff0f00" stroke="#000" stroke-width="1"><circle cx="0" cy="0" r="50"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'performers': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ccff00" stroke="#000" stroke-width="1"><rect x="-45" y="-45" width="90" height="90" rx="20" ry="20"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'staff': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#9eff00" stroke="#000" stroke-width="1"><path d="M0,-55 L45,0 0,55 -45,0 Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`,
-      'goods-and-services': `<svg viewBox="-60 -80 120 160" width="40" height="40"><g fill="#ff6b00" stroke="#000" stroke-width="1"><path d="M0,-30 C-30,-70 -70,-20 -35,15 Q0,55 35,15 C70,-20 30,-70 0,-30Z"/></g><path d="M-8,55 L0,60 L8,55 Z" fill="#000" stroke="#000" stroke-width="1"/><line x1="0" y1="60" x2="0" y2="80" stroke="#fff" stroke-width="2"/><ellipse cx="-20" cy="-20" rx="10" ry="6" fill="#fff"/></svg>`
+    const ICON_BASE = {
+      "What's On": "whats on category icon",
+      "Opportunities": "opportunities category icon",
+      "Learning": "learning category icon",
+      "Buy and Sell": "Buy and sell category icon",
+      "For Hire": "For hire category icon"
     };
+    const MARKER_BASE = {
+      "What's On": "whats-on",
+      "Opportunities": "opportunities",
+      "Learning": "learning",
+      "Buy and Sell": "buy-and-sell",
+      "For Hire": "for-hire"
+    };
+    const COLOR_NAMES = ['blue','dark-yellow','green','indigo','orange','red','violet'];
     const subcategoryIcons = window.subcategoryIcons = {};
     const subcategoryMarkers = window.subcategoryMarkers = {};
     const subcategoryMarkerIds = window.subcategoryMarkerIds = {};
@@ -5053,11 +5045,9 @@ function makePosts(){
             attributionControl:true
           });
         map.on('styleimagemissing', (e)=>{
-          const svg = subcategoryMarkers[e.id];
-          if(svg){
-            const {svg: svgData, width, height} = ensureSvgDimensions(svg);
-            const url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgData);
-            const img = new Image(width, height);
+          const url = subcategoryMarkers[e.id];
+          if(url){
+            const img = new Image(40, 40);
             img.onload = ()=> { if(!map.hasImage(e.id)) map.addImage(e.id, img); };
             img.onerror = err => console.warn('load image failed', e.id, err);
             img.src = url;
@@ -5236,11 +5226,9 @@ function makePosts(){
         if(existing) map.removeSource('posts');
         map.addSource('posts', { type:'geojson', data: geojson, cluster: shouldCluster, clusterRadius: clusterRadius, clusterMaxZoom: clusterMaxZoom });
       }
-        await Promise.all(Object.entries(subcategoryMarkers).map(([sub, svg])=> new Promise(res=>{
+        await Promise.all(Object.entries(subcategoryMarkers).map(([sub, url])=> new Promise(res=>{
           if(map.hasImage(sub)) map.removeImage(sub);
-          const {svg: svgData, width, height} = ensureSvgDimensions(svg);
-          const url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgData);
-          const img = new Image(width, height);
+          const img = new Image(40, 40);
           img.onload = () => { if(!map.hasImage(sub)) map.addImage(sub, img); res(); };
           img.onerror = err => { console.warn('load image failed', sub, err); res(); };
           img.src = url;
@@ -6187,11 +6175,10 @@ function makePosts(){
             interactive: false
           });
             const subId = subcategoryMarkerIds[p.subcategory] || slugify(p.subcategory);
-            const svg = subcategoryMarkers[subId];
-            if(svg){
-              const {svg: svgData, width, height} = ensureSvgDimensions(svg);
-              const img = new Image(width, height);
-              img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgData);
+            const url = subcategoryMarkers[subId];
+            if(url){
+              const img = new Image(40, 40);
+              img.src = url;
               marker = new mapboxgl.Marker({element:img}).setLngLat([loc.lng, loc.lat]).addTo(map);
             } else {
               marker = new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).addTo(map);
@@ -7141,12 +7128,14 @@ document.addEventListener('pointerdown', handleDocInteract);
     const shape = shapeList[idx % shapeList.length];
     categoryShapes[cat.name] = shape;
     cat.subs.forEach(sub => {
-      const color = COLORS[colorIdx % COLORS.length];
+      const color = COLOR_NAMES[colorIdx % COLOR_NAMES.length];
       colorIdx++;
       const slug = slugify(sub);
-        subcategoryIcons[sub] = subcategorySvgs[slug];
-        subcategoryMarkerIds[sub] = slug;
-        subcategoryMarkers[slug] = subcategorySvgs[slug];
+      const iconPrefix = ICON_BASE[cat.name];
+      const markerPrefix = MARKER_BASE[cat.name];
+      subcategoryIcons[sub] = `<img src="assets/icons 20/${iconPrefix} ${color} 20.webp" width="20" height="20" alt="">`;
+      subcategoryMarkerIds[sub] = slug;
+      subcategoryMarkers[slug] = `assets/mapmarkers 40/${markerPrefix}-${color} 40.webp`;
     });
   });
   if(window.postsLoaded) addPostSource();


### PR DESCRIPTION
## Summary
- Replace hardcoded SVG subcategory icons with <img> elements sourced from `assets/icons 20` and cycle through seven color variants.
- Load matching Mapbox marker images from `assets/mapmarkers 40` instead of inline SVG, updating marker handling logic accordingly.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b2ba9a488331ac5afadf9ce251d6