### PR TITLE
style: adjust map marker opacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3112,6 +3112,11 @@ img.thumb{
   }
 }
 
+.mapboxgl-marker{
+  opacity:0.9;
+  pointer-events:none;
+}
+
 @media (max-width:450px){
   :root{
     --footer-h:0;


### PR DESCRIPTION
## Summary
- Set map markers to 90% opacity
- Prevent marker images from intercepting pointer events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7eaf074c08331ad6e431d1c9ca9c5