### PR TITLE
Adjust post-board width for ad panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1570,6 +1570,9 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   padding-bottom:10px;
   gap:0;
 }
+  @media (max-width:1319px){
+    .post-board{width:440px;}
+  }
   @media (max-width:879px){
     .post-board{width:440px;}
     .post-board .post-body{flex-direction:column;}


### PR DESCRIPTION
## Summary
- keep post board at 440px when viewport is too narrow for 880px board plus 440px ad panel by adding a max-width 1319px media query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7edfd0374833182f2ae6f30948131