### PR TITLE
style: adjust map marker opacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3111,7 +3111,6 @@ img.thumb{
     object-fit:cover;
   }
 }
-
 @media (max-width:450px){
   :root{
     --footer-h:0;
@@ -6205,6 +6204,10 @@ function makePosts(){
             } else {
               marker = new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).addTo(map);
             }
+            const markerEl = marker.getElement();
+            markerEl.style.opacity = '0.9';
+            markerEl.style.pointerEvents = 'none';
+            markerEl.style.display = 'block';
           setTimeout(()=> map && map.resize(),0);
           window.addEventListener('resize', ()=>{ if(map) map.resize(); });
         } else {


### PR DESCRIPTION
## Summary
- Apply inline styling to map markers so they render at 90% opacity
- Disable marker pointer events and force block display to avoid empty clickable areas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7eaf074c08331ad6e431d1c9ca9c5