### PR TITLE
Restore Mapbox canary rule to avoid warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -4931,8 +4931,9 @@ function makePosts(){
             css = css.replace(/-ms-high-contrast/g,'forced-colors')
               .replace(/float:[^;]+;/g,'')
               .replace(/margin:[^;]+;/g,'')
-              .replace(/background-color:[^;]+;/g,'')
-              .replace(/box-shadow:[^;]+;/g,'')
+              .replace(/background-color:[^;]+;/g,'');
+            css += '.mapboxgl-canary{background-color:rgba(0,0,0,0);}';
+            css = css.replace(/box-shadow:[^;]+;/g,'')
               .replace(/border-radius:[^;]+;/g,'');
             if(url.includes('geocoder')) css += '.mapboxgl-ctrl-geocoder{width:unset!important;min-width:unset!important;}';
             const style = document.createElement('style');


### PR DESCRIPTION
## Summary
- restore `.mapboxgl-canary` rule after removing background-color declarations so Mapbox no longer warns about missing CSS

## Testing
- `npm test`
- Unable to run browser-based check: `npm install puppeteer` failed with E403

------
https://chatgpt.com/codex/tasks/task_e_68c7f6e42380833187d3cbbb11784df1