### PR TITLE
Clear history view when opening posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5925,6 +5925,12 @@ function makePosts(){
         stopSpin();
         const p = posts.find(x=>x.id===id); if(!p) return;
         activePostId = id;
+
+        if(document.body.classList.contains('show-history')){
+          document.body.classList.remove('show-history');
+          adjustBoards();
+          updateModeToggle();
+        }
         $$('.history-card[aria-selected="true"], .post-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
         $$('.mapboxgl-popup.map-card .hover-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
         if(mode !== 'posts'){


### PR DESCRIPTION
## Summary
- Hide history board when a post is opened so the post content is visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8004c45908331b30a39c3bcdf1392