### PR TITLE
Open history posts inline

### DIFF
--- a/index.html
+++ b/index.html
@@ -5925,9 +5925,15 @@ function makePosts(){
         stopSpin();
         const p = posts.find(x=>x.id===id); if(!p) return;
         activePostId = id;
+
+        if(!fromHistory && document.body.classList.contains('show-history')){
+          document.body.classList.remove('show-history');
+          adjustBoards();
+          updateModeToggle();
+        }
         $$('.history-card[aria-selected="true"], .post-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
         $$('.mapboxgl-popup.map-card .hover-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
-        if(mode !== 'posts'){
+        if(!fromHistory && mode !== 'posts'){
           setMode('posts', true);
           await nextFrame();
         }


### PR DESCRIPTION
## Summary
- Keep history view active when opening a history entry
- Switch to post mode only for non-history opens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8004c45908331b30a39c3bcdf1392