### PR TITLE
Enable map after closing history board

### DIFF
--- a/index.html
+++ b/index.html
@@ -4908,6 +4908,13 @@ function makePosts(){
         }
       });
 
+      historyBoard && historyBoard.addEventListener('click', e=>{
+        if(e.target === historyBoard){
+          setMode('map');
+          document.body.classList.remove('show-history');
+        }
+      });
+
 
       function setMode(m, skipFilters = false){
         mode = m;


### PR DESCRIPTION
## Summary
- Allow history board clicks to revert to map mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c80af9fb748331b50c404c3544cc03