### PR TITLE
Fix mode toggle button alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1802,6 +1802,11 @@ body.hide-ads .ad-board{
   font-weight:600;
   cursor:pointer;
   transition:background .2s,border-color .2s,color .2s;
+  height:100%;
+  border-radius:0;
+}
+.mode-toggle button + button{
+  border-left:1px solid var(--btn);
 }
 .mode-toggle button[aria-pressed="true"]{
   background:var(--btn-selected);


### PR DESCRIPTION
## Summary
- Reset border radius and height for mode toggle buttons so they sit flush inside the group border
- Add dividers between toggle buttons for clearer segmentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c800ef66c88331bca820c1379bb23f