### PR TITLE
fix: correct Mapbox CSS selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4955,8 +4955,8 @@ function makePosts(){
     // Mapbox
     function loadMapbox(cb){
       const cssSel = [
-        'link[href*"mapbox-gl.css"], link[href*"mapbox-gl@"], style[data-mapbox]',
-        'link[href*"mapbox-gl-geocoder.css"], link[href*"mapbox-gl-geocoder@"]'
+        'link[href*="mapbox-gl.css"], link[href*="mapbox-gl@"], style[data-mapbox]',
+        'link[href*="mapbox-gl-geocoder.css"], link[href*="mapbox-gl-geocoder@"]'
       ];
       if(window.mapboxgl && window.MapboxGeocoder){
         let pending = 0;
@@ -5039,7 +5039,7 @@ function makePosts(){
     document.head.appendChild(script);
     return;
   }
-  const cssLink = document.querySelector('style[data-mapbox], link[href*"mapbox-gl.css"], link[href*"mapbox-gl@"]');
+  const cssLink = document.querySelector('style[data-mapbox], link[href*="mapbox-gl.css"], link[href*="mapbox-gl@"]');
   if(!cssLink || !cssLink.sheet){
     setTimeout(addControls, 50);
     return;


### PR DESCRIPTION
## Summary
- fix Mapbox asset selectors to use valid CSS attribute syntax

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c81b69483483319b5537abbe37aa1c