### PR TITLE
Ensure mode toggle fits within header on narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ input[type="checkbox"]{
   .view-toggle{
   position: absolute;
   left: 68px;
-  right: auto;
+  right: 10px;
   top: 50%;
   transform: translateY(-50%);
   display: flex;
@@ -1790,6 +1790,8 @@ body.hide-ads .ad-board{
 }
 .mode-toggle{
   display:flex;
+  flex:1;
+  min-width:0;
   height:40px;
   border:1px solid var(--btn);
   border-radius:8px;


### PR DESCRIPTION
## Summary
- prevent primary nav from overflowing by constraining `.view-toggle` to the right edge
- allow `.mode-toggle` to flex within available space so the Map button no longer clips

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c81afd8798833186bd9167e86cfb26