### PR TITLE
Fix CSS lint issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,8 +608,7 @@ button[aria-expanded="true"] .results-arrow{
   pointer-events:auto;
   transition:transform 0.3s;
 }
-.panel-content.panel-visible{
-}
+
 .panel-content .resizer{position:absolute;z-index:10;background:transparent;display:none;}
 .panel-content .resizer.n{top:0;left:0;right:0;height:6px;cursor:n-resize;}
 .panel-content .resizer.s{bottom:0;left:0;right:0;height:6px;cursor:s-resize;}
@@ -991,10 +990,6 @@ button[aria-expanded="true"] .results-arrow{
   border-radius:var(--dropdown-radius);
   padding:0;
   box-sizing:border-box;
-}
-  width:35px;
-  height:35px;
-  padding:0;
 }
 #adminPanel .admin-fieldset input,
 #adminPanel .admin-fieldset select,
@@ -1873,6 +1868,7 @@ body.filters-active #filterBtn{
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
@@ -2642,6 +2638,7 @@ body.filters-active #filterBtn{
 .desc{
   margin-top:8px;
   display:-webkit-box;
+  line-clamp:4;
   -webkit-line-clamp:4;
   -webkit-box-orient:vertical;
   overflow:hidden;
@@ -2649,6 +2646,7 @@ body.filters-active #filterBtn{
 }
 .desc.expanded{
   display:block;
+  line-clamp:unset;
   -webkit-line-clamp:unset;
   overflow:visible;
 }
@@ -2913,6 +2911,7 @@ body.filters-active #filterBtn{
   word-break: break-word;
   overflow-wrap: anywhere;
   display: -webkit-box;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden;
@@ -2926,6 +2925,7 @@ body.filters-active #filterBtn{
   word-break: break-word;
   overflow-wrap: anywhere;
   display: -webkit-box;
+  line-clamp: 1;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
   overflow: hidden;
@@ -2973,9 +2973,10 @@ body.filters-active #filterBtn{
 .multi-item.map-card .t{
   white-space: normal;
   overflow-wrap: anywhere;
+  display: -webkit-box;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  display: -webkit-box;
 }
 
 .multi-item.map-card .s{


### PR DESCRIPTION
## Summary
- remove stray CSS declarations and an empty ruleset from `index.html`
- add standard `line-clamp` alongside existing `-webkit-line-clamp` usages for better compatibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c868a1835c8331897ec67d9ac6c454