### PR TITLE
Ensure Mapbox GL CSS loads from main template head

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
+  <link href='https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css' rel='stylesheet' />
   <link
     rel="stylesheet"
     href="https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css"


### PR DESCRIPTION
## Summary
- add the Mapbox GL JS stylesheet link to the main template head so it loads alongside the script loader

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c98877911883318c466ca1d6e695bd