### PR TITLE
Revamp post detail layout and panel behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,9 @@
   --header-h: 56px;
   --subheader-h: 0;
   --panel-w: 440px;
-  --results-w: 440px; 
+  --results-w: 440px;
   --gap: 10px;
+    --filter-panel-offset: 0px;
     --media-h: 200px;
     --calendar-scale: 1;
     --ink: #ffffff;
@@ -110,7 +111,6 @@
   box-sizing: border-box;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
-  scrollbar-gutter: auto;
   border-color: var(--border) !important;
 }
 
@@ -179,7 +179,6 @@ html,body{
   }
   .panel-content, .options-menu, .calendar-scroll{
     overscroll-behavior: contain;
-    scrollbar-gutter: auto;
   }
 
   h1, h2, h3, h4, h5, h6{
@@ -1146,28 +1145,20 @@ button[aria-expanded="true"] .results-arrow{
 .panel-header .header-top{
   display:flex;
   align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  width:100%;
 }
 .panel-header .panel-actions{
   margin-top:0;
-  justify-content:center;
+  margin-left:auto;
+  justify-content:flex-end;
 }
 .panel-header h2{
   margin:0;
 }
 #filterPanel .panel-header{
   padding:10px;
-}
-#filterPanel .panel-header .header-top{
-  width:100%;
-  justify-content:space-between;
-  gap:10px;
-}
-#filterPanel .panel-header .panel-actions{
-  margin-left:auto;
-  justify-content:flex-end;
-}
-#filterPanel .panel-header h2{
-  margin-left:0;
 }
 .palette{
   display:flex;
@@ -1621,7 +1612,7 @@ button[aria-expanded="true"] .results-arrow{
   bottom:var(--footer-h);
   left:0;
   right:0;
-  padding-left:0;
+  padding-left:var(--filter-panel-offset);
   padding-right:0;
   display:flex;
   justify-content:center;
@@ -1629,6 +1620,10 @@ button[aria-expanded="true"] .results-arrow{
   z-index:2;
   pointer-events:none;
   transition:padding 0.3s ease;
+}
+
+body.filter-anchored .post-mode-boards{
+  justify-content:flex-start;
 }
 
 body.hide-ads .post-mode-boards{padding-right:0;}
@@ -1659,7 +1654,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   margin:0;
   overflow:auto;
   overflow:overlay;
-  background:rgba(0,0,0,0);
+  background:rgba(0,0,0,0.7);
   transition:margin 0.3s ease;
   display:flex;
   flex-direction:column;
@@ -1675,11 +1670,52 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 }
 @media (max-width:439px){
   .post-board,
-  .history-board{
+  .history-board,
+  .post-detail-board{
     width:100%;
     max-width:100%;
     min-width:360px;
   }
+}
+
+.post-detail-board{
+  width:440px;
+  max-width:440px;
+  flex-shrink:0;
+  overflow-y:auto;
+  overflow-y:overlay;
+  background:rgba(0,0,0,0.7);
+  display:flex;
+  flex-direction:column;
+  gap:0;
+  pointer-events:auto;
+  opacity:0;
+  transform:translateX(20px);
+  transition:transform 0.3s ease, opacity 0.3s ease;
+  border-left:1px solid rgba(255,255,255,0.12);
+}
+.post-detail-board.is-visible{
+  opacity:1;
+  transform:translateX(0);
+}
+.post-detail-board:not(.is-visible){
+  pointer-events:none;
+}
+.post-detail-board .second-post-column{
+  width:100%;
+  max-width:100%;
+  min-width:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  overflow-y:auto;
+  overflow-y:overlay;
+  height:100%;
+}
+.post-detail-board .post-details{
+  width:100%;
+  max-width:440px;
+  min-width:0;
 }
 
 .last-opened-label{
@@ -1700,7 +1736,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   display:flex;
   flex-direction:column;
   gap:0;
-  background:rgba(0,0,0,0);
+  background:rgba(0,0,0,0.7);
   pointer-events:auto;
   transition:margin 0.3s ease;
 }
@@ -1711,6 +1747,13 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 .history-board .history-card{
   width:100%;
 }
+.history-board .history-card{
+  margin:0;
+  border-radius:0;
+  background-color:transparent;
+  border-bottom:1px solid rgba(255,255,255,0.12);
+}
+.history-board .history-card:last-child{border-bottom:none;}
 
 .post-board .post-body,
 .history-board .post-body{
@@ -1797,29 +1840,8 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   flex-direction:column;
   overflow-y:auto;
   overflow-y:overlay;
-  height:auto;
-  margin-top:var(--gap);
-  transition:transform 0.3s ease, opacity 0.3s ease;
-}
-
-.open-post.drawer-ready .second-post-column{
-  position:absolute;
-  top:0;
-  left:100%;
-  width:440px;
-  max-width:440px;
-  min-width:440px;
-  height:calc(100vh - var(--header-h) - var(--subheader-h) - var(--footer-h) - var(--post-header-h,0px));
-  transform:translateX(20px);
-  opacity:0;
-  pointer-events:none;
+  height:100%;
   margin-top:0;
-}
-
-.open-post.drawer-open .second-post-column{
-  transform:translateX(0);
-  opacity:1;
-  pointer-events:auto;
 }
 
 .post-venue-selection-container,
@@ -1941,8 +1963,8 @@ body.hide-ads .ad-board{
   color:var(--button-active-text);
 }
 body.filters-active #filterBtn{
-  background: red;
-  border-color: red;
+  background: var(--filter-active-color);
+  border-color: var(--filter-active-color);
   }
 
 .options-dropdown{ position:relative; }
@@ -2135,14 +2157,25 @@ body.filters-active #filterBtn{
 .map-control-row{
   display:flex;
   align-items:center;
-  gap:var(--gap);
+  gap:0;
+}
+.map-control-row > * + *{
+  margin-left:var(--gap);
+}
+@keyframes geolocate-pulse{
+  0%{box-shadow:0 0 0 0 rgba(92,111,177,0.6);}
+  70%{box-shadow:0 0 0 12px rgba(92,111,177,0);}
+  100%{box-shadow:0 0 0 0 rgba(92,111,177,0);}
+}
+.mapboxgl-ctrl-geolocate.locating button{
+  animation:geolocate-pulse 1.5s infinite;
 }
 
 .panel-body .map-control-row{
   width:100%;
-  max-width:420px;
-  margin:0 auto;
-  justify-content:center;
+  max-width:100%;
+  margin:0;
+  justify-content:flex-start;
 }
 
 .mode-posts .map-controls-map{display:none;}
@@ -2163,9 +2196,10 @@ body.filters-active #filterBtn{
 .post-board .post-card,
 .post-board .open-post{
   background-color:transparent;
-  margin:10px 0 12px;
+  margin:0;
   border:none;
-  border-radius:4px;
+  border-radius:0;
+  border-bottom:1px solid rgba(255,255,255,0.12);
 }
 .post-board .post-card:last-child,
 .post-board .open-post:last-child{border-bottom:none;}
@@ -2193,8 +2227,8 @@ body.filters-active #filterBtn{
 
 .open-post{
   border:none;
-  border-radius:4px;
-  margin:10px 0 12px;
+  border-radius:0;
+  margin:0;
   padding-top:10px;
   overflow:visible;
   color:#fff;
@@ -3423,6 +3457,7 @@ img.thumb{
         </div>
       </div>
     </section>
+    <section class="post-detail-board" aria-label="Post Details Board"></section>
     <section class="ad-board" aria-label="Ad Board">
       <div class="ad-panel">
       </div>
@@ -3934,7 +3969,7 @@ img.thumb{
       const footerH = parseFloat(rootStyles.getPropertyValue('--footer-h')) || 0;
       const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
       const availableHeight = window.innerHeight - headerH - subH - footerH - safeTop;
-      document.querySelectorAll('.history-board, .posts').forEach(list=>{
+      document.querySelectorAll('.history-board, .posts, .post-detail-board').forEach(list=>{
         list.style.maxHeight = `${availableHeight}px`;
       });
     }
@@ -3969,38 +4004,33 @@ img.thumb{
         const imgArea = body ? body.querySelector('.post-images') : null;
         const header = document.querySelector('.open-post .post-header');
         const board = document.querySelector('.post-board');
-        const openPost = body ? body.closest('.open-post') : null;
-        const drawerMode = !!(openPost && openPost.classList.contains('drawer-open'));
-        root.classList.toggle('hide-map-calendar', !drawerMode);
-        if(body){
-          const venueContainer = body.querySelector('.post-venue-selection-container');
-          const sessionContainer = body.querySelector('.post-session-selection-container');
-          if(venueDropdownEl && venueContainer && venueDropdownEl.parentElement !== venueContainer){
+        const detailBoard = document.querySelector('.post-detail-board');
+        const detailColumn = detailBoard ? detailBoard.querySelector('.second-post-column') : null;
+        const venueContainer = detailColumn ? detailColumn.querySelector('.post-venue-selection-container') : null;
+        const sessionContainer = detailColumn ? detailColumn.querySelector('.post-session-selection-container') : null;
+        const detailVisible = !!(detailBoard && detailBoard.classList.contains('is-visible'));
+        root.classList.toggle('hide-map-calendar', !detailVisible);
+        if(venueDropdownEl){
+          if(venueContainer && venueDropdownEl.parentElement !== venueContainer){
             venueContainer.appendChild(venueDropdownEl);
-          }
-          if(sessionDropdownEl && sessionContainer && sessionDropdownEl.parentElement !== sessionContainer){
-            sessionContainer.appendChild(sessionDropdownEl);
-          }
-        }else{
-          if(venueDropdownEl && venueDropdownParent && venueDropdownEl.parentElement !== venueDropdownParent){
+          } else if(venueDropdownParent && venueDropdownEl.parentElement !== venueDropdownParent){
             venueDropdownParent.appendChild(venueDropdownEl);
           }
-          if(sessionDropdownEl && sessionDropdownParent && sessionDropdownEl.parentElement !== sessionDropdownParent){
+        }
+        if(sessionDropdownEl){
+          if(sessionContainer && sessionDropdownEl.parentElement !== sessionContainer){
+            sessionContainer.appendChild(sessionDropdownEl);
+          } else if(sessionDropdownParent && sessionDropdownEl.parentElement !== sessionDropdownParent){
             sessionDropdownParent.appendChild(sessionDropdownEl);
           }
         }
-        if(!body || !imgArea || !header || !board){
+        if(!body || !imgArea || !header || !board || !detailVisible){
           root.classList.remove('open-post-sticky-images');
           document.documentElement.style.removeProperty('--open-post-header-h');
           return;
         }
-        if(drawerMode){
-          document.documentElement.style.setProperty('--open-post-header-h', header.offsetHeight + 'px');
-          root.classList.add('open-post-sticky-images');
-        } else {
-          document.documentElement.style.removeProperty('--open-post-header-h');
-          root.classList.remove('open-post-sticky-images');
-        }
+        document.documentElement.style.setProperty('--open-post-header-h', header.offsetHeight + 'px');
+        root.classList.add('open-post-sticky-images');
       }
 
     window.updateStickyImages = updateStickyImages;
@@ -5035,22 +5065,49 @@ function makePosts(){
       function adjustBoards(){
         const small = window.innerWidth < 1200;
         const historyActive = document.body.classList.contains('show-history');
-        boardsContainer.style.paddingLeft = '10px';
-        if(small){
-          document.body.classList.add('hide-ads');
-          boardsContainer.style.justifyContent = 'flex-start';
-          postBoard.style.marginLeft = '';
-          postBoard.style.marginRight = '';
-        } else {
-          if(document.body.classList.contains('mode-map')){
-            document.body.classList.add('hide-ads');
-          } else {
-            document.body.classList.remove('hide-ads');
-          }
-          boardsContainer.style.justifyContent = 'flex-start';
-          postBoard.style.marginLeft = '';
-          postBoard.style.marginRight = '';
+        const filterPanel = document.getElementById('filterPanel');
+        const filterContent = filterPanel ? filterPanel.querySelector('.panel-content') : null;
+        const pinBtn = filterPanel ? filterPanel.querySelector('.pin-panel') : null;
+        const filterPinned = !!(filterPanel && filterPanel.classList.contains('show') && pinBtn && pinBtn.getAttribute('aria-pressed') === 'true');
+        const detailBoard = document.querySelector('.post-detail-board');
+        const detailVisible = !!(detailBoard && detailBoard.classList.contains('is-visible') && !historyActive);
+        const gap = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--gap')) || 10;
+        let filterWidth = filterPinned && filterContent ? filterContent.getBoundingClientRect().width : 0;
+        const postWidth = postBoard ? (postBoard.offsetWidth || 440) : 0;
+        const historyWidth = historyBoard ? (historyBoard.offsetWidth || 440) : 0;
+        const detailWidth = detailVisible && detailBoard ? (detailBoard.offsetWidth || 440) : 0;
+        const boardsWidths = [];
+        if(historyActive && historyBoard){
+          boardsWidths.push(historyWidth);
+        } else if(postBoard){
+          boardsWidths.push(postWidth);
         }
+        if(detailVisible){
+          boardsWidths.push(detailWidth);
+        }
+        let totalBoardsWidth = boardsWidths.reduce((sum, w)=> sum + w, 0);
+        if(boardsWidths.length > 1){
+          totalBoardsWidth += gap * (boardsWidths.length - 1);
+        }
+        const adWidth = adBoard ? (adBoard.offsetWidth || 440) : 0;
+        let hideAds = small || document.body.classList.contains('mode-map') || document.body.classList.contains('hide-posts-ui');
+        let requiredWidth = totalBoardsWidth;
+        if(filterPinned && filterWidth){
+          requiredWidth += filterWidth + gap;
+        } else {
+          filterWidth = 0;
+        }
+        if(!hideAds && adWidth){
+          requiredWidth += adWidth + gap;
+        }
+        if(requiredWidth > window.innerWidth && !hideAds && adWidth){
+          hideAds = true;
+          requiredWidth -= adWidth + gap;
+        }
+        const canAnchor = filterPinned && filterWidth && requiredWidth <= window.innerWidth;
+        document.body.classList.toggle('filter-anchored', canAnchor);
+        document.documentElement.style.setProperty('--filter-panel-offset', canAnchor ? `${filterWidth + gap}px` : '0px');
+        boardsContainer.style.justifyContent = 'flex-start';
         if(historyBoard){
           historyBoard.style.display = historyActive ? '' : 'none';
           historyBoard.setAttribute('aria-hidden', historyActive ? 'false' : 'true');
@@ -5059,9 +5116,23 @@ function makePosts(){
           postBoard.style.display = historyActive ? 'none' : '';
           postBoard.setAttribute('aria-hidden', historyActive ? 'true' : 'false');
         }
-        adBoard.setAttribute('aria-hidden', document.body.classList.contains('hide-ads') ? 'true' : 'false');
+        if(historyActive && detailBoard){
+          detailBoard.classList.remove('is-visible');
+          detailBoard.removeAttribute('data-id');
+          document.body.classList.remove('detail-open');
+          if(typeof updateStickyImages === 'function') updateStickyImages();
+        }
+        if(hideAds || !adBoard){
+          document.body.classList.add('hide-ads');
+        } else {
+          document.body.classList.remove('hide-ads');
+        }
+        if(adBoard){
+          adBoard.setAttribute('aria-hidden', document.body.classList.contains('hide-ads') ? 'true' : 'false');
+        }
         updateModeToggle();
       }
+      window.adjustBoards = adjustBoards;
       adjustBoards();
       window.addEventListener('resize', adjustBoards);
       window.adjustListHeight();
@@ -5367,7 +5438,11 @@ function makePosts(){
           stopSpin();
           if(mode!=='map') setMode('map');
           if(map){
-            map.jumpTo({ center: e.result.center, zoom: Math.max(map.getZoom(), 12) });
+            map.flyTo({
+              center: e.result.center,
+              zoom: Math.max(map.getZoom(), 12),
+              essential: true
+            });
           }
           gc.clear();
         });
@@ -5380,6 +5455,7 @@ function makePosts(){
         geocoders.push(gc);
         if(idx===1) geocoder = gc;
         const geolocate = new mapboxgl.GeolocateControl({ positionOptions:{ enableHighAccuracy:true }, trackUserLocation:false });
+        let geoCtrlEl = null;
         geolocate.on('geolocate', (e)=>{
           spinEnabled = false; localStorage.setItem('spinGlobe','false'); stopSpin();
           if(mode!=='map') setMode('map');
@@ -5389,9 +5465,21 @@ function makePosts(){
             pitch:45,
             essential:true
           });
+          if(geoCtrlEl) geoCtrlEl.classList.remove('locating');
         });
+        geolocate.on('error', ()=>{ if(geoCtrlEl) geoCtrlEl.classList.remove('locating'); });
+        geolocate.on('outofmaxbounds', ()=>{ if(geoCtrlEl) geoCtrlEl.classList.remove('locating'); });
         const geoHolder = document.querySelector(sel.locate);
-        if(geoHolder) geoHolder.appendChild(geolocate.onAdd(map));
+        if(geoHolder){
+          geoCtrlEl = geolocate.onAdd(map);
+          geoHolder.appendChild(geoCtrlEl);
+          const geoBtn = geoCtrlEl.querySelector('button');
+          if(geoBtn){
+            geoBtn.addEventListener('click', ()=>{
+              geoCtrlEl.classList.add('locating');
+            });
+          }
+        }
         const nav = new mapboxgl.NavigationControl({showZoom:false});
         if (nav._onDown && nav._onMove) {
           const origOnDown = nav._onDown.bind(nav);
@@ -5499,9 +5587,7 @@ function makePosts(){
         };
         ['moveend','zoomend','rotateend','pitchend'].forEach(ev => map.on(ev, refreshMapView));
         map.on('dragend', () => { if(geocoder) geocoder.clear(); });
-        map.on('click', () => {
-          if(mode === 'posts') setMode('map');
-        });
+        map.on('click', () => { if(geocoder) geocoder.clear(); });
       }
 
     function startSpin(fromCurrent=false){
@@ -6293,7 +6379,42 @@ function makePosts(){
         viewHistory = viewHistory.filter(x=>x.id!==id);
         viewHistory.unshift({id:p.id, title:p.title, url:postUrl(p), lastOpened: Date.now()});
         if(viewHistory.length>100) viewHistory.length=100;
-        saveHistory(); renderHistoryBoard();
+        saveHistory();
+        if(!fromHistory){
+          renderHistoryBoard();
+        }
+      }
+
+      function closeActivePost(){
+        const openEl = document.querySelector('.post-board .open-post, #historyBoard .open-post');
+        if(!openEl){
+          document.body.classList.remove('detail-open');
+          if(typeof initPostLayout === 'function') initPostLayout(postsWideEl);
+          if(typeof window.adjustBoards === 'function') window.adjustBoards();
+          return;
+        }
+        const container = openEl.closest('.post-board, #historyBoard') || postsWideEl;
+        const isHistory = container && container.id === 'historyBoard';
+        const id = openEl.dataset ? openEl.dataset.id : null;
+        const post = id ? posts.find(x => x.id === id) : null;
+        const detailBoard = document.querySelector('.post-detail-board');
+        if(detailBoard){
+          detailBoard.classList.remove('is-visible');
+          detailBoard.innerHTML='';
+          detailBoard.removeAttribute('data-id');
+        }
+        document.body.classList.remove('detail-open');
+        $$('.history-card[aria-selected="true"], .post-card[aria-selected="true"]').forEach(el=> el.removeAttribute('aria-selected'));
+        if(post){
+          const replacement = card(post, !isHistory);
+          openEl.replaceWith(replacement);
+        } else {
+          openEl.remove();
+        }
+        activePostId = null;
+        if(typeof initPostLayout === 'function') initPostLayout(postsWideEl);
+        if(typeof updateStickyImages === 'function') updateStickyImages();
+        if(typeof window.adjustBoards === 'function') window.adjustBoards();
       }
 
     function openPostModal(id){
@@ -6400,6 +6521,14 @@ function makePosts(){
       });
     }
   }
+      const headerEl = el.querySelector('.post-header');
+      if(headerEl){
+        headerEl.addEventListener('click', evt=>{
+          if(evt.target.closest('button')) return;
+          evt.stopPropagation();
+          closeActivePost();
+        });
+      }
       const favBtn = el.querySelector('.fav');
       if(favBtn){
         favBtn.addEventListener('click', (e)=>{
@@ -6463,15 +6592,18 @@ function makePosts(){
     }
     show(0);
     setupHorizontalWheel(thumbCol);
+    thumbCol.addEventListener('mouseover', e=>{
+      const t = e.target.closest('img');
+      if(!t) return;
+      const idx = parseInt(t.dataset.index,10);
+      show(idx);
+    });
     thumbCol.addEventListener('click', e=>{
       const t = e.target.closest('img');
       if(!t) return;
       const idx = parseInt(t.dataset.index,10);
-      if(t.classList.contains('selected')){
-        openImagePopup(idx);
-      } else {
-        show(idx);
-      }
+      show(idx);
+      openImagePopup(idx);
     });
       thumbCol.addEventListener('keydown', e=>{
         const cur = parseInt(mainImg.dataset.index||'0',10);
@@ -7035,6 +7167,7 @@ function openPanel(m){
   }
   bringToTop(m);
   if(map && typeof map.resize === 'function') setTimeout(()=> map.resize(),0);
+  if(typeof window.adjustBoards === 'function') setTimeout(()=> window.adjustBoards(), 0);
 }
 function closePanel(m){
   const btnId = panelButtons[m && m.id];
@@ -7061,6 +7194,7 @@ function closePanel(m){
       const idx = panelStack.indexOf(m);
       if(idx!==-1) panelStack.splice(idx,1);
       if(map && typeof map.resize === 'function') setTimeout(()=> map.resize(),0);
+      if(typeof window.adjustBoards === 'function') setTimeout(()=> window.adjustBoards(), 0);
     }, {once:true});
   } else {
     m.classList.remove('show');
@@ -7069,6 +7203,7 @@ function closePanel(m){
     const idx = panelStack.indexOf(m);
     if(idx!==-1) panelStack.splice(idx,1);
     if(map && typeof map.resize === 'function') setTimeout(()=> map.resize(),0);
+    if(typeof window.adjustBoards === 'function') setTimeout(()=> window.adjustBoards(), 0);
   }
 }
 const welcomeModalEl = document.getElementById('welcome-modal');
@@ -7225,6 +7360,7 @@ document.addEventListener('pointerdown', handleDocInteract);
       e.stopPropagation();
       const pressed = btn.getAttribute('aria-pressed')==='true';
       btn.setAttribute('aria-pressed', pressed ? 'false' : 'true');
+      if(typeof window.adjustBoards === 'function') setTimeout(()=> window.adjustBoards(), 0);
     });
   });
 
@@ -7882,63 +8018,60 @@ document.addEventListener('DOMContentLoaded', () => {
 let boardAdjustCleanup = null;
 function initPostLayout(board){
   if(boardAdjustCleanup){ boardAdjustCleanup(); boardAdjustCleanup = null; }
+  const detailBoard = document.querySelector('.post-detail-board');
+  if(detailBoard){
+    detailBoard.classList.remove('is-visible');
+    detailBoard.innerHTML='';
+    detailBoard.removeAttribute('data-id');
+  }
   if(!board){
     document.documentElement.style.removeProperty('--post-header-h');
+    document.body.classList.remove('detail-open');
+    if(typeof window.adjustBoards === 'function') window.adjustBoards();
     return;
   }
   const openPost = board.querySelector('.open-post');
   if(!openPost){
     document.documentElement.style.removeProperty('--post-header-h');
+    document.body.classList.remove('detail-open');
+    if(typeof window.adjustBoards === 'function') window.adjustBoards();
     return;
   }
   const postBody = openPost.querySelector('.post-body');
-  const mainCol = postBody ? postBody.querySelector('.main-post-column') : null;
-  const secondCol = postBody ? postBody.querySelector('.second-post-column') : null;
-  const details = postBody ? postBody.querySelector('.post-details') : null;
-  const postImages = postBody ? postBody.querySelector('.post-images') : null;
   const postHeader = openPost.querySelector('.post-header');
+  const postImages = postBody ? postBody.querySelector('.post-images') : null;
+  const secondCol = openPost.querySelector('.second-post-column');
   const thumbRow = postBody ? postBody.querySelector('.thumbnail-row') : null;
   const selectedImageBox = postImages ? postImages.querySelector('.selected-image, .image-box') : null;
   const imageModalContainer = document.querySelector('.image-modal-container');
   const imageModal = imageModalContainer ? imageModalContainer.querySelector('.image-modal') : null;
-  if(!postBody || !mainCol || !secondCol || !details || !postImages || !postHeader) return;
 
-  let drawerAnimScheduled = false;
-
-  function adjust(){
-    const baseWidth = board.offsetWidth || 440;
-    const drawerWidth = secondCol.offsetWidth || 440;
-    const shouldDrawer = window.innerWidth >= (baseWidth + drawerWidth);
-
-    if(shouldDrawer){
-      openPost.classList.add('drawer-ready');
-      if(!openPost.classList.contains('drawer-open') && !drawerAnimScheduled){
-        drawerAnimScheduled = true;
-        requestAnimationFrame(() => {
-          if(!openPost.isConnected){
-            drawerAnimScheduled = false;
-            return;
-          }
-          openPost.classList.add('drawer-open');
-          drawerAnimScheduled = false;
-        });
-      }
-      document.documentElement.style.setProperty('--post-header-h', postHeader.offsetHeight + 'px');
+  if(detailBoard){
+    if(secondCol){
+      detailBoard.innerHTML='';
+      detailBoard.appendChild(secondCol);
+      detailBoard.classList.add('is-visible');
+      detailBoard.setAttribute('data-id', openPost.dataset.id || '');
+      document.body.classList.add('detail-open');
     } else {
-      openPost.classList.remove('drawer-open');
-      openPost.classList.remove('drawer-ready');
-      drawerAnimScheduled = false;
-      document.documentElement.style.removeProperty('--post-header-h');
+      detailBoard.classList.remove('is-visible');
+      detailBoard.removeAttribute('data-id');
+      document.body.classList.remove('detail-open');
     }
   }
 
-  window.adjust = adjust;
-  adjust();
-  window.addEventListener('load', adjust);
-  window.addEventListener('resize', adjust);
-  const ro = new ResizeObserver(() => adjust());
-  ro.observe(board);
-  ro.observe(openPost);
+  function updateMetrics(){
+    if(postHeader){
+      document.documentElement.style.setProperty('--post-header-h', postHeader.offsetHeight + 'px');
+    } else {
+      document.documentElement.style.removeProperty('--post-header-h');
+    }
+    if(typeof window.adjustBoards === 'function') window.adjustBoards();
+  }
+
+  updateMetrics();
+  window.addEventListener('resize', updateMetrics);
+  window.addEventListener('load', updateMetrics);
 
   function openImageModal(src){
     if(!imageModalContainer || !imageModal) return;
@@ -7953,7 +8086,7 @@ function initPostLayout(board){
     imageModalContainer.addEventListener('click', e => {
       if(e.target === imageModalContainer){
         imageModalContainer.classList.add('hidden');
-        imageModal.innerHTML='';
+        if(imageModal) imageModal.innerHTML='';
       }
     });
     imageModalContainer._listenerAdded = true;
@@ -7974,9 +8107,8 @@ function initPostLayout(board){
   }
 
   boardAdjustCleanup = () => {
-    window.removeEventListener('load', adjust);
-    window.removeEventListener('resize', adjust);
-    ro.disconnect();
+    window.removeEventListener('resize', updateMetrics);
+    window.removeEventListener('load', updateMetrics);
   };
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated post detail board with sliding behavior and update board layout anchoring logic
- adjust styling for post/history boards, filter button state, panel headers, and map controls including geolocate animation
- enhance interactions for thumbnails, header closing, geocoder fly-to, and pinned filter panel behavior

## Testing
- not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68c9b4a9acc883319e7aaaa3a95d260e