### PR TITLE
Remove admin map theme controls and clean up Mapbox warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3591,50 +3591,6 @@ img.thumb{
       </div>
       <form id="adminForm" class="panel-body">
         <div id="tab-map" class="tab-panel active">
-          <div class="map-theme-container">
-            <div class="panel-field">
-              <label for="mapTheme">Theme</label>
-              <select id="mapTheme">
-                <option value="mapbox://styles/mapbox/outdoors-v12">Outdoors</option>
-                <option value="mapbox://styles/mapbox/streets-v12">Streets</option>
-                <option value="mapbox://styles/mapbox/light-v11">Light</option>
-                <option value="mapbox://styles/mapbox/dark-v11">Dark</option>
-                <option value="mapbox://styles/mapbox/satellite-streets-v12">Satellite Streets</option>
-                <option value="mapbox://styles/mapbox/satellite-v9">Satellite Only</option>
-                <option value="mapbox://styles/mapbox/navigation-day-v1">Navigation Day</option>
-                <option value="mapbox://styles/mapbox/navigation-night-v1">Navigation Night</option>
-                  <option value="mapbox://styles/mapbox/standard">Standard</option>
-                  <option value="mapbox://styles/mapbox/satellite-streets-v12">Standard Satellite</option>
-                <option value="mapbox://styles/mapbox/traffic-day-v2">Traffic Day</option>
-                <option value="mapbox://styles/mapbox/traffic-night-v2">Traffic Night</option>
-                  <option value="mapbox://styles/mapbox/terrain-v2">Terrain</option>
-                  <option value="mapbox://styles/mapbox/light-v11">Standard Light</option>
-                  <option value="mapbox://styles/mapbox/dark-v11">Standard Dark</option>
-                <option value="mapbox://styles/mapbox/streets-v8">Streets Classic</option>
-                <option value="mapbox://styles/mapbox/emerald-v8">Emerald</option>
-                <option value="mapbox://styles/mapbox/wheatpaste-v9">Wheatpaste</option>
-                <option value="mapbox://styles/mapbox/pencil-v2">Pencil</option>
-                <option value="mapbox://styles/mapbox/vintage-v10">Vintage</option>
-              </select>
-            </div>
-            <div class="panel-field">
-              <label for="skyTheme">Sky</label>
-              <select id="skyTheme">
-                <option value="default">Default</option>
-                <option value="sunset">Sunset</option>
-                <option value="night">Night</option>
-                <option value="aurora">Aurora</option>
-                <option value="dawn">Dawn</option>
-                <option value="dusk">Dusk</option>
-                <option value="space">Space</option>
-                <option value="cloudy">Cloudy</option>
-                <option value="storm">Storm</option>
-                <option value="twilight">Twilight</option>
-                <option value="sunrise">Sunrise</option>
-                <option value="rainbow">Rainbow</option>
-              </select>
-            </div>
-          </div>
           <div class="map-spin-container">
             <div class="panel-field">
               <label for="spinSpeed">Spin speed</label>
@@ -3825,9 +3781,13 @@ img.thumb{
           spinLoadType = localStorage.getItem('spinLoadType') || 'all',
           spinLogoClick = localStorage.getItem('spinLogoClick') === 'false' ? false : true,
           spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),
-          spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
-          mapStyle = window.mapStyle = normalizeMapStyle(localStorage.getItem('mapStyle')) || 'mapbox://styles/mapbox/standard',
-          skyStyle = window.skyStyle = localStorage.getItem('skyStyle') || 'night',
+          spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit));
+        const DEFAULT_MAP_STYLE = 'mapbox://styles/mapbox/dark-v11';
+        const DEFAULT_SKY_STYLE = 'night';
+        localStorage.removeItem('mapStyle');
+        localStorage.removeItem('skyStyle');
+        let mapStyle = window.mapStyle = normalizeMapStyle(DEFAULT_MAP_STYLE);
+        let skyStyle = window.skyStyle = DEFAULT_SKY_STYLE;
           clusterRadius = parseInt(localStorage.getItem('clusterRadius') || '52', 10),
           clusterMaxZoom = parseInt(localStorage.getItem('clusterMaxZoom') || '14', 10),
           clusterIconType = localStorage.getItem('clusterIconType') || 'circle',
@@ -3935,10 +3895,7 @@ img.thumb{
             }
           }
           if(/label/i.test(id)){
-            if(layer.type === 'symbol'){
-              safeSetPaint(layer, 'text-color', labelColor);
-              safeSetPaint(layer, 'text-halo-color', labelHalo);
-            }
+            return;
           }
         });
       }
@@ -5627,7 +5584,6 @@ function makePosts(){
         const baseStyle = getStyleBase(originUrl);
         const resolvedStyle = normalizeMapStyle(baseStyle) || baseStyle || mapStyle;
         mapStyle = window.mapStyle = resolvedStyle;
-        applyTerrainForStyle(resolvedStyle);
         applySky(skyStyle);
         applyMutedMapStyle(map);
       });
@@ -6371,6 +6327,30 @@ function makePosts(){
         return wrap;
     }
 
+    function releaseDetailMap(node, seenDetailMaps = new Set()){
+      if(!node || !node._detailMap) return seenDetailMaps;
+      const ref = node._detailMap;
+      if(ref && !seenDetailMaps.has(ref)){
+        if(ref.resizeHandler){
+          window.removeEventListener('resize', ref.resizeHandler);
+        }
+        if(ref.mutedHandler && ref.map && typeof ref.map.off === 'function'){
+          try { ref.map.off('style.load', ref.mutedHandler); } catch(err){}
+        }
+        if(ref.map && typeof ref.map.remove === 'function'){
+          try { ref.map.remove(); } catch(err){}
+        }
+        seenDetailMaps.add(ref);
+      }
+      if(ref){
+        ref.map = null;
+        ref.resizeHandler = null;
+        ref.mutedHandler = null;
+      }
+      delete node._detailMap;
+      return seenDetailMaps;
+    }
+
       async function openPost(id, fromHistory=false, fromMap=false, originEl=null){
         lockMap(false);
         touchMarker = null;
@@ -6411,32 +6391,10 @@ function makePosts(){
           const ex = container.querySelector('.open-post');
           if(ex){
             const seenDetailMaps = new Set();
-            const cleanupDetailMap = node=>{
-              if(!node || !node._detailMap) return;
-              const ref = node._detailMap;
-              if(!seenDetailMaps.has(ref)){
-                if(ref.resizeHandler){
-                  window.removeEventListener('resize', ref.resizeHandler);
-                }
-                if(ref.mutedHandler && ref.map && typeof ref.map.off === 'function'){
-                  try { ref.map.off('style.load', ref.mutedHandler); } catch(err){}
-                }
-                if(ref.map && typeof ref.map.remove === 'function'){
-                  ref.map.remove();
-                }
-                seenDetailMaps.add(ref);
-              }
-              if(ref){
-                ref.map = null;
-                ref.resizeHandler = null;
-                ref.mutedHandler = null;
-              }
-              delete node._detailMap;
-            };
-            cleanupDetailMap(ex);
+            releaseDetailMap(ex, seenDetailMaps);
             const mapNode = ex.querySelector('.post-map');
             if(mapNode){
-              cleanupDetailMap(mapNode);
+              releaseDetailMap(mapNode, seenDetailMaps);
             }
             const exId = ex.dataset && ex.dataset.id;
             const prev = posts.find(x=> x.id===exId);
@@ -6501,12 +6459,21 @@ function makePosts(){
           if(typeof window.adjustBoards === 'function') window.adjustBoards();
           return;
         }
+        const seenDetailMaps = new Set();
+        releaseDetailMap(openEl, seenDetailMaps);
+        const openMapNode = openEl.querySelector('.post-map');
+        if(openMapNode){
+          releaseDetailMap(openMapNode, seenDetailMaps);
+        }
         const container = openEl.closest('.post-board, #historyBoard') || postsWideEl;
         const isHistory = container && container.id === 'historyBoard';
         const id = openEl.dataset ? openEl.dataset.id : null;
         const post = id ? posts.find(x => x.id === id) : null;
         const detailBoard = document.querySelector('.post-detail-board');
         if(detailBoard){
+          detailBoard.querySelectorAll('.post-map').forEach(node=>{
+            releaseDetailMap(node, seenDetailMaps);
+          });
           detailBoard.classList.remove('is-visible');
           detailBoard.innerHTML='';
           detailBoard.removeAttribute('data-id');
@@ -7978,11 +7945,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const opacityVal = document.getElementById('postModeBgOpacityVal');
   const root = document.documentElement;
   const settings = JSON.parse(localStorage.getItem('admin-settings-current') || '{}');
-  const themeSelect = document.getElementById('mapTheme');
-  const skySelect = document.getElementById('skyTheme');
-  if(themeSelect) themeSelect.value = window.mapStyle;
-  if(skySelect) skySelect.value = window.skyStyle;
-
   function hexToRgb(hex){
     const r = parseInt(hex.slice(1,3),16);
     const g = parseInt(hex.slice(3,5),16);


### PR DESCRIPTION
## Summary
- remove the admin map theme and sky selectors and lock the map to the default style
- stop applying terrain and skip label overrides to avoid Mapbox console warnings
- add shared cleanup for post detail maps so WebGL contexts are released when closing posts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c22396f08331a94530999e144f51