### PR TITLE
Avoid muting Mapbox standard style to prevent console warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3874,6 +3874,13 @@ img.thumb{
         } catch(err){
           return;
         }
+        const metadata = style && style.metadata ? style.metadata : {};
+        const originUrl = metadata['mapbox:origin'] || metadata['mapbox:requestedUrl'] || metadata['mapbox:style_url'] || metadata['mapbox:originUrl'] || mapStyle;
+        const baseUrl = getStyleBase(originUrl);
+        const normalizedUrl = normalizeMapStyle(baseUrl) || baseUrl || '';
+        if(typeof normalizedUrl === 'string' && normalizedUrl.includes('/standard')){
+          return;
+        }
         const layers = style && Array.isArray(style.layers) ? style.layers : null;
         if(!layers) return;
         const charcoal = '#26282b';


### PR DESCRIPTION
## Summary
- skip applying the muted map styling helper when the active style is Mapbox Standard to avoid internal feature namespace warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9fcfde4348331b9da54b79d8457bf