### PR TITLE
Apply detail board styles to second column

### DIFF
--- a/index.html
+++ b/index.html
@@ -2401,15 +2401,20 @@ body.filters-active #filterBtn{
     padding:0;
   }
   .open-post .venue-dropdown,
-  .open-post .session-dropdown{
+  .open-post .session-dropdown,
+  .post-detail-board .second-post-column .venue-dropdown,
+  .post-detail-board .second-post-column .session-dropdown{
     width:100%;
     max-width:420px;
     padding:0;
   }
   .open-post .location-section .map-container,
   .post-detail-board .location-section .map-container,
+  .post-detail-board .second-post-column .location-section .map-container,
   .open-post .venue-dropdown,
-  .open-post .session-dropdown{
+  .open-post .session-dropdown,
+  .post-detail-board .second-post-column .venue-dropdown,
+  .post-detail-board .second-post-column .session-dropdown{
     min-width:250px;
     width:100%;
     max-width:420px;
@@ -2458,7 +2463,8 @@ body.filters-active #filterBtn{
 }
 
 
-.open-post .location-section{
+.open-post .location-section,
+.post-detail-board .second-post-column .location-section{
   display:flex;
   flex-wrap:wrap;
   gap:var(--gap);
@@ -2466,8 +2472,9 @@ body.filters-active #filterBtn{
   margin-bottom:6px;
 }
 
-.open-post .location-section .map-container,
-.post-detail-board .location-section .map-container{
+  .open-post .location-section .map-container,
+  .post-detail-board .location-section .map-container,
+  .post-detail-board .second-post-column .location-section .map-container{
   display:flex;
   flex-direction:column;
   gap:var(--gap);
@@ -2477,12 +2484,14 @@ body.filters-active #filterBtn{
   max-width:420px;
   height:auto;
 }
-.open-post .map-container .venue-dropdown{
+.open-post .map-container .venue-dropdown,
+.post-detail-board .second-post-column .map-container .venue-dropdown{
   width:100%;
 }
 
 .open-post .post-map,
-.post-detail-board .post-map{
+.post-detail-board .post-map,
+.post-detail-board .second-post-column .post-map{
   flex:0 0 auto;
   width:100%;
   max-width:420px;
@@ -2494,21 +2503,25 @@ body.filters-active #filterBtn{
 
 
 .open-post .venue-dropdown,
-.open-post .session-dropdown{
+.open-post .session-dropdown,
+.post-detail-board .second-post-column .venue-dropdown,
+.post-detail-board .second-post-column .session-dropdown{
   position:relative;
   min-width:250px;
   width:100%;
   max-width:420px;
 }
 
-.open-post .calendar-container .session-dropdown{
+.open-post .calendar-container .session-dropdown,
+.post-detail-board .second-post-column .calendar-container .session-dropdown{
   margin-top:0;
   width:100%;
 }
 
 
 
-.open-post .venue-dropdown > button{
+.open-post .venue-dropdown > button,
+.post-detail-board .second-post-column .venue-dropdown > button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2523,7 +2536,8 @@ body.filters-active #filterBtn{
   width:100%;
 }
 
-.open-post .session-dropdown > button{
+.open-post .session-dropdown > button,
+.post-detail-board .second-post-column .session-dropdown > button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2538,33 +2552,43 @@ body.filters-active #filterBtn{
 }
 
 
-.open-post .venue-dropdown > button .venue-name{
+.open-post .venue-dropdown > button .venue-name,
+.post-detail-board .second-post-column .venue-dropdown > button .venue-name{
   font-weight:bold;
   display:block;
 }
 
-.open-post .venue-dropdown > button .venue-address{
+.open-post .venue-dropdown > button .venue-address,
+.post-detail-board .second-post-column .venue-dropdown > button .venue-address{
   display:block;
 }
 
-.open-post .venue-menu button .venue-name{
+.open-post .venue-menu button .venue-name,
+.post-detail-board .second-post-column .venue-menu button .venue-name{
   font-weight:bold;
   display:block;
 }
 
-.open-post .venue-menu button .venue-address{
+.open-post .venue-menu button .venue-address,
+.post-detail-board .second-post-column .venue-menu button .venue-address{
   display:block;
 }
 
 .open-post .venue-dropdown > button .venue-name,
+.post-detail-board .second-post-column .venue-dropdown > button .venue-name,
 .open-post .venue-dropdown > button .venue-address,
+.post-detail-board .second-post-column .venue-dropdown > button .venue-address,
 .open-post .venue-menu button .venue-name,
-.open-post .venue-menu button .venue-address{
+.post-detail-board .second-post-column .venue-menu button .venue-name,
+.open-post .venue-menu button .venue-address,
+.post-detail-board .second-post-column .venue-menu button .venue-address{
   line-height:1.2;
 }
 
 .open-post .venue-menu,
-.open-post .session-menu{
+.open-post .session-menu,
+.post-detail-board .second-post-column .venue-menu,
+.post-detail-board .second-post-column .session-menu{
   position:absolute;
   top:calc(100% + 4px);
   left:0;
@@ -2586,9 +2610,12 @@ body.filters-active #filterBtn{
 }
 
 .open-post .venue-menu[hidden],
-.open-post .session-menu[hidden]{display:none;}
+.open-post .session-menu[hidden],
+.post-detail-board .second-post-column .venue-menu[hidden],
+.post-detail-board .second-post-column .session-menu[hidden]{display:none;}
 
-.open-post .venue-menu button{
+.open-post .venue-menu button,
+.post-detail-board .second-post-column .venue-menu button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2603,7 +2630,8 @@ body.filters-active #filterBtn{
   width:100%;
 }
 
-.open-post .session-menu button{
+.open-post .session-menu button,
+.post-detail-board .second-post-column .session-menu button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2618,22 +2646,27 @@ body.filters-active #filterBtn{
 
 
 .open-post .venue-menu button.selected,
-.open-post .session-menu button.selected{
+.open-post .session-menu button.selected,
+.post-detail-board .second-post-column .venue-menu button.selected,
+.post-detail-board .second-post-column .session-menu button.selected{
   background:var(--dropdown-selected-bg);
   color:var(--dropdown-selected-text);
 }
 
-.open-post .session-menu button .session-time{
+.open-post .session-menu button .session-time,
+.post-detail-board .second-post-column .session-menu button .session-time{
   margin-left:auto;
   padding-right:20px;
 }
-.open-post .session-dropdown > button .session-time{
+.open-post .session-dropdown > button .session-time,
+.post-detail-board .second-post-column .session-dropdown > button .session-time{
   margin-left:auto;
   padding-right:20px;
 }
 
 
-.open-post .location-section .calendar-container{
+.open-post .location-section .calendar-container,
+.post-detail-board .second-post-column .location-section .calendar-container{
     display:flex;
     flex-direction:column;
     gap:var(--gap);
@@ -2645,18 +2678,22 @@ body.filters-active #filterBtn{
     max-width:420px;
     height:auto;
   }
-.open-post .location-section .options-menu{
+.open-post .location-section .options-menu,
+.post-detail-board .second-post-column .location-section .options-menu{
   width:100%;
   box-sizing:border-box;
 }
 
 .hide-map-calendar .open-post .map-container,
-.hide-map-calendar .open-post .calendar-container{
+.hide-map-calendar .open-post .calendar-container,
+.hide-map-calendar .post-detail-board .second-post-column .map-container,
+.hide-map-calendar .post-detail-board .second-post-column .calendar-container{
   display:none;
 }
 
 .open-post .post-calendar,
-.post-detail-board .post-calendar{
+.post-detail-board .post-calendar,
+.post-detail-board .second-post-column .post-calendar{
   position:relative;
   font-size:14px;
   min-width:var(--calendar-width);
@@ -2664,7 +2701,8 @@ body.filters-active #filterBtn{
 }
 
 
-.open-post .calendar-container .calendar-scroll{
+.open-post .calendar-container .calendar-scroll,
+.post-detail-board .second-post-column .calendar-container .calendar-scroll{
   width:100%;
   max-width:420px;
   height:var(--calendar-height);
@@ -2681,7 +2719,8 @@ body.filters-active #filterBtn{
   flex:1 1 auto;
 }
 .open-post .post-calendar .calendar,
-.post-detail-board .post-calendar .calendar{
+.post-detail-board .post-calendar .calendar,
+.post-detail-board .second-post-column .post-calendar .calendar{
   margin:0;
   box-sizing:border-box;
   display:flex;
@@ -2695,7 +2734,8 @@ body.filters-active #filterBtn{
   color:var(--dropdown-text);
 }
 .open-post .post-calendar .month,
-.post-detail-board .post-calendar .month{
+.post-detail-board .post-calendar .month,
+.post-detail-board .second-post-column .post-calendar .month{
   flex:0 0 auto;
   width:var(--calendar-width);
   min-width:var(--calendar-width);
@@ -2704,11 +2744,13 @@ body.filters-active #filterBtn{
   flex-direction:column;
 }
 .open-post .post-calendar .month:not(:first-child),
-.post-detail-board .post-calendar .month:not(:first-child){
+.post-detail-board .post-calendar .month:not(:first-child),
+.post-detail-board .second-post-column .post-calendar .month:not(:first-child){
   border-left:1px solid var(--calendar-past-bg);
 }
 .open-post .post-calendar .grid,
-.post-detail-board .post-calendar .grid{
+.post-detail-board .post-calendar .grid,
+.post-detail-board .second-post-column .post-calendar .grid{
   flex:1 1 auto;
   width:100%;
   height:calc(var(--calendar-height) - var(--calendar-header-h));
@@ -2717,7 +2759,8 @@ body.filters-active #filterBtn{
   grid-template-rows:repeat(7,var(--calendar-cell-h));
 }
 .open-post .post-calendar .calendar-header,
-.post-detail-board .post-calendar .calendar-header{
+.post-detail-board .post-calendar .calendar-header,
+.post-detail-board .second-post-column .post-calendar .calendar-header{
   height:var(--calendar-header-h);
   display:flex;
   align-items:center;
@@ -2731,7 +2774,9 @@ body.filters-active #filterBtn{
 .open-post .post-calendar .weekday,
 .open-post .post-calendar .day,
 .post-detail-board .post-calendar .weekday,
-.post-detail-board .post-calendar .day{
+.post-detail-board .post-calendar .day,
+.post-detail-board .second-post-column .post-calendar .weekday,
+.post-detail-board .second-post-column .post-calendar .day{
   width:var(--calendar-cell-w);
   height:var(--calendar-cell-h);
   display:flex;
@@ -2740,13 +2785,15 @@ body.filters-active #filterBtn{
   line-height:var(--calendar-cell-h);
 }
 .open-post .post-calendar .weekday,
-.post-detail-board .post-calendar .weekday{
+.post-detail-board .post-calendar .weekday,
+.post-detail-board .second-post-column .post-calendar .weekday{
   font-size:10px;
   font-weight:bold;
   color:var(--dropdown-text);
 }
 .open-post .post-calendar .day,
-.post-detail-board .post-calendar .day{
+.post-detail-board .post-calendar .day,
+.post-detail-board .second-post-column .post-calendar .day{
   cursor:pointer;
   font-size:12px;
   border-radius:8px;
@@ -2755,56 +2802,68 @@ body.filters-active #filterBtn{
   transition:background .2s,color .2s;
 }
 .open-post .post-calendar .day.empty,
-.post-detail-board .post-calendar .day.empty{
+.post-detail-board .post-calendar .day.empty,
+.post-detail-board .second-post-column .post-calendar .day.empty{
   cursor:default;
   background:var(--calendar-future-bg);
   color:var(--dropdown-text);
   opacity:0.6;
 }
 .open-post .post-calendar .day.available-day,
-.post-detail-board .post-calendar .day.available-day{
+.post-detail-board .post-calendar .day.available-day,
+.post-detail-board .second-post-column .post-calendar .day.available-day{
   background:var(--calendar-future-bg);
   color:var(--dropdown-text);
 }
 .open-post .post-calendar .day.available-day:hover,
-.post-detail-board .post-calendar .day.available-day:hover{
+.post-detail-board .post-calendar .day.available-day:hover,
+.post-detail-board .second-post-column .post-calendar .day.available-day:hover{
   background:var(--session-available);
   color:#fff;
 }
 .open-post .post-calendar .day.selected,
-.post-detail-board .post-calendar .day.selected{
+.post-detail-board .post-calendar .day.selected,
+.post-detail-board .second-post-column .post-calendar .day.selected{
   background:var(--session-selected);
   color:#fff;
 }
 .open-post .post-calendar .day.selected:hover,
-.post-detail-board .post-calendar .day.selected:hover{
+.post-detail-board .post-calendar .day.selected:hover,
+.post-detail-board .second-post-column .post-calendar .day.selected:hover{
   background:var(--session-selected);
   color:#fff;
 }
 .open-post .post-calendar .day.today,
-.post-detail-board .post-calendar .day.today{color:var(--today) !important;}
+.post-detail-board .post-calendar .day.today,
+.post-detail-board .second-post-column .post-calendar .day.today{color:var(--today) !important;}
 .open-post .post-calendar .day.available-day.today,
 .open-post .post-calendar .day.available-day.selected.today,
 .open-post .post-calendar .day.selected.today,
 .post-detail-board .post-calendar .day.available-day.today,
 .post-detail-board .post-calendar .day.available-day.selected.today,
-.post-detail-board .post-calendar .day.selected.today{color:var(--today) !important;}
+.post-detail-board .post-calendar .day.selected.today,
+.post-detail-board .second-post-column .post-calendar .day.available-day.today,
+.post-detail-board .second-post-column .post-calendar .day.available-day.selected.today,
+.post-detail-board .second-post-column .post-calendar .day.selected.today{color:var(--today) !important;}
 
 
 .open-post .post-calendar .selected-month-name,
-.post-detail-board .post-calendar .selected-month-name{
+.post-detail-board .post-calendar .selected-month-name,
+.post-detail-board .second-post-column .post-calendar .selected-month-name{
   background:var(--accent);
   color:var(--button-hover-text);
   border-radius:8px;
   padding:0 4px;
 }
 
-.open-post .calendar-container .time-popup{
+.open-post .calendar-container .time-popup,
+.post-detail-board .second-post-column .calendar-container .time-popup{
   position:absolute;
   z-index:10;
 }
 
-.open-post .calendar-container .time-popup .time-list{
+.open-post .calendar-container .time-popup .time-list,
+.post-detail-board .second-post-column .calendar-container .time-popup .time-list{
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
   padding:8px;
@@ -2814,7 +2873,8 @@ body.filters-active #filterBtn{
   gap:4px;
    }
 
-.open-post .calendar-container .time-popup .time-list button{
+.open-post .calendar-container .time-popup .time-list button,
+.post-detail-board .second-post-column .calendar-container .time-popup .time-list button{
   background:var(--btn);
   border:1px solid var(--btn);
   color:var(--button-text);
@@ -2824,12 +2884,16 @@ body.filters-active #filterBtn{
 }
 
 .open-post .venue-info,
-.open-post .session-info{
+.open-post .session-info,
+.post-detail-board .second-post-column .venue-info,
+.post-detail-board .second-post-column .session-info{
   color: inherit;
   font-size: inherit;
 }
-.open-post .venue-info{margin-top:4px;}
-.open-post .session-info{margin-top:8px;}
+.open-post .venue-info,
+.post-detail-board .second-post-column .venue-info{margin-top:4px;}
+.open-post .session-info,
+.post-detail-board .second-post-column .session-info{margin-top:8px;}
 
 
 
@@ -2930,7 +2994,9 @@ body.filters-active #filterBtn{
     display:none;
   }
   .open-post .venue-dropdown,
-  .open-post .session-dropdown{
+  .open-post .session-dropdown,
+  .post-detail-board .second-post-column .venue-dropdown,
+  .post-detail-board .second-post-column .session-dropdown{
     display:block;
   }
 }


### PR DESCRIPTION
## Summary
- extend the map, dropdown, and menu selectors so `.post-detail-board .second-post-column` inherits the same sizing as the open post column
- propagate calendar, time popup, and detail info selectors to the detail board second column to keep the calendar viewport horizontal layout
- ensure the responsive rule also exposes the detail board dropdowns on narrow screens

## Testing
- npm test
- Playwright verification script (see artifacts/verify-results.txt)


------
https://chatgpt.com/codex/tasks/task_e_68ca279405f4833193475ab2fd46b475