### PR TITLE
Ensure location section order in detail board

### DIFF
--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,8 @@ body.filters-active #filterBtn{
   .open-post .post-body{
     flex-direction:column;
   }
-  .open-post .post-details .location-section{
+  .open-post .post-details .location-section,
+  .post-detail-board .second-post-column .post-details .location-section{
     order:-1;
   }
   .open-post .image-box{


### PR DESCRIPTION
## Summary
- extend the 840px responsive rule so the detail board's location section keeps the same `order:-1` positioning as the inline post view after `initPostLayout` moves the column

## Testing
- npm test
- manual Playwright check at 800px viewport to confirm the location section renders first after moving `.second-post-column` into `.post-detail-board`


------
https://chatgpt.com/codex/tasks/task_e_68ca356d1128833180c886a800e89e05