### PR TITLE
Align second post column max width to 520px

### DIFF
--- a/index.html
+++ b/index.html
@@ -1712,7 +1712,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 }
 .post-detail-board .second-post-column{
   width:100%;
-  max-width:100%;
+  max-width:520px;
   min-width:0;
   padding:10px;
   box-sizing:border-box;
@@ -1721,6 +1721,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   overflow-y:auto;
   overflow-y:overlay;
   height:100%;
+  flex:0 1 520px;
 }
 .post-detail-board .post-details{
   width:100%;
@@ -1854,7 +1855,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 
 .second-post-column{
   width:100%;
-  max-width:100%;
+  max-width:520px;
   min-width:0;
   padding:0;
   display:flex;
@@ -3503,7 +3504,7 @@ img.thumb{
   }
   .second-post-column{
     width:100%;
-    max-width:100%;
+    max-width:520px;
     min-width:0;
     flex:0 0 100%;
   }


### PR DESCRIPTION
## Summary
- update `.post-detail-board .second-post-column` to cap the column at 520px and align its flex-basis
- set the base `.second-post-column` rule to the same max width and update the responsive override to respect that limit

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca4eae7bd88331bddd59d6f824df39