### PR TITLE
Remove post detail board and keep second column inline

### DIFF
--- a/index.html
+++ b/index.html
@@ -1674,62 +1674,11 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 }
 @media (max-width:439px){
   .post-board,
-  .history-board,
-  .post-detail-board.is-visible{
+  .history-board{
     width:100%;
     max-width:100%;
     min-width:360px;
   }
-  .post-detail-board{
-    display:none;
-  }
-}
-
-.post-detail-board{
-  flex:0 1 560px;
-  width:100%;
-  max-width:560px;
-  overflow-y:auto;
-  overflow-y:overlay;
-  background:rgba(0,0,0,0.7);
-  display:flex;
-  flex-direction:column;
-  gap:0;
-  pointer-events:auto;
-  opacity:0;
-  transform:translateX(20px);
-  transition:transform 0.3s ease, opacity 0.3s ease, max-width 0.3s ease, border-left-width 0.3s ease;
-  border-left:1px solid rgba(255,255,255,0.12);
-}
-.post-detail-board.is-visible{
-  opacity:1;
-  transform:translateX(0);
-  max-width:560px;
-  flex:0 1 560px;
-}
-.post-detail-board:not(.is-visible){
-  pointer-events:none;
-  max-width:0;
-  border-left-width:0;
-  flex:0 0 0;
-}
-.post-detail-board .second-post-column{
-  width:100%;
-  max-width:520px;
-  min-width:0;
-  padding:10px;
-  box-sizing:border-box;
-  display:flex;
-  flex-direction:column;
-  overflow-y:auto;
-  overflow-y:overlay;
-  height:100%;
-  flex:0 1 520px;
-}
-.post-detail-board .post-details{
-  width:100%;
-  max-width:100%;
-  min-width:0;
 }
 .last-opened-label{
   font-size:12px;
@@ -1848,13 +1797,15 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   width:100%;
   max-width:520px;
   min-width:0;
-  padding:0;
+  padding:10px;
+  box-sizing:border-box;
   display:flex;
   flex-direction:column;
   overflow-y:auto;
   overflow-y:overlay;
   height:100%;
   margin-top:0;
+  flex:0 1 520px;
 }
 
 .post-venue-selection-container,
@@ -2415,23 +2366,18 @@ body.filters-active #filterBtn{
     max-width:420px;
     padding:0;
   }
-  .post-detail-board .second-post-column .venue-dropdown,
-  .post-detail-board .second-post-column .session-dropdown{
-    width:100%;
-    max-width:100%;
-    padding:0;
-  }
   .open-post .location-section .map-container,
-  .post-detail-board .location-section .map-container,
   .open-post .venue-dropdown,
   .open-post .session-dropdown{
     min-width:250px;
     width:100%;
     max-width:420px;
   }
-  .post-detail-board .second-post-column .location-section .map-container,
-  .post-detail-board .second-post-column .venue-dropdown,
-  .post-detail-board .second-post-column .session-dropdown{
+  .open-post .second-post-column .venue-dropdown,
+  .open-post .second-post-column .session-dropdown{
+    max-width:100%;
+  }
+  .open-post .second-post-column .location-section .map-container{
     min-width:250px;
     width:100%;
     max-width:100%;
@@ -2481,7 +2427,7 @@ body.filters-active #filterBtn{
 
 
 .open-post .location-section,
-.post-detail-board .second-post-column .location-section{
+.open-post .second-post-column .location-section{
   display:flex;
   flex-wrap:wrap;
   gap:var(--gap);
@@ -2490,8 +2436,7 @@ body.filters-active #filterBtn{
 }
 
   .open-post .location-section .map-container,
-  .post-detail-board .location-section .map-container,
-  .post-detail-board .second-post-column .location-section .map-container{
+  .open-post .second-post-column .location-section .map-container{
   display:flex;
   flex-direction:column;
   gap:var(--gap);
@@ -2502,13 +2447,11 @@ body.filters-active #filterBtn{
   height:auto;
 }
 .open-post .map-container .venue-dropdown,
-.post-detail-board .second-post-column .map-container .venue-dropdown{
+.open-post .second-post-column .map-container .venue-dropdown{
   width:100%;
 }
 
-.open-post .post-map,
-.post-detail-board .post-map,
-.post-detail-board .second-post-column .post-map{
+.open-post .post-map{
   flex:0 0 auto;
   width:100%;
   max-width:420px;
@@ -2519,12 +2462,12 @@ body.filters-active #filterBtn{
 }
 
 
-.post-detail-board .second-post-column .location-section .map-container{
+.open-post .second-post-column .location-section .map-container{
   flex:1 1 100%;
   max-width:100%;
 }
 
-.post-detail-board .second-post-column .post-map{
+.open-post .second-post-column .post-map{
   flex-basis:100%;
   max-width:100%;
 }
@@ -2537,8 +2480,8 @@ body.filters-active #filterBtn{
   width:100%;
   max-width:420px;
 }
-.post-detail-board .second-post-column .venue-dropdown,
-.post-detail-board .second-post-column .session-dropdown{
+.open-post .second-post-column .venue-dropdown,
+.open-post .second-post-column .session-dropdown{
   position:relative;
   min-width:250px;
   width:100%;
@@ -2546,7 +2489,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .calendar-container .session-dropdown,
-.post-detail-board .second-post-column .calendar-container .session-dropdown{
+.open-post .second-post-column .calendar-container .session-dropdown{
   margin-top:0;
   width:100%;
 }
@@ -2554,7 +2497,7 @@ body.filters-active #filterBtn{
 
 
 .open-post .venue-dropdown > button,
-.post-detail-board .second-post-column .venue-dropdown > button{
+.open-post .second-post-column .venue-dropdown > button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2570,7 +2513,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .session-dropdown > button,
-.post-detail-board .second-post-column .session-dropdown > button{
+.open-post .second-post-column .session-dropdown > button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2586,42 +2529,42 @@ body.filters-active #filterBtn{
 
 
 .open-post .venue-dropdown > button .venue-name,
-.post-detail-board .second-post-column .venue-dropdown > button .venue-name{
+.open-post .second-post-column .venue-dropdown > button .venue-name{
   font-weight:bold;
   display:block;
 }
 
 .open-post .venue-dropdown > button .venue-address,
-.post-detail-board .second-post-column .venue-dropdown > button .venue-address{
+.open-post .second-post-column .venue-dropdown > button .venue-address{
   display:block;
 }
 
 .open-post .venue-menu button .venue-name,
-.post-detail-board .second-post-column .venue-menu button .venue-name{
+.open-post .second-post-column .venue-menu button .venue-name{
   font-weight:bold;
   display:block;
 }
 
 .open-post .venue-menu button .venue-address,
-.post-detail-board .second-post-column .venue-menu button .venue-address{
+.open-post .second-post-column .venue-menu button .venue-address{
   display:block;
 }
 
 .open-post .venue-dropdown > button .venue-name,
-.post-detail-board .second-post-column .venue-dropdown > button .venue-name,
+.open-post .second-post-column .venue-dropdown > button .venue-name,
 .open-post .venue-dropdown > button .venue-address,
-.post-detail-board .second-post-column .venue-dropdown > button .venue-address,
+.open-post .second-post-column .venue-dropdown > button .venue-address,
 .open-post .venue-menu button .venue-name,
-.post-detail-board .second-post-column .venue-menu button .venue-name,
+.open-post .second-post-column .venue-menu button .venue-name,
 .open-post .venue-menu button .venue-address,
-.post-detail-board .second-post-column .venue-menu button .venue-address{
+.open-post .second-post-column .venue-menu button .venue-address{
   line-height:1.2;
 }
 
 .open-post .venue-menu,
 .open-post .session-menu,
-.post-detail-board .second-post-column .venue-menu,
-.post-detail-board .second-post-column .session-menu{
+.open-post .second-post-column .venue-menu,
+.open-post .second-post-column .session-menu{
   position:absolute;
   top:calc(100% + 4px);
   left:0;
@@ -2644,18 +2587,18 @@ body.filters-active #filterBtn{
 .open-post .session-menu{
   max-width:420px;
 }
-.post-detail-board .second-post-column .venue-menu,
-.post-detail-board .second-post-column .session-menu{
+.open-post .second-post-column .venue-menu,
+.open-post .second-post-column .session-menu{
   max-width:100%;
 }
 
 .open-post .venue-menu[hidden],
 .open-post .session-menu[hidden],
-.post-detail-board .second-post-column .venue-menu[hidden],
-.post-detail-board .second-post-column .session-menu[hidden]{display:none;}
+.open-post .second-post-column .venue-menu[hidden],
+.open-post .second-post-column .session-menu[hidden]{display:none;}
 
 .open-post .venue-menu button,
-.post-detail-board .second-post-column .venue-menu button{
+.open-post .second-post-column .venue-menu button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2671,7 +2614,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .session-menu button,
-.post-detail-board .second-post-column .session-menu button{
+.open-post .second-post-column .session-menu button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2687,26 +2630,26 @@ body.filters-active #filterBtn{
 
 .open-post .venue-menu button.selected,
 .open-post .session-menu button.selected,
-.post-detail-board .second-post-column .venue-menu button.selected,
-.post-detail-board .second-post-column .session-menu button.selected{
+.open-post .second-post-column .venue-menu button.selected,
+.open-post .second-post-column .session-menu button.selected{
   background:var(--dropdown-selected-bg);
   color:var(--dropdown-selected-text);
 }
 
 .open-post .session-menu button .session-time,
-.post-detail-board .second-post-column .session-menu button .session-time{
+.open-post .second-post-column .session-menu button .session-time{
   margin-left:auto;
   padding-right:20px;
 }
 .open-post .session-dropdown > button .session-time,
-.post-detail-board .second-post-column .session-dropdown > button .session-time{
+.open-post .second-post-column .session-dropdown > button .session-time{
   margin-left:auto;
   padding-right:20px;
 }
 
 
 .open-post .location-section .calendar-container,
-.post-detail-board .second-post-column .location-section .calendar-container{
+.open-post .second-post-column .location-section .calendar-container{
     display:flex;
     flex-direction:column;
     gap:var(--gap);
@@ -2720,26 +2663,24 @@ body.filters-active #filterBtn{
     flex:1 1 420px;
     max-width:420px;
   }
-.post-detail-board .second-post-column .location-section .calendar-container{
-    flex:1 1 100%;
-    max-width:100%;
-  }
+.open-post .second-post-column .location-section .calendar-container{
+  flex:1 1 100%;
+  max-width:100%;
+}
 .open-post .location-section .options-menu,
-.post-detail-board .second-post-column .location-section .options-menu{
+.open-post .second-post-column .location-section .options-menu{
   width:100%;
   box-sizing:border-box;
 }
 
 .hide-map-calendar .open-post .map-container,
 .hide-map-calendar .open-post .calendar-container,
-.hide-map-calendar .post-detail-board .second-post-column .map-container,
-.hide-map-calendar .post-detail-board .second-post-column .calendar-container{
+.hide-map-calendar .open-post .second-post-column .map-container,
+.hide-map-calendar .open-post .second-post-column .calendar-container{
   display:none;
 }
 
-.open-post .post-calendar,
-.post-detail-board .post-calendar,
-.post-detail-board .second-post-column .post-calendar{
+.open-post .post-calendar{
   position:relative;
   font-size:14px;
   min-width:var(--calendar-width);
@@ -2748,7 +2689,7 @@ body.filters-active #filterBtn{
 
 
 .open-post .calendar-container .calendar-scroll,
-.post-detail-board .second-post-column .calendar-container .calendar-scroll{
+.open-post .second-post-column .calendar-container .calendar-scroll{
   width:100%;
   height:var(--calendar-height);
   max-height:var(--calendar-height);
@@ -2766,12 +2707,10 @@ body.filters-active #filterBtn{
 .open-post .calendar-container .calendar-scroll{
   max-width:420px;
 }
-.post-detail-board .second-post-column .calendar-container .calendar-scroll{
+.open-post .second-post-column .calendar-container .calendar-scroll{
   max-width:100%;
 }
-.open-post .post-calendar .calendar,
-.post-detail-board .post-calendar .calendar,
-.post-detail-board .second-post-column .post-calendar .calendar{
+.open-post .post-calendar .calendar{
   margin:0;
   box-sizing:border-box;
   display:flex;
@@ -2784,9 +2723,7 @@ body.filters-active #filterBtn{
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
 }
-.open-post .post-calendar .month,
-.post-detail-board .post-calendar .month,
-.post-detail-board .second-post-column .post-calendar .month{
+.open-post .post-calendar .month{
   flex:0 0 auto;
   width:var(--calendar-width);
   min-width:var(--calendar-width);
@@ -2794,14 +2731,10 @@ body.filters-active #filterBtn{
   display:flex;
   flex-direction:column;
 }
-.open-post .post-calendar .month:not(:first-child),
-.post-detail-board .post-calendar .month:not(:first-child),
-.post-detail-board .second-post-column .post-calendar .month:not(:first-child){
+.open-post .post-calendar .month:not(:first-child){
   border-left:1px solid var(--calendar-past-bg);
 }
-.open-post .post-calendar .grid,
-.post-detail-board .post-calendar .grid,
-.post-detail-board .second-post-column .post-calendar .grid{
+.open-post .post-calendar .grid{
   flex:1 1 auto;
   width:100%;
   height:calc(var(--calendar-height) - var(--calendar-header-h));
@@ -2809,9 +2742,7 @@ body.filters-active #filterBtn{
   grid-template-columns:repeat(7,var(--calendar-cell-w));
   grid-template-rows:repeat(7,var(--calendar-cell-h));
 }
-.open-post .post-calendar .calendar-header,
-.post-detail-board .post-calendar .calendar-header,
-.post-detail-board .second-post-column .post-calendar .calendar-header{
+.open-post .post-calendar .calendar-header{
   height:var(--calendar-header-h);
   display:flex;
   align-items:center;
@@ -2823,11 +2754,7 @@ body.filters-active #filterBtn{
   color:#fff;
 }
 .open-post .post-calendar .weekday,
-.open-post .post-calendar .day,
-.post-detail-board .post-calendar .weekday,
-.post-detail-board .post-calendar .day,
-.post-detail-board .second-post-column .post-calendar .weekday,
-.post-detail-board .second-post-column .post-calendar .day{
+.open-post .post-calendar .day{
   width:var(--calendar-cell-w);
   height:var(--calendar-cell-h);
   display:flex;
@@ -2835,16 +2762,12 @@ body.filters-active #filterBtn{
   justify-content:center;
   line-height:var(--calendar-cell-h);
 }
-.open-post .post-calendar .weekday,
-.post-detail-board .post-calendar .weekday,
-.post-detail-board .second-post-column .post-calendar .weekday{
+.open-post .post-calendar .weekday{
   font-size:10px;
   font-weight:bold;
   color:var(--dropdown-text);
 }
-.open-post .post-calendar .day,
-.post-detail-board .post-calendar .day,
-.post-detail-board .second-post-column .post-calendar .day{
+.open-post .post-calendar .day{
   cursor:pointer;
   font-size:12px;
   border-radius:8px;
@@ -2852,55 +2775,43 @@ body.filters-active #filterBtn{
   color:var(--dropdown-text);
   transition:background .2s,color .2s;
 }
-.open-post .post-calendar .day.empty,
-.post-detail-board .post-calendar .day.empty,
-.post-detail-board .second-post-column .post-calendar .day.empty{
+.open-post .post-calendar .day.empty{
   cursor:default;
   background:var(--calendar-future-bg);
   color:var(--dropdown-text);
   opacity:0.6;
 }
 .open-post .post-calendar .day.available-day,
-.post-detail-board .post-calendar .day.available-day,
-.post-detail-board .second-post-column .post-calendar .day.available-day{
+.open-post .second-post-column .post-calendar .day.available-day{
   background:var(--calendar-future-bg);
   color:var(--dropdown-text);
 }
 .open-post .post-calendar .day.available-day:hover,
-.post-detail-board .post-calendar .day.available-day:hover,
-.post-detail-board .second-post-column .post-calendar .day.available-day:hover{
+.open-post .second-post-column .post-calendar .day.available-day:hover{
   background:var(--session-available);
   color:#fff;
 }
 .open-post .post-calendar .day.selected,
-.post-detail-board .post-calendar .day.selected,
-.post-detail-board .second-post-column .post-calendar .day.selected{
+.open-post .second-post-column .post-calendar .day.selected{
   background:var(--session-selected);
   color:#fff;
 }
 .open-post .post-calendar .day.selected:hover,
-.post-detail-board .post-calendar .day.selected:hover,
-.post-detail-board .second-post-column .post-calendar .day.selected:hover{
+.open-post .second-post-column .post-calendar .day.selected:hover{
   background:var(--session-selected);
   color:#fff;
 }
 .open-post .post-calendar .day.today,
-.post-detail-board .post-calendar .day.today,
-.post-detail-board .second-post-column .post-calendar .day.today{color:var(--today) !important;}
 .open-post .post-calendar .day.available-day.today,
 .open-post .post-calendar .day.available-day.selected.today,
 .open-post .post-calendar .day.selected.today,
-.post-detail-board .post-calendar .day.available-day.today,
-.post-detail-board .post-calendar .day.available-day.selected.today,
-.post-detail-board .post-calendar .day.selected.today,
-.post-detail-board .second-post-column .post-calendar .day.available-day.today,
-.post-detail-board .second-post-column .post-calendar .day.available-day.selected.today,
-.post-detail-board .second-post-column .post-calendar .day.selected.today{color:var(--today) !important;}
+.open-post .second-post-column .post-calendar .day.available-day.today,
+.open-post .second-post-column .post-calendar .day.available-day.selected.today,
+.open-post .second-post-column .post-calendar .day.selected.today{color:var(--today) !important;}
 
 
 .open-post .post-calendar .selected-month-name,
-.post-detail-board .post-calendar .selected-month-name,
-.post-detail-board .second-post-column .post-calendar .selected-month-name{
+.open-post .second-post-column .post-calendar .selected-month-name{
   background:var(--accent);
   color:var(--button-hover-text);
   border-radius:8px;
@@ -2908,13 +2819,13 @@ body.filters-active #filterBtn{
 }
 
 .open-post .calendar-container .time-popup,
-.post-detail-board .second-post-column .calendar-container .time-popup{
+.open-post .second-post-column .calendar-container .time-popup{
   position:absolute;
   z-index:10;
 }
 
 .open-post .calendar-container .time-popup .time-list,
-.post-detail-board .second-post-column .calendar-container .time-popup .time-list{
+.open-post .second-post-column .calendar-container .time-popup .time-list{
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
   padding:8px;
@@ -2925,7 +2836,7 @@ body.filters-active #filterBtn{
    }
 
 .open-post .calendar-container .time-popup .time-list button,
-.post-detail-board .second-post-column .calendar-container .time-popup .time-list button{
+.open-post .second-post-column .calendar-container .time-popup .time-list button{
   background:var(--btn);
   border:1px solid var(--btn);
   color:var(--button-text);
@@ -2936,15 +2847,15 @@ body.filters-active #filterBtn{
 
 .open-post .venue-info,
 .open-post .session-info,
-.post-detail-board .second-post-column .venue-info,
-.post-detail-board .second-post-column .session-info{
+.open-post .second-post-column .venue-info,
+.open-post .second-post-column .session-info{
   color: inherit;
   font-size: inherit;
 }
 .open-post .venue-info,
-.post-detail-board .second-post-column .venue-info{margin-top:4px;}
+.open-post .second-post-column .venue-info{margin-top:4px;}
 .open-post .session-info,
-.post-detail-board .second-post-column .session-info{margin-top:8px;}
+.open-post .second-post-column .session-info{margin-top:8px;}
 
 
 
@@ -3024,7 +2935,7 @@ body.filters-active #filterBtn{
     flex-direction:column;
   }
   .open-post .post-details .location-section,
-  .post-detail-board .second-post-column .post-details .location-section{
+  .open-post .second-post-column .post-details .location-section{
     order:-1;
   }
   .open-post .image-box{
@@ -3036,8 +2947,8 @@ body.filters-active #filterBtn{
   }
   .open-post .venue-dropdown,
   .open-post .session-dropdown,
-  .post-detail-board .second-post-column .venue-dropdown,
-  .post-detail-board .second-post-column .session-dropdown{
+  .open-post .second-post-column .venue-dropdown,
+  .open-post .second-post-column .session-dropdown{
     display:block;
   }
 }
@@ -3639,7 +3550,6 @@ img.thumb{
         </div>
       </div>
     </section>
-    <section class="post-detail-board" aria-label="Post Details Board"></section>
     <section class="ad-board" aria-label="Ad Board">
       <div class="ad-panel">
       </div>
@@ -4237,7 +4147,7 @@ img.thumb{
       const footerH = parseFloat(rootStyles.getPropertyValue('--footer-h')) || 0;
       const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
       const availableHeight = window.innerHeight - headerH - subH - footerH - safeTop;
-      document.querySelectorAll('.history-board, .posts, .post-detail-board').forEach(list=>{
+      document.querySelectorAll('.history-board, .posts').forEach(list=>{
         list.style.maxHeight = `${availableHeight}px`;
       });
     }
@@ -4321,12 +4231,10 @@ img.thumb{
         const imgArea = body ? body.querySelector('.post-images') : null;
         const header = document.querySelector('.open-post .post-header');
         const board = document.querySelector('.post-board');
-        const detailBoard = document.querySelector('.post-detail-board');
-        const detailColumn = detailBoard ? detailBoard.querySelector('.second-post-column') : null;
+        const detailColumn = document.querySelector('.open-post .second-post-column');
         const venueContainer = detailColumn ? detailColumn.querySelector('.post-venue-selection-container') : null;
         const sessionContainer = detailColumn ? detailColumn.querySelector('.post-session-selection-container') : null;
-        const detailColumnMounted = !!(detailColumn && document.contains(detailColumn));
-        const detailVisible = !!(detailBoard && detailBoard.classList.contains('is-visible') && detailColumnMounted);
+        const detailVisible = !!(detailColumn && document.contains(detailColumn));
         root.classList.toggle('hide-map-calendar', !detailVisible);
         if(venueDropdownEl){
           if(venueContainer && document.contains(venueContainer) && venueDropdownEl.parentElement !== venueContainer){
@@ -5387,29 +5295,19 @@ function makePosts(){
         const filterContent = filterPanel ? filterPanel.querySelector('.panel-content') : null;
         const pinBtn = filterPanel ? filterPanel.querySelector('.pin-panel') : null;
         const filterPinned = !!(filterPanel && filterPanel.classList.contains('show') && pinBtn && pinBtn.getAttribute('aria-pressed') === 'true');
-        const detailBoard = document.querySelector('.post-detail-board');
         const historyOpenPost = historyBoard ? historyBoard.querySelector('.open-post') : null;
         const postsOpenPost = postBoard ? postBoard.querySelector('.open-post') : null;
         const activeOpenPost = historyActive ? (historyOpenPost || postsOpenPost) : (postsOpenPost || historyOpenPost);
-        const activeOpenId = activeOpenPost && activeOpenPost.dataset ? activeOpenPost.dataset.id : null;
         const anyOpenPost = historyOpenPost || postsOpenPost;
-        const anyOpenId = anyOpenPost && anyOpenPost.dataset ? anyOpenPost.dataset.id : null;
-        const detailMatchesActive = !!(detailBoard && activeOpenId && detailBoard.dataset && detailBoard.dataset.id === activeOpenId);
-        const detailMatchesAny = !!(detailBoard && anyOpenId && detailBoard.dataset && detailBoard.dataset.id === anyOpenId);
-        const detailVisible = !!(detailBoard && detailBoard.classList.contains('is-visible') && detailMatchesActive);
         const gap = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--gap')) || 10;
         let filterWidth = filterPinned && filterContent ? filterContent.getBoundingClientRect().width : 0;
         const postWidth = postBoard ? (postBoard.offsetWidth || 440) : 0;
         const historyWidth = historyBoard ? (historyBoard.offsetWidth || 440) : 0;
-        const detailWidth = detailBoard && detailMatchesAny ? (detailBoard.offsetWidth || 560) : 0;
         const boardsWidths = [];
         if(historyActive && historyBoard){
           boardsWidths.push(historyWidth);
         } else if(postBoard){
           boardsWidths.push(postWidth);
-        }
-        if(detailVisible){
-          boardsWidths.push(detailWidth);
         }
         let totalBoardsWidth = boardsWidths.reduce((sum, w)=> sum + w, 0);
         if(boardsWidths.length > 1){
@@ -5442,16 +5340,7 @@ function makePosts(){
           postBoard.style.display = historyActive ? 'none' : '';
           postBoard.setAttribute('aria-hidden', historyActive ? 'true' : 'false');
         }
-        if(detailBoard){
-          if(detailMatchesActive && !detailBoard.classList.contains('is-visible')){
-            detailBoard.classList.add('is-visible');
-          } else if(!detailVisible && !detailMatchesAny){
-            detailBoard.classList.remove('is-visible');
-            detailBoard.removeAttribute('data-id');
-            if(typeof updateStickyImages === 'function') updateStickyImages();
-          }
-        }
-        document.body.classList.toggle('detail-open', detailVisible || detailMatchesAny);
+        document.body.classList.toggle('detail-open', !!anyOpenPost);
         if(hideAds || !adBoard){
           document.body.classList.add('hide-ads');
         } else {
@@ -5460,6 +5349,7 @@ function makePosts(){
         if(adBoard){
           adBoard.setAttribute('aria-hidden', document.body.classList.contains('hide-ads') ? 'true' : 'false');
         }
+        if(typeof updateStickyImages === 'function') updateStickyImages();
         updateModeToggle();
       }
       window.adjustBoards = adjustBoards;
@@ -6714,17 +6604,11 @@ function makePosts(){
         const detail = buildDetail(p);
         target.replaceWith(detail);
         hookDetailActions(detail, p);
-        if (typeof updateStickyImages === 'function') {
-          const mountedDetailColumn = document.querySelector('.post-detail-board .second-post-column');
-          if(mountedDetailColumn){
-            updateStickyImages();
-          }
-        }
         if (typeof initPostLayout === 'function') {
           initPostLayout(container);
-          if (typeof updateStickyImages === 'function') {
-            updateStickyImages();
-          }
+        }
+        if (typeof updateStickyImages === 'function') {
+          updateStickyImages();
         }
 
         await nextFrame();
@@ -6768,12 +6652,6 @@ function makePosts(){
         const isHistory = container && container.id === 'historyBoard';
         const id = openEl.dataset ? openEl.dataset.id : null;
         const post = id ? posts.find(x => x.id === id) : null;
-        const detailBoard = document.querySelector('.post-detail-board');
-        if(detailBoard){
-          detailBoard.classList.remove('is-visible');
-          detailBoard.innerHTML='';
-          detailBoard.removeAttribute('data-id');
-        }
         document.body.classList.remove('detail-open');
         $$('.history-card[aria-selected="true"], .post-card[aria-selected="true"]').forEach(el=> el.removeAttribute('aria-selected'));
         if(post){
@@ -8421,23 +8299,9 @@ document.addEventListener('DOMContentLoaded', () => {
 let boardAdjustCleanup = null;
 function initPostLayout(board){
   if(boardAdjustCleanup){ boardAdjustCleanup(); boardAdjustCleanup = null; }
-  const detailBoard = document.querySelector('.post-detail-board');
   const openPost = (board && board.querySelector('.open-post')) || document.querySelector('.post-board .open-post, #historyBoard .open-post');
-  const getAvailableWidth = () => {
-    const values = [];
-    if(typeof window !== 'undefined' && typeof window.innerWidth === 'number' && !Number.isNaN(window.innerWidth)){
-      values.push(window.innerWidth);
-    }
-    if(document.documentElement && typeof document.documentElement.clientWidth === 'number' && !Number.isNaN(document.documentElement.clientWidth)){
-      values.push(document.documentElement.clientWidth);
-    }
-    if(board && typeof board.clientWidth === 'number' && board.clientWidth > 0){
-      values.push(board.clientWidth);
-    }
-    return values.length ? Math.min(...values) : 0;
-  };
   const scheduleMapResize = mapInstance => {
-    if(!mapInstance || typeof mapInstance.resize !== 'function') return;
+    if(!mapInstance) return;
     if(typeof requestAnimationFrame === 'function'){
       requestAnimationFrame(() => mapInstance.resize());
     } else {
@@ -8460,39 +8324,14 @@ function initPostLayout(board){
       if(target.dataset) delete target.dataset.secondPostHeight;
     }
   };
-  const applyPreservedHeight = (target, height) => {
-    if(!target) return;
-    if(height){
-      target.style.setProperty('--second-post-height', height + 'px');
-      target.style.minHeight = height + 'px';
-      if(target.dataset) target.dataset.secondPostHeight = height;
-    } else {
-      clearPreservedHeight(target);
-    }
-  };
   document.querySelectorAll('.second-post-placeholder').forEach(node => {
     const parentBody = node.parentElement;
     if(parentBody) clearPreservedHeight(parentBody);
     node.remove();
   });
-  if(!detailBoard){
-    document.documentElement.style.removeProperty('--post-header-h');
-    if(!openPost){
-      document.body.classList.remove('detail-open');
-    }
-    if(openPost){
-      const body = openPost.querySelector('.post-body');
-      if(body) clearPreservedHeight(body);
-    }
-    if(typeof window.adjustBoards === 'function') window.adjustBoards();
-    return;
-  }
   if(!openPost){
-    detailBoard.classList.remove('is-visible');
-    detailBoard.innerHTML='';
-    detailBoard.removeAttribute('data-id');
-    document.body.classList.remove('detail-open');
     document.documentElement.style.removeProperty('--post-header-h');
+    document.body.classList.remove('detail-open');
     if(board){
       board.querySelectorAll('.post-body').forEach(clearPreservedHeight);
     }
@@ -8503,103 +8342,33 @@ function initPostLayout(board){
   const postHeader = openPost.querySelector('.post-header');
   const postImages = postBody ? postBody.querySelector('.post-images') : null;
   const mainColumn = postBody ? postBody.querySelector('.main-post-column') : null;
-  const openPostId = openPost && openPost.dataset ? (openPost.dataset.id || '') : '';
-  const detailBoardId = detailBoard ? (detailBoard.getAttribute('data-id') || '') : '';
-  let secondCol = openPost ? openPost.querySelector('.second-post-column') : null;
-  const existingDetailCol = detailBoard ? detailBoard.querySelector('.second-post-column') : null;
-  if(!secondCol && existingDetailCol && openPostId === detailBoardId){
-    secondCol = existingDetailCol;
-  }
+  const secondCol = postBody ? postBody.querySelector('.second-post-column') : null;
   const thumbRow = postBody ? postBody.querySelector('.thumbnail-row') : null;
   const selectedImageBox = postImages ? postImages.querySelector('.selected-image, .image-box') : null;
   const imageModalContainer = document.querySelector('.image-modal-container');
   const imageModal = imageModalContainer ? imageModalContainer.querySelector('.image-modal') : null;
-  const availableWidth = getAvailableWidth();
-  const usingSharedBoard = Boolean(detailBoard && secondCol && availableWidth >= 440);
-  let detailDocked = usingSharedBoard;
-  if(usingSharedBoard){
-    if(secondCol){
-      const alreadyMounted = detailBoard && secondCol.parentElement === detailBoard;
-      if(!alreadyMounted){
-        detailBoard.innerHTML='';
-        detailBoard.appendChild(secondCol);
-      }
-      if(detailBoard && detailBoard.getAttribute('data-id') !== openPostId){
-        detailBoard.setAttribute('data-id', openPostId);
-      }
-      if(detailBoard && !detailBoard.classList.contains('is-visible')){
-        detailBoard.classList.add('is-visible');
-      }
-      if(!alreadyMounted && !document.body.classList.contains('detail-open')){
-        document.body.classList.add('detail-open');
-      }
-      triggerDetailMapResize(secondCol);
-    } else if(postBody){
-      clearPreservedHeight(postBody);
-    }
-  } else {
-    if(secondCol && postBody && secondCol.parentElement !== postBody){
-      if(mainColumn && mainColumn.parentElement === postBody){
-        mainColumn.insertAdjacentElement('afterend', secondCol);
-      } else {
-        postBody.appendChild(secondCol);
-      }
-    }
-    if(postBody) clearPreservedHeight(postBody);
-    detailBoard.classList.remove('is-visible');
-    detailBoard.innerHTML='';
-    detailBoard.removeAttribute('data-id');
-    document.body.classList.remove('detail-open');
-    triggerDetailMapResize(secondCol);
-  }
-
-  function updatePreservedHeight(){
-    if(!postBody){
-      return;
-    }
-    if(!detailDocked){
-      clearPreservedHeight(postBody);
-      return;
-    }
-    if(secondCol && detailBoard.contains(secondCol)){
-      const height = secondCol.offsetHeight;
-      if(height){
-        applyPreservedHeight(postBody, height);
-        return;
-      }
-    }
-    const storedHeight = postBody.dataset ? postBody.dataset.secondPostHeight : null;
-    if(storedHeight){
-      const parsed = parseFloat(storedHeight);
-      if(!Number.isNaN(parsed)){
-        applyPreservedHeight(postBody, parsed);
-        return;
-      }
-    }
+  if(postBody){
     clearPreservedHeight(postBody);
   }
-
-  function updateMetrics(){
-    const widthNow = getAvailableWidth();
-    const shouldUseSharedBoard = Boolean(detailBoard && secondCol && widthNow >= 440);
-    if(shouldUseSharedBoard !== detailDocked){
-      initPostLayout(board);
-      return;
-    }
+  if(secondCol && postBody && mainColumn && secondCol.parentElement !== postBody){
+    mainColumn.insertAdjacentElement('afterend', secondCol);
+  } else if(secondCol && postBody && secondCol.parentElement !== postBody){
+    postBody.appendChild(secondCol);
+  }
+  document.body.classList.add('detail-open');
+  triggerDetailMapResize(secondCol);
+  const updateMetrics = () => {
     if(postHeader){
       document.documentElement.style.setProperty('--post-header-h', postHeader.offsetHeight + 'px');
     } else {
       document.documentElement.style.removeProperty('--post-header-h');
     }
-    updatePreservedHeight();
+    triggerDetailMapResize(secondCol);
     if(typeof window.adjustBoards === 'function') window.adjustBoards();
-  }
-
-  updatePreservedHeight();
+  };
   updateMetrics();
   window.addEventListener('resize', updateMetrics);
   window.addEventListener('load', updateMetrics);
-
   function openImageModal(src){
     if(!imageModalContainer || !imageModal) return;
     imageModal.innerHTML='';
@@ -8608,7 +8377,6 @@ function initPostLayout(board){
     imageModal.appendChild(img);
     imageModalContainer.classList.remove('hidden');
   }
-
   if(imageModalContainer && !imageModalContainer._listenerAdded){
     imageModalContainer.addEventListener('click', e => {
       if(e.target === imageModalContainer){
@@ -8618,21 +8386,18 @@ function initPostLayout(board){
     });
     imageModalContainer._listenerAdded = true;
   }
-
   if(thumbRow){
     thumbRow.addEventListener('dblclick', e => {
       const img = e.target.closest('img');
       if(img) openImageModal(img.src);
     });
   }
-
   if(selectedImageBox){
     selectedImageBox.addEventListener('click', () => {
       const img = selectedImageBox.querySelector('img');
       if(img) openImageModal(img.src);
     });
   }
-
   boardAdjustCleanup = () => {
     window.removeEventListener('resize', updateMetrics);
     window.removeEventListener('load', updateMetrics);


### PR DESCRIPTION
## Summary
- remove the standalone post detail board markup and rely on the inline second column inside post bodies
- update CSS to style the second column directly and drop selectors tied to the removed board
- simplify layout/sticky logic to work with the inline column, updating initPostLayout, adjustBoards, and related helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca634fba6c8331bf21dca7011d398c