### PR TITLE
Fix post layout docking width calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -8424,8 +8424,13 @@ function initPostLayout(board){
     if(document.documentElement && typeof document.documentElement.clientWidth === 'number' && !Number.isNaN(document.documentElement.clientWidth)){
       values.push(document.documentElement.clientWidth);
     }
-    if(board && typeof board.clientWidth === 'number' && board.clientWidth > 0){
-      values.push(board.clientWidth);
+    if(board){
+      const rect = typeof board.getBoundingClientRect === 'function' ? board.getBoundingClientRect() : null;
+      if(rect && rect.width){
+        values.push(rect.width);
+      } else if(typeof board.offsetWidth === 'number' && board.offsetWidth > 0){
+        values.push(board.offsetWidth);
+      }
     }
     return values.length ? Math.min(...values) : 0;
   };


### PR DESCRIPTION
## Summary
- measure the post board width with the bounding rectangle so scrollbar width does not block docking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca791e3d248331b5c25dddb75d5107