### PR TITLE
Limit ad board visibility and streamline post layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,8 +699,8 @@ button[aria-expanded="true"] .results-arrow{
     color:#fff;
   }
 #filterPanel .panel-content{
-  width:440px;
-  max-width:440px;
+  width:100%;
+  max-width:380px;
   background:#222222;
   color:#fff;
   display:flex;
@@ -1675,56 +1675,16 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 @media (max-width:439px){
   .post-board,
   .history-board,
-  .post-mode-boards > .second-post-column.is-visible{
+  .second-post-column.is-visible{
     width:100%;
     max-width:100%;
     min-width:360px;
   }
-  .post-mode-boards > .second-post-column{
+  .second-post-column{
     display:none;
   }
 }
 
-.post-mode-boards > .second-post-column{
-  flex:0 1 560px;
-  width:100%;
-  max-width:560px;
-  overflow-y:auto;
-  overflow-y:overlay;
-  background:rgba(0,0,0,0.7);
-  display:flex;
-  flex-direction:column;
-  gap:0;
-  pointer-events:auto;
-  opacity:0;
-  transform:translateX(20px);
-  transition:transform 0.3s ease, opacity 0.3s ease, max-width 0.3s ease, border-left-width 0.3s ease;
-  border-left:1px solid rgba(255,255,255,0.12);
-  padding:10px 0 10px 10px;
-  box-sizing:border-box;
-  min-width:0;
-  height:100%;
-}
-.post-mode-boards > .second-post-column.is-visible{
-  opacity:1;
-  transform:translateX(0);
-  max-width:560px;
-  flex:0 1 560px;
-  display:flex;
-  margin-left:calc(-1 * var(--gap));
-}
-.post-mode-boards > .second-post-column:not(.is-visible){
-  pointer-events:none;
-  max-width:0;
-  border-left-width:0;
-  flex:0 0 0;
-  margin-left:0;
-}
-.post-mode-boards > .second-post-column .post-details{
-  width:100%;
-  max-width:530px;
-  min-width:0;
-}
 .last-opened-label{
   font-size:12px;
   margin:10px;
@@ -1840,14 +1800,13 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 
 .second-post-column{
   width:100%;
-  max-width:520px;
+  max-width:100%;
   min-width:0;
   padding:0;
   display:flex;
   flex-direction:column;
-  overflow-y:auto;
-  overflow-y:overlay;
-  height:100%;
+  overflow:visible;
+  height:auto;
   margin-top:0;
 }
 
@@ -1880,11 +1839,22 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   z-index:2;
   transform:translateX(0);
   transition:transform 0.3s ease;
+  display:none;
 }
 
 body.hide-ads .ad-board{
   transform:translateX(100%);
   pointer-events:none;
+  display:none;
+}
+
+@media (min-width:1920px){
+  .ad-board{
+    display:block;
+  }
+  body.hide-ads .ad-board{
+    display:none;
+  }
 }
 
 .ad-panel{
@@ -2283,9 +2253,9 @@ body.filters-active #filterBtn{
   width:440px;
 }
 .open-post .post-body > .second-post-column{
-  flex:1 1 0;
-  max-width:530px;
-  width:auto;
+  flex:1 1 100%;
+  max-width:100%;
+  width:100%;
 }
 
 .open-post .post-details{
@@ -2424,23 +2394,23 @@ body.filters-active #filterBtn{
     max-width:100%;
     padding:0;
   }
-  .post-mode-boards > .second-post-column .venue-dropdown,
-  .post-mode-boards > .second-post-column .session-dropdown{
+  .second-post-column .venue-dropdown,
+  .second-post-column .session-dropdown{
     width:100%;
     max-width:100%;
     padding:0;
   }
   .open-post .location-section .map-container,
-  .post-mode-boards > .second-post-column .location-section .map-container,
+  .second-post-column .location-section .map-container,
   .open-post .venue-dropdown,
   .open-post .session-dropdown{
     min-width:250px;
     width:100%;
     max-width:100%;
   }
-  .post-mode-boards > .second-post-column .location-section .map-container,
-  .post-mode-boards > .second-post-column .venue-dropdown,
-  .post-mode-boards > .second-post-column .session-dropdown{
+  .second-post-column .location-section .map-container,
+  .second-post-column .venue-dropdown,
+  .second-post-column .session-dropdown{
     min-width:250px;
     width:100%;
     max-width:100%;
@@ -2476,7 +2446,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .member-avatar-row,
-.post-mode-boards > .second-post-column .member-avatar-row{
+.second-post-column .member-avatar-row{
   display:flex;
   align-items:center;
   height:50px;
@@ -2484,14 +2454,14 @@ body.filters-active #filterBtn{
   margin:0 0 var(--gap);
 }
 .open-post .member-avatar-row img,
-.post-mode-boards > .second-post-column .member-avatar-row img{
+.second-post-column .member-avatar-row img{
   width:50px;
   height:50px;
   object-fit:cover;
 }
 
 .open-post .member-avatar-row span,
-.post-mode-boards > .second-post-column .member-avatar-row span{
+.second-post-column .member-avatar-row span{
   padding-left:10px;
 }
 
@@ -2527,7 +2497,7 @@ body.filters-active #filterBtn{
 
 
 .open-post .location-section,
-.post-mode-boards > .second-post-column .location-section{
+.second-post-column .location-section{
   display:flex;
   flex-wrap:wrap;
   gap:var(--gap);
@@ -2536,8 +2506,8 @@ body.filters-active #filterBtn{
 }
 
   .open-post .location-section .map-container,
-  .post-mode-boards > .second-post-column .location-section .map-container,
-  .post-mode-boards > .second-post-column .location-section .map-container{
+  .second-post-column .location-section .map-container,
+  .second-post-column .location-section .map-container{
   display:flex;
   flex-direction:column;
   gap:var(--gap);
@@ -2548,13 +2518,13 @@ body.filters-active #filterBtn{
   height:auto;
 }
 .open-post .map-container .venue-dropdown,
-.post-mode-boards > .second-post-column .map-container .venue-dropdown{
+.second-post-column .map-container .venue-dropdown{
   width:100%;
 }
 
 .open-post .post-map,
-.post-mode-boards > .second-post-column .post-map,
-.post-mode-boards > .second-post-column .post-map{
+.second-post-column .post-map,
+.second-post-column .post-map{
   flex:0 0 auto;
   width:100%;
   max-width:100%;
@@ -2567,11 +2537,11 @@ body.filters-active #filterBtn{
 
 
 @media (max-width:529px){
-  .post-mode-boards > .second-post-column .location-section .map-container{
+  .second-post-column .location-section .map-container{
     flex:1 1 100%;
     max-width:100%;
   }
-  .post-mode-boards > .second-post-column .post-map{
+  .second-post-column .post-map{
     flex-basis:100%;
     max-width:100%;
   }
@@ -2579,19 +2549,20 @@ body.filters-active #filterBtn{
 
 @media (min-width:530px){
   .open-post .location-section,
-  .post-mode-boards > .second-post-column .location-section{
+  .second-post-column .location-section{
     flex-wrap:nowrap;
   }
   .open-post .location-section .map-container,
   .open-post .location-section .calendar-container,
-  .post-mode-boards > .second-post-column .location-section .map-container,
-  .post-mode-boards > .second-post-column .location-section .calendar-container{
+  .second-post-column .location-section .map-container,
+  .second-post-column .location-section .calendar-container{
     flex:0 0 250px;
     max-width:250px;
     width:250px;
   }
   .open-post .post-body > .second-post-column{
-    flex:0 1 530px;
+    flex:1 1 100%;
+    max-width:100%;
   }
 }
 
@@ -2603,34 +2574,34 @@ body.filters-active #filterBtn{
   width:100%;
   max-width:420px;
 }
-.post-mode-boards > .second-post-column .venue-dropdown,
-.post-mode-boards > .second-post-column .session-dropdown{
+.second-post-column .venue-dropdown,
+.second-post-column .session-dropdown{
   position:relative;
   min-width:250px;
   width:100%;
   max-width:100%;
 }
 .open-post .map-container,
-.post-mode-boards > .second-post-column .map-container{
+.second-post-column .map-container{
   position:relative;
 }
 .open-post .map-container .venue-dropdown,
-.post-mode-boards > .second-post-column .map-container .venue-dropdown{
+.second-post-column .map-container .venue-dropdown{
   position:static;
 }
 .open-post .map-container .venue-menu,
-.post-mode-boards > .second-post-column .map-container .venue-menu{
+.second-post-column .map-container .venue-menu{
   left:0;
   right:0;
   width:auto;
   top:calc(100% - var(--gap) - 40px);
 }
 .open-post .calendar-container .session-dropdown,
-.post-mode-boards > .second-post-column .calendar-container .session-dropdown{
+.second-post-column .calendar-container .session-dropdown{
   position:static;
 }
 .open-post .calendar-container .session-menu,
-.post-mode-boards > .second-post-column .calendar-container .session-menu{
+.second-post-column .calendar-container .session-menu{
   left:0;
   right:0;
   width:auto;
@@ -2638,7 +2609,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .calendar-container .session-dropdown,
-.post-mode-boards > .second-post-column .calendar-container .session-dropdown{
+.second-post-column .calendar-container .session-dropdown{
   margin-top:0;
   width:100%;
 }
@@ -2646,7 +2617,7 @@ body.filters-active #filterBtn{
 
 
 .open-post .venue-dropdown > button,
-.post-mode-boards > .second-post-column .venue-dropdown > button{
+.second-post-column .venue-dropdown > button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2662,7 +2633,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .session-dropdown > button,
-.post-mode-boards > .second-post-column .session-dropdown > button{
+.second-post-column .session-dropdown > button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2678,42 +2649,42 @@ body.filters-active #filterBtn{
 
 
 .open-post .venue-dropdown > button .venue-name,
-.post-mode-boards > .second-post-column .venue-dropdown > button .venue-name{
+.second-post-column .venue-dropdown > button .venue-name{
   font-weight:bold;
   display:block;
 }
 
 .open-post .venue-dropdown > button .venue-address,
-.post-mode-boards > .second-post-column .venue-dropdown > button .venue-address{
+.second-post-column .venue-dropdown > button .venue-address{
   display:block;
 }
 
 .open-post .venue-menu button .venue-name,
-.post-mode-boards > .second-post-column .venue-menu button .venue-name{
+.second-post-column .venue-menu button .venue-name{
   font-weight:bold;
   display:block;
 }
 
 .open-post .venue-menu button .venue-address,
-.post-mode-boards > .second-post-column .venue-menu button .venue-address{
+.second-post-column .venue-menu button .venue-address{
   display:block;
 }
 
 .open-post .venue-dropdown > button .venue-name,
-.post-mode-boards > .second-post-column .venue-dropdown > button .venue-name,
+.second-post-column .venue-dropdown > button .venue-name,
 .open-post .venue-dropdown > button .venue-address,
-.post-mode-boards > .second-post-column .venue-dropdown > button .venue-address,
+.second-post-column .venue-dropdown > button .venue-address,
 .open-post .venue-menu button .venue-name,
-.post-mode-boards > .second-post-column .venue-menu button .venue-name,
+.second-post-column .venue-menu button .venue-name,
 .open-post .venue-menu button .venue-address,
-.post-mode-boards > .second-post-column .venue-menu button .venue-address{
+.second-post-column .venue-menu button .venue-address{
   line-height:1.2;
 }
 
 .open-post .venue-menu,
 .open-post .session-menu,
-.post-mode-boards > .second-post-column .venue-menu,
-.post-mode-boards > .second-post-column .session-menu{
+.second-post-column .venue-menu,
+.second-post-column .session-menu{
   position:absolute;
   top:calc(100% + 4px);
   left:0;
@@ -2736,18 +2707,18 @@ body.filters-active #filterBtn{
 .open-post .session-menu{
   max-width:100%;
 }
-.post-mode-boards > .second-post-column .venue-menu,
-.post-mode-boards > .second-post-column .session-menu{
+.second-post-column .venue-menu,
+.second-post-column .session-menu{
   max-width:100%;
 }
 
 .open-post .venue-menu[hidden],
 .open-post .session-menu[hidden],
-.post-mode-boards > .second-post-column .venue-menu[hidden],
-.post-mode-boards > .second-post-column .session-menu[hidden]{display:none;}
+.second-post-column .venue-menu[hidden],
+.second-post-column .session-menu[hidden]{display:none;}
 
 .open-post .venue-menu button,
-.post-mode-boards > .second-post-column .venue-menu button{
+.second-post-column .venue-menu button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2763,7 +2734,7 @@ body.filters-active #filterBtn{
 }
 
 .open-post .session-menu button,
-.post-mode-boards > .second-post-column .session-menu button{
+.second-post-column .session-menu button{
   height:50px;
   background:var(--btn);
   border:1px solid var(--btn);
@@ -2779,26 +2750,26 @@ body.filters-active #filterBtn{
 
 .open-post .venue-menu button.selected,
 .open-post .session-menu button.selected,
-.post-mode-boards > .second-post-column .venue-menu button.selected,
-.post-mode-boards > .second-post-column .session-menu button.selected{
+.second-post-column .venue-menu button.selected,
+.second-post-column .session-menu button.selected{
   background:var(--dropdown-selected-bg);
   color:var(--dropdown-selected-text);
 }
 
 .open-post .session-menu button .session-time,
-.post-mode-boards > .second-post-column .session-menu button .session-time{
+.second-post-column .session-menu button .session-time{
   margin-left:auto;
   padding-right:20px;
 }
 .open-post .session-dropdown > button .session-time,
-.post-mode-boards > .second-post-column .session-dropdown > button .session-time{
+.second-post-column .session-dropdown > button .session-time{
   margin-left:auto;
   padding-right:20px;
 }
 
 
 .open-post .location-section .calendar-container,
-.post-mode-boards > .second-post-column .location-section .calendar-container{
+.second-post-column .location-section .calendar-container{
     display:flex;
     flex-direction:column;
     gap:var(--gap);
@@ -2812,26 +2783,26 @@ body.filters-active #filterBtn{
     flex:1 1 100%;
     max-width:100%;
   }
-.post-mode-boards > .second-post-column .location-section .calendar-container{
+.second-post-column .location-section .calendar-container{
     flex:1 1 100%;
     max-width:100%;
   }
 .open-post .location-section .options-menu,
-.post-mode-boards > .second-post-column .location-section .options-menu{
+.second-post-column .location-section .options-menu{
   width:100%;
   box-sizing:border-box;
 }
 
 .hide-map-calendar .open-post .map-container,
 .hide-map-calendar .open-post .calendar-container,
-.hide-map-calendar .post-mode-boards > .second-post-column .map-container,
-.hide-map-calendar .post-mode-boards > .second-post-column .calendar-container{
+.hide-map-calendar .second-post-column .map-container,
+.hide-map-calendar .second-post-column .calendar-container{
   display:none;
 }
 
 .open-post .post-calendar,
-.post-mode-boards > .second-post-column .post-calendar,
-.post-mode-boards > .second-post-column .post-calendar{
+.second-post-column .post-calendar,
+.second-post-column .post-calendar{
   position:relative;
   font-size:14px;
   min-width:var(--calendar-width);
@@ -2840,7 +2811,7 @@ body.filters-active #filterBtn{
 
 
 .open-post .calendar-container .calendar-scroll,
-.post-mode-boards > .second-post-column .calendar-container .calendar-scroll{
+.second-post-column .calendar-container .calendar-scroll{
   width:100%;
   height:var(--calendar-height);
   max-height:var(--calendar-height);
@@ -2858,12 +2829,12 @@ body.filters-active #filterBtn{
 .open-post .calendar-container .calendar-scroll{
   max-width:420px;
 }
-.post-mode-boards > .second-post-column .calendar-container .calendar-scroll{
+.second-post-column .calendar-container .calendar-scroll{
   max-width:100%;
 }
 .open-post .post-calendar .calendar,
-.post-mode-boards > .second-post-column .post-calendar .calendar,
-.post-mode-boards > .second-post-column .post-calendar .calendar{
+.second-post-column .post-calendar .calendar,
+.second-post-column .post-calendar .calendar{
   margin:0;
   box-sizing:border-box;
   display:flex;
@@ -2877,8 +2848,8 @@ body.filters-active #filterBtn{
   color:var(--dropdown-text);
 }
 .open-post .post-calendar .month,
-.post-mode-boards > .second-post-column .post-calendar .month,
-.post-mode-boards > .second-post-column .post-calendar .month{
+.second-post-column .post-calendar .month,
+.second-post-column .post-calendar .month{
   flex:0 0 auto;
   width:var(--calendar-width);
   min-width:var(--calendar-width);
@@ -2887,13 +2858,13 @@ body.filters-active #filterBtn{
   flex-direction:column;
 }
 .open-post .post-calendar .month:not(:first-child),
-.post-mode-boards > .second-post-column .post-calendar .month:not(:first-child),
-.post-mode-boards > .second-post-column .post-calendar .month:not(:first-child){
+.second-post-column .post-calendar .month:not(:first-child),
+.second-post-column .post-calendar .month:not(:first-child){
   border-left:1px solid var(--calendar-past-bg);
 }
 .open-post .post-calendar .grid,
-.post-mode-boards > .second-post-column .post-calendar .grid,
-.post-mode-boards > .second-post-column .post-calendar .grid{
+.second-post-column .post-calendar .grid,
+.second-post-column .post-calendar .grid{
   flex:1 1 auto;
   width:100%;
   height:calc(var(--calendar-height) - var(--calendar-header-h));
@@ -2902,8 +2873,8 @@ body.filters-active #filterBtn{
   grid-template-rows:repeat(7,var(--calendar-cell-h));
 }
 .open-post .post-calendar .calendar-header,
-.post-mode-boards > .second-post-column .post-calendar .calendar-header,
-.post-mode-boards > .second-post-column .post-calendar .calendar-header{
+.second-post-column .post-calendar .calendar-header,
+.second-post-column .post-calendar .calendar-header{
   height:var(--calendar-header-h);
   display:flex;
   align-items:center;
@@ -2916,10 +2887,10 @@ body.filters-active #filterBtn{
 }
 .open-post .post-calendar .weekday,
 .open-post .post-calendar .day,
-.post-mode-boards > .second-post-column .post-calendar .weekday,
-.post-mode-boards > .second-post-column .post-calendar .day,
-.post-mode-boards > .second-post-column .post-calendar .weekday,
-.post-mode-boards > .second-post-column .post-calendar .day{
+.second-post-column .post-calendar .weekday,
+.second-post-column .post-calendar .day,
+.second-post-column .post-calendar .weekday,
+.second-post-column .post-calendar .day{
   width:var(--calendar-cell-w);
   height:var(--calendar-cell-h);
   display:flex;
@@ -2928,15 +2899,15 @@ body.filters-active #filterBtn{
   line-height:var(--calendar-cell-h);
 }
 .open-post .post-calendar .weekday,
-.post-mode-boards > .second-post-column .post-calendar .weekday,
-.post-mode-boards > .second-post-column .post-calendar .weekday{
+.second-post-column .post-calendar .weekday,
+.second-post-column .post-calendar .weekday{
   font-size:10px;
   font-weight:bold;
   color:var(--dropdown-text);
 }
 .open-post .post-calendar .day,
-.post-mode-boards > .second-post-column .post-calendar .day,
-.post-mode-boards > .second-post-column .post-calendar .day{
+.second-post-column .post-calendar .day,
+.second-post-column .post-calendar .day{
   cursor:pointer;
   font-size:12px;
   border-radius:8px;
@@ -2945,54 +2916,54 @@ body.filters-active #filterBtn{
   transition:background .2s,color .2s;
 }
 .open-post .post-calendar .day.empty,
-.post-mode-boards > .second-post-column .post-calendar .day.empty,
-.post-mode-boards > .second-post-column .post-calendar .day.empty{
+.second-post-column .post-calendar .day.empty,
+.second-post-column .post-calendar .day.empty{
   cursor:default;
   background:var(--calendar-future-bg);
   color:var(--dropdown-text);
   opacity:0.6;
 }
 .open-post .post-calendar .day.available-day,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day{
+.second-post-column .post-calendar .day.available-day,
+.second-post-column .post-calendar .day.available-day{
   background:var(--session-available);
   color:#fff;
 }
 .open-post .post-calendar .day.available-day:hover,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day:hover,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day:hover{
+.second-post-column .post-calendar .day.available-day:hover,
+.second-post-column .post-calendar .day.available-day:hover{
   background:var(--session-available);
   color:#fff;
 }
 .open-post .post-calendar .day.selected,
-.post-mode-boards > .second-post-column .post-calendar .day.selected,
-.post-mode-boards > .second-post-column .post-calendar .day.selected{
+.second-post-column .post-calendar .day.selected,
+.second-post-column .post-calendar .day.selected{
   background:var(--session-selected);
   color:#fff;
 }
 .open-post .post-calendar .day.selected:hover,
-.post-mode-boards > .second-post-column .post-calendar .day.selected:hover,
-.post-mode-boards > .second-post-column .post-calendar .day.selected:hover{
+.second-post-column .post-calendar .day.selected:hover,
+.second-post-column .post-calendar .day.selected:hover{
   background:var(--session-selected);
   color:#fff;
 }
 .open-post .post-calendar .day.today,
-.post-mode-boards > .second-post-column .post-calendar .day.today,
-.post-mode-boards > .second-post-column .post-calendar .day.today{color:var(--today) !important;}
+.second-post-column .post-calendar .day.today,
+.second-post-column .post-calendar .day.today{color:var(--today) !important;}
 .open-post .post-calendar .day.available-day.today,
 .open-post .post-calendar .day.available-day.selected.today,
 .open-post .post-calendar .day.selected.today,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day.today,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day.selected.today,
-.post-mode-boards > .second-post-column .post-calendar .day.selected.today,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day.today,
-.post-mode-boards > .second-post-column .post-calendar .day.available-day.selected.today,
-.post-mode-boards > .second-post-column .post-calendar .day.selected.today{color:var(--today) !important;}
+.second-post-column .post-calendar .day.available-day.today,
+.second-post-column .post-calendar .day.available-day.selected.today,
+.second-post-column .post-calendar .day.selected.today,
+.second-post-column .post-calendar .day.available-day.today,
+.second-post-column .post-calendar .day.available-day.selected.today,
+.second-post-column .post-calendar .day.selected.today{color:var(--today) !important;}
 
 
 .open-post .post-calendar .selected-month-name,
-.post-mode-boards > .second-post-column .post-calendar .selected-month-name,
-.post-mode-boards > .second-post-column .post-calendar .selected-month-name{
+.second-post-column .post-calendar .selected-month-name,
+.second-post-column .post-calendar .selected-month-name{
   background:var(--accent);
   color:var(--button-hover-text);
   border-radius:8px;
@@ -3000,13 +2971,13 @@ body.filters-active #filterBtn{
 }
 
 .open-post .calendar-container .time-popup,
-.post-mode-boards > .second-post-column .calendar-container .time-popup{
+.second-post-column .calendar-container .time-popup{
   position:absolute;
   z-index:10;
 }
 
 .open-post .calendar-container .time-popup .time-list,
-.post-mode-boards > .second-post-column .calendar-container .time-popup .time-list{
+.second-post-column .calendar-container .time-popup .time-list{
   background:var(--dropdown-bg);
   color:var(--dropdown-text);
   padding:8px;
@@ -3017,7 +2988,7 @@ body.filters-active #filterBtn{
    }
 
 .open-post .calendar-container .time-popup .time-list button,
-.post-mode-boards > .second-post-column .calendar-container .time-popup .time-list button{
+.second-post-column .calendar-container .time-popup .time-list button{
   background:var(--btn);
   border:1px solid var(--btn);
   color:var(--button-text);
@@ -3028,15 +2999,15 @@ body.filters-active #filterBtn{
 
 .open-post .venue-info,
 .open-post .session-info,
-.post-mode-boards > .second-post-column .venue-info,
-.post-mode-boards > .second-post-column .session-info{
+.second-post-column .venue-info,
+.second-post-column .session-info{
   color: inherit;
   font-size: inherit;
 }
 .open-post .venue-info,
-.post-mode-boards > .second-post-column .venue-info{margin-top:4px;}
+.second-post-column .venue-info{margin-top:4px;}
 .open-post .session-info,
-.post-mode-boards > .second-post-column .session-info{margin-top:8px;}
+.second-post-column .session-info{margin-top:8px;}
 
 
 
@@ -3123,7 +3094,7 @@ body.filters-active #filterBtn{
     width:100%;
   }
   .open-post .location-section,
-  .post-mode-boards > .second-post-column .location-section{
+  .second-post-column .location-section{
     flex-wrap:wrap;
   }
   .open-post .location-section .map-container,
@@ -3133,7 +3104,7 @@ body.filters-active #filterBtn{
     width:100%;
   }
   .open-post .post-details .location-section,
-  .post-mode-boards > .second-post-column .post-details .location-section{
+  .second-post-column .post-details .location-section{
     order:-1;
   }
   .open-post .image-box{
@@ -3145,8 +3116,8 @@ body.filters-active #filterBtn{
   }
   .open-post .venue-dropdown,
   .open-post .session-dropdown,
-  .post-mode-boards > .second-post-column .venue-dropdown,
-  .post-mode-boards > .second-post-column .session-dropdown{
+  .second-post-column .venue-dropdown,
+  .second-post-column .session-dropdown{
     display:block;
   }
 }
@@ -3588,9 +3559,7 @@ img.thumb{
     border-radius:0;
     padding-bottom:10px;
   }
-  #filterPanel .panel-content .resizer,
-  #filterPanel .panel-actions .move-left,
-  #filterPanel .panel-actions .move-right{
+  #filterPanel .panel-content .resizer{
     display:none;
   }
 }
@@ -3728,31 +3697,6 @@ img.thumb{
     <section class="history-board quick-list-board" id="historyBoard" aria-label="History Board">
     </section>
     <section class="post-board" aria-label="Post Board">
-      <div class="post-header"></div>
-      <div class="post-body">
-        <div class="second-post-column">
-          <div class="post-header column-post-header"></div>
-          <div class="post-details">
-            <div class="post-details-member-container">
-              <div class="member-avatar-row"></div>
-            </div>
-            <div class="post-venue-selection-container"></div>
-            <div class="post-session-selection-container"></div>
-            <div class="location-section">
-              <div class="map-container"></div>
-              <div class="calendar-container"></div>
-            </div>
-            <div class="post-details-info-container"></div>
-            <div class="post-details-description-container">
-              <div class="desc-wrap"><div class="desc" tabindex="0" role="button" aria-expanded="false"></div></div>
-            </div>
-          </div>
-          <div class="post-images">
-            <div class="selected-image"></div>
-            <div class="thumbnail-row"></div>
-          </div>
-        </div>
-      </div>
     </section>
     <section class="ad-board" aria-label="Ad Board">
       <div class="ad-panel">
@@ -3767,8 +3711,6 @@ img.thumb{
         <div class="header-top">
           <h2>Filters</h2>
           <div class="panel-actions">
-            <button type="button" class="move-left" aria-label="Move panel left">&lt;</button>
-            <button type="button" class="move-right" aria-label="Move panel right">&gt;</button>
             <button type="button" class="pin-panel" aria-pressed="true" aria-label="Pin filter panel">📌</button>
             <button type="button" class="close-panel">Close</button>
           </div>
@@ -4435,117 +4377,27 @@ img.thumb{
       const footerH = parseFloat(rootStyles.getPropertyValue('--footer-h')) || 0;
       const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
       const availableHeight = window.innerHeight - headerH - subH - footerH - safeTop;
-      document.querySelectorAll('.history-board, .posts, .post-mode-boards > .second-post-column').forEach(list=>{
+      document.querySelectorAll('.history-board, .posts').forEach(list=>{
         list.style.maxHeight = `${availableHeight}px`;
       });
     }
     window.adjustListHeight = adjustListHeight;
 
     let stickyScrollHandler = null;
-    let venueDropdownEl = null;
-    let sessionDropdownEl = null;
-    let venueDropdownParent = null;
-    let sessionDropdownParent = null;
       function updateStickyImages(){
         const root = document.documentElement;
-        const body = document.querySelector('.open-post .post-body');
-        if(!venueDropdownEl || !document.contains(venueDropdownEl)){
-          const vd = document.querySelector('.venue-dropdown');
-          venueDropdownEl = vd || null;
-        }
-        if(!sessionDropdownEl || !document.contains(sessionDropdownEl)){
-          const sd = document.querySelector('.session-dropdown');
-          sessionDropdownEl = sd || null;
-        }
-        if(venueDropdownEl){
-          const currentParent = venueDropdownEl.parentElement;
-          const currentInDom = currentParent && document.contains(currentParent);
-          const isDetailSlot = currentParent && currentParent.classList.contains('post-venue-selection-container');
-          if(currentInDom && !isDetailSlot){
-            venueDropdownEl._homeParent = currentParent;
-          }
-          if(venueDropdownEl._homeParent && !document.contains(venueDropdownEl._homeParent)){
-            venueDropdownEl._homeParent = null;
-          }
-          if(!venueDropdownEl._homeParent && venueDropdownEl.id){
-            const suffix = venueDropdownEl.id.replace(/^venue-/, '');
-            if(suffix){
-              const mapEl = document.getElementById(`map-${suffix}`);
-              if(mapEl && mapEl.parentElement && document.contains(mapEl.parentElement)){
-                venueDropdownEl._homeParent = mapEl.parentElement;
-              }
-            }
-          }
-          if(venueDropdownEl._homeParent && document.contains(venueDropdownEl._homeParent)){
-            venueDropdownParent = venueDropdownEl._homeParent;
-          } else if(currentInDom && !isDetailSlot){
-            venueDropdownParent = currentParent;
-          } else if(venueDropdownParent && !document.contains(venueDropdownParent)){
-            venueDropdownParent = null;
-          }
-        } else {
-          venueDropdownParent = null;
-        }
-        if(sessionDropdownEl){
-          const currentParent = sessionDropdownEl.parentElement;
-          const currentInDom = currentParent && document.contains(currentParent);
-          const isDetailSlot = currentParent && currentParent.classList.contains('post-session-selection-container');
-          if(currentInDom && !isDetailSlot){
-            sessionDropdownEl._homeParent = currentParent;
-          }
-          if(sessionDropdownEl._homeParent && !document.contains(sessionDropdownEl._homeParent)){
-            sessionDropdownEl._homeParent = null;
-          }
-          if(!sessionDropdownEl._homeParent && sessionDropdownEl.id){
-            const suffix = sessionDropdownEl.id.replace(/^sess-/, '');
-            if(suffix){
-              const calEl = document.getElementById(`cal-${suffix}`);
-              const container = calEl ? calEl.closest('.calendar-container') : null;
-              if(container && document.contains(container)){
-                sessionDropdownEl._homeParent = container;
-              }
-            }
-          }
-          if(sessionDropdownEl._homeParent && document.contains(sessionDropdownEl._homeParent)){
-            sessionDropdownParent = sessionDropdownEl._homeParent;
-          } else if(currentInDom && !isDetailSlot){
-            sessionDropdownParent = currentParent;
-          } else if(sessionDropdownParent && !document.contains(sessionDropdownParent)){
-            sessionDropdownParent = null;
-          }
-        } else {
-          sessionDropdownParent = null;
-        }
+        const openPost = document.querySelector('.post-board .open-post');
+        const body = openPost ? openPost.querySelector('.post-body') : null;
         const imgArea = body ? body.querySelector('.post-images') : null;
-        const header = document.querySelector('.open-post .post-header');
-        const board = document.querySelector('.post-board');
-        const detailColumn = document.querySelector('.post-mode-boards > .second-post-column');
-        const venueContainer = detailColumn ? detailColumn.querySelector('.post-venue-selection-container') : null;
-        const sessionContainer = detailColumn ? detailColumn.querySelector('.post-session-selection-container') : null;
-        const detailColumnMounted = !!(detailColumn && document.contains(detailColumn));
-        const detailVisible = !!(detailColumn && detailColumn.classList.contains('is-visible') && detailColumnMounted);
-        root.classList.toggle('hide-map-calendar', !detailVisible);
-        if(venueDropdownEl){
-          if(venueContainer && document.contains(venueContainer) && venueDropdownEl.parentElement !== venueContainer){
-            venueContainer.appendChild(venueDropdownEl);
-          } else if(venueDropdownParent && document.contains(venueDropdownParent) && venueDropdownEl.parentElement !== venueDropdownParent){
-            venueDropdownParent.appendChild(venueDropdownEl);
-          }
-        }
-        if(sessionDropdownEl){
-          if(sessionContainer && document.contains(sessionContainer) && sessionDropdownEl.parentElement !== sessionContainer){
-            sessionContainer.appendChild(sessionDropdownEl);
-          } else if(sessionDropdownParent && document.contains(sessionDropdownParent) && sessionDropdownEl.parentElement !== sessionDropdownParent){
-            sessionDropdownParent.appendChild(sessionDropdownEl);
-          }
-        }
-        if(!body || !imgArea || !header || !board || !detailVisible){
-          root.classList.remove('open-post-sticky-images');
-          document.documentElement.style.removeProperty('--open-post-header-h');
+        const header = openPost ? openPost.querySelector('.post-header') : null;
+        document.body.classList.remove('hide-map-calendar');
+        if(!openPost || !body || !imgArea || !header){
+          document.body.classList.remove('open-post-sticky-images');
+          root.style.removeProperty('--open-post-header-h');
           return;
         }
-        document.documentElement.style.setProperty('--open-post-header-h', header.offsetHeight + 'px');
-        root.classList.add('open-post-sticky-images');
+        root.style.setProperty('--open-post-header-h', header.offsetHeight + 'px');
+        document.body.classList.add('open-post-sticky-images');
       }
 
     window.updateStickyImages = updateStickyImages;
@@ -5586,35 +5438,23 @@ function makePosts(){
         const filterPinned = !!(filterPanel && filterPanel.classList.contains('show') && pinBtn && pinBtn.getAttribute('aria-pressed') === 'true');
         const historyOpenPost = historyBoard ? historyBoard.querySelector('.open-post') : null;
         const postsOpenPost = postBoard ? postBoard.querySelector('.open-post') : null;
-        const activeOpenPost = historyActive ? (historyOpenPost || postsOpenPost) : (postsOpenPost || historyOpenPost);
-        const activeOpenId = activeOpenPost && activeOpenPost.dataset ? activeOpenPost.dataset.id : null;
         const anyOpenPost = historyOpenPost || postsOpenPost;
-        const anyOpenId = anyOpenPost && anyOpenPost.dataset ? anyOpenPost.dataset.id : null;
-        const detailColumn = document.querySelector('.post-mode-boards > .second-post-column');
-        const columnId = detailColumn && detailColumn.dataset ? detailColumn.dataset.openPostId || '' : '';
-        const detailMatchesActive = !!(detailColumn && activeOpenId && columnId === activeOpenId);
-        const detailMatchesAny = !!(detailColumn && anyOpenId && columnId === anyOpenId);
-        const detailVisible = !!(detailColumn && detailColumn.classList.contains('is-visible') && detailMatchesActive);
         const gap = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--gap')) || 10;
         let filterWidth = filterPinned && filterContent ? filterContent.getBoundingClientRect().width : 0;
         const postWidth = postBoard ? (postBoard.offsetWidth || 440) : 0;
         const historyWidth = historyBoard ? (historyBoard.offsetWidth || 440) : 0;
-        const detailWidth = detailColumn && detailMatchesAny ? (detailColumn.offsetWidth || 560) : 0;
         const boardsWidths = [];
         if(historyActive && historyBoard){
           boardsWidths.push(historyWidth);
         } else if(postBoard){
           boardsWidths.push(postWidth);
         }
-        if(detailVisible){
-          boardsWidths.push(detailWidth);
-        }
         let totalBoardsWidth = boardsWidths.reduce((sum, w)=> sum + w, 0);
         if(boardsWidths.length > 1){
           totalBoardsWidth += gap * (boardsWidths.length - 1);
         }
         const adWidth = adBoard ? (adBoard.offsetWidth || 440) : 0;
-        let hideAds = small || document.body.classList.contains('mode-map') || document.body.classList.contains('hide-posts-ui');
+        let hideAds = small || document.body.classList.contains('mode-map') || document.body.classList.contains('hide-posts-ui') || window.innerWidth < 1920;
         let requiredWidth = totalBoardsWidth;
         if(filterPinned && filterWidth){
           requiredWidth += filterWidth + gap;
@@ -5640,16 +5480,7 @@ function makePosts(){
           postBoard.style.display = historyActive ? 'none' : '';
           postBoard.setAttribute('aria-hidden', historyActive ? 'true' : 'false');
         }
-        if(detailColumn){
-          if(detailMatchesActive && !detailColumn.classList.contains('is-visible')){
-            detailColumn.classList.add('is-visible');
-          } else if(!detailVisible && !detailMatchesAny){
-            detailColumn.classList.remove('is-visible');
-            if(detailColumn.dataset) delete detailColumn.dataset.openPostId;
-            if(typeof updateStickyImages === 'function') updateStickyImages();
-          }
-        }
-        document.body.classList.toggle('detail-open', detailVisible || detailMatchesAny);
+        document.body.classList.toggle('detail-open', !!anyOpenPost);
         if(hideAds || !adBoard){
           document.body.classList.add('hide-ads');
         } else {
@@ -6813,7 +6644,7 @@ function makePosts(){
       wrap.querySelectorAll('.post-header').forEach(head => {
         head.style.background = 'linear-gradient(rgba(0,0,0,0.8),rgba(0,0,0,0.6))';
       });
-      wrap.style.background = 'linear-gradient(rgba(0,0,0,0.8),rgba(0,0,0,0.8))';
+      wrap.style.background = '#555555';
         // progressive hero swap
         (function(){
           const img = wrap.querySelector('#hero-img');
@@ -6926,10 +6757,7 @@ function makePosts(){
         target.replaceWith(detail);
         hookDetailActions(detail, p);
         if (typeof updateStickyImages === 'function') {
-          const mountedDetailColumn = document.querySelector('.post-mode-boards > .second-post-column');
-          if(mountedDetailColumn){
-            updateStickyImages();
-          }
+          updateStickyImages();
         }
         if (typeof initPostLayout === 'function') {
           initPostLayout(container);
@@ -8036,8 +7864,9 @@ document.addEventListener('pointerdown', handleDocInteract);
   document.querySelectorAll('.panel').forEach(panel=>{
     const content = panel.querySelector('.panel-content');
     if(content){
-      content.style.width = '440px';
-      content.style.maxWidth = '440px';
+      const defaultWidth = panel.id === 'filterPanel' ? '380px' : '440px';
+      content.style.width = defaultWidth;
+      content.style.maxWidth = defaultWidth;
       content.style.top = 'var(--header-h)';
       content.style.bottom = 'var(--footer-h)';
       content.style.height = 'calc(100vh - var(--header-h) - var(--footer-h))';
@@ -8645,257 +8474,54 @@ document.addEventListener('DOMContentLoaded', () => {
 let boardAdjustCleanup = null;
 
 function initPostLayout(board){
-  if(boardAdjustCleanup){ boardAdjustCleanup(); boardAdjustCleanup = null; }
-  const boardsContainer = document.querySelector('.post-mode-boards');
-  const adBoard = document.querySelector('.ad-board');
-  const openPost = (board && board.querySelector('.open-post')) || document.querySelector('.post-board .open-post, #historyBoard .open-post');
-  const getAvailableWidth = () => {
-    const values = [];
-    if(typeof window !== 'undefined' && typeof window.innerWidth === 'number' && !Number.isNaN(window.innerWidth)){
-      values.push(window.innerWidth);
-    }
-    if(document.documentElement && typeof document.documentElement.clientWidth === 'number' && !Number.isNaN(document.documentElement.clientWidth)){
-      values.push(document.documentElement.clientWidth);
-    }
-    if(board){
-      const rect = typeof board.getBoundingClientRect === 'function' ? board.getBoundingClientRect() : null;
-      if(rect && rect.width){
-        values.push(rect.width);
-      } else if(typeof board.offsetWidth === 'number' && board.offsetWidth > 0){
-        values.push(board.offsetWidth);
-      }
-    }
-    return values.length ? Math.min(...values) : 0;
-  };
-  const postsUIActive = () => document.body.classList.contains('mode-posts') && !document.body.classList.contains('hide-posts-ui');
+  if(typeof boardAdjustCleanup === 'function'){
+    boardAdjustCleanup();
+    boardAdjustCleanup = null;
+  }
   const scheduleMapResize = mapInstance => {
-    if(!mapInstance || typeof mapInstance.resize !== 'function') return;
-    if(typeof requestAnimationFrame === 'function'){
-      requestAnimationFrame(() => mapInstance.resize());
-    } else {
-      setTimeout(() => mapInstance.resize(), 0);
+    if(!mapInstance) return;
+    if(typeof mapInstance.resize === 'function'){
+      requestAnimationFrame(()=>{
+        try { mapInstance.resize(); } catch(err){}
+      });
     }
   };
+  if(!(board instanceof Element)){
+    document.documentElement.style.removeProperty('--post-header-h');
+    if(typeof window.adjustBoards === 'function') window.adjustBoards();
+    return;
+  }
+  const openPost = board.querySelector('.open-post');
+  if(!openPost){
+    document.body.classList.remove('detail-open');
+    document.body.classList.remove('hide-map-calendar');
+    document.documentElement.style.removeProperty('--post-header-h');
+    if(typeof window.adjustBoards === 'function') window.adjustBoards();
+    return;
+  }
+  document.body.classList.add('detail-open');
+  document.body.classList.remove('hide-map-calendar');
+  const postBody = openPost.querySelector('.post-body');
+  const secondCol = postBody ? postBody.querySelector('.second-post-column') : null;
+  if(secondCol){
+    secondCol.removeAttribute('hidden');
+    secondCol.classList.remove('is-visible');
+    if(secondCol.dataset) delete secondCol.dataset.openPostId;
+  }
   const triggerDetailMapResize = target => {
     if(!target) return;
-    const mapNode = typeof target.querySelector === 'function' ? target.querySelector('.post-map') : null;
+    const mapNode = target.querySelector ? target.querySelector('.post-map') : null;
     const ref = target._detailMap || (mapNode && mapNode._detailMap) || null;
     const mapInstance = ref && ref.map;
     if(mapInstance && typeof mapInstance.resize === 'function'){
       scheduleMapResize(mapInstance);
     }
   };
-  const clearPreservedHeight = target => {
-    if(target){
-      target.style.removeProperty('--second-post-height');
-      target.style.removeProperty('min-height');
-      if(target.dataset) delete target.dataset.secondPostHeight;
-    }
-  };
-  const applyPreservedHeight = (target, height) => {
-    if(!target) return;
-    if(height){
-      target.style.setProperty('--second-post-height', height + 'px');
-      target.style.minHeight = height + 'px';
-      if(target.dataset) target.dataset.secondPostHeight = height;
-    } else {
-      clearPreservedHeight(target);
-    }
-  };
-  document.querySelectorAll('.second-post-placeholder').forEach(node => {
-    const parentBody = node.parentElement;
-    if(parentBody) clearPreservedHeight(parentBody);
-    node.remove();
-  });
-  const getMountedColumn = () => {
-    if(!boardsContainer) return null;
-    return Array.from(boardsContainer.children).find(node => node.classList && node.classList.contains('second-post-column')) || null;
-  };
-  let mountedColumn = getMountedColumn();
-  if(!boardsContainer){
-    document.documentElement.style.removeProperty('--post-header-h');
-    if(!openPost){
-      document.body.classList.remove('detail-open');
-    }
-    if(openPost){
-      const body = openPost.querySelector('.post-body');
-      if(body) clearPreservedHeight(body);
-    }
-    if(mountedColumn){
-      mountedColumn.classList.remove('is-visible');
-      if(mountedColumn.dataset) delete mountedColumn.dataset.openPostId;
-      mountedColumn.remove();
-      mountedColumn = null;
-    }
-    if(typeof window.adjustBoards === 'function') window.adjustBoards();
-    return;
-  }
-  if(!openPost){
-    if(mountedColumn){
-      mountedColumn.classList.remove('is-visible');
-      if(mountedColumn.dataset) delete mountedColumn.dataset.openPostId;
-      mountedColumn.remove();
-      mountedColumn = null;
-    }
-    document.body.classList.remove('detail-open');
-    document.documentElement.style.removeProperty('--post-header-h');
-    if(board){
-      board.querySelectorAll('.post-body').forEach(clearPreservedHeight);
-    }
-    if(typeof window.adjustBoards === 'function') window.adjustBoards();
-    return;
-  }
-  const postBody = openPost ? openPost.querySelector('.post-body') : null;
-  const postHeader = openPost ? Array.from(openPost.children).find(node => node.classList && node.classList.contains('post-header')) : null;
-  const postImages = postBody ? postBody.querySelector('.post-images') : null;
-  const openPostId = openPost && openPost.dataset ? (openPost.dataset.id || '') : '';
-  let secondCol = openPost ? openPost.querySelector('.second-post-column') : null;
-  if(!secondCol && mountedColumn){
-    const mountedId = mountedColumn.dataset ? mountedColumn.dataset.openPostId || '' : '';
-    if(mountedId === openPostId){
-      secondCol = mountedColumn;
-    }
-  }
-  if(mountedColumn && secondCol !== mountedColumn){
-    mountedColumn.classList.remove('is-visible');
-    if(mountedColumn.dataset) delete mountedColumn.dataset.openPostId;
-    mountedColumn.remove();
-    mountedColumn = null;
-  }
+  triggerDetailMapResize(secondCol);
   const thumbRow = postBody ? postBody.querySelector('.thumbnail-row') : null;
-  const selectedImageBox = postImages ? postImages.querySelector('.selected-image, .image-box') : null;
+  const selectedImageBox = postBody ? postBody.querySelector('.selected-image, .image-box') : null;
   const imageModalContainer = document.querySelector('.image-modal-container');
   const imageModal = imageModalContainer ? imageModalContainer.querySelector('.image-modal') : null;
-  const availableWidth = getAvailableWidth();
-  const activePostsUI = postsUIActive();
-  const canRender = Boolean(secondCol && activePostsUI && availableWidth >= 440);
-  const shouldDock = Boolean(canRender && boardsContainer);
-  const isDocked = Boolean(secondCol && boardsContainer && secondCol.parentElement === boardsContainer);
-  if(!canRender){
-    if(secondCol){
-      if(postBody && secondCol.parentElement !== postBody){
-        postBody.appendChild(secondCol);
-      }
-      if(!secondCol.hasAttribute('hidden')){
-        secondCol.setAttribute('hidden', '');
-      }
-      secondCol.classList.remove('is-visible');
-      if(secondCol.dataset) delete secondCol.dataset.openPostId;
-    }
-    document.body.classList.remove('detail-open');
-    triggerDetailMapResize(secondCol);
-  } else if(shouldDock && secondCol){
-    if(secondCol.hasAttribute('hidden')){
-      secondCol.removeAttribute('hidden');
-    }
-    if(!isDocked){
-      const referenceNode = adBoard && adBoard.parentElement === boardsContainer ? adBoard : null;
-      if(referenceNode){
-        boardsContainer.insertBefore(secondCol, referenceNode);
-      } else {
-        boardsContainer.appendChild(secondCol);
-      }
-    }
-    if(secondCol.dataset) secondCol.dataset.openPostId = openPostId;
-    if(!secondCol.classList.contains('is-visible')){
-      secondCol.classList.add('is-visible');
-    }
-    if(!document.body.classList.contains('detail-open')){
-      document.body.classList.add('detail-open');
-    }
-    triggerDetailMapResize(secondCol);
-  } else {
-    if(secondCol){
-      if(postBody && secondCol.parentElement !== postBody){
-        postBody.appendChild(secondCol);
-      }
-      if(secondCol.hasAttribute('hidden')){
-        secondCol.removeAttribute('hidden');
-      }
-      if(secondCol.classList.contains('is-visible')){
-        secondCol.classList.remove('is-visible');
-      }
-      if(secondCol.dataset) delete secondCol.dataset.openPostId;
-    }
-    document.body.classList.remove('detail-open');
-    triggerDetailMapResize(secondCol);
-  }
-
-  function updatePreservedHeight(){
-    if(!postBody){
-      return;
-    }
-    if(!(secondCol && secondCol.parentElement === postBody && !secondCol.hasAttribute('hidden'))){
-      clearPreservedHeight(postBody);
-      return;
-    }
-    const height = secondCol.offsetHeight;
-    if(height){
-      applyPreservedHeight(postBody, height);
-      return;
-    }
-    const storedHeight = postBody.dataset ? postBody.dataset.secondPostHeight : null;
-    if(storedHeight){
-      const parsed = parseFloat(storedHeight);
-      if(!Number.isNaN(parsed)){
-        applyPreservedHeight(postBody, parsed);
-        return;
-      }
-    }
-    clearPreservedHeight(postBody);
-  }
-
-  function updateMetrics(){
-    const widthNow = getAvailableWidth();
-    const activeNow = postsUIActive();
-    const canRenderNow = Boolean(secondCol && activeNow && widthNow >= 440);
-    const dockNow = Boolean(canRenderNow && boardsContainer);
-    const currentlyDocked = Boolean(secondCol && boardsContainer && secondCol.parentElement === boardsContainer);
-    const currentlyHidden = Boolean(secondCol && secondCol.hasAttribute('hidden'));
-    if(!canRenderNow){
-      if(currentlyDocked || !currentlyHidden){
-        initPostLayout(board);
-        return;
-      }
-    } else {
-      if(currentlyHidden || dockNow !== currentlyDocked){
-        initPostLayout(board);
-        return;
-      }
-    }
-    if(postHeader){
-      document.documentElement.style.setProperty('--post-header-h', postHeader.offsetHeight + 'px');
-    } else {
-      document.documentElement.style.removeProperty('--post-header-h');
-    }
-    updatePreservedHeight();
-    if(typeof window.adjustBoards === 'function') window.adjustBoards();
-  }
-
-  let bodyClassObserver = null;
-  if(typeof MutationObserver === 'function'){
-    bodyClassObserver = new MutationObserver(records => {
-      for(const record of records){
-        if(record.attributeName !== 'class') continue;
-        const oldVal = record.oldValue || '';
-        const oldClasses = new Set(oldVal.split(/\s+/).filter(Boolean));
-        const newClasses = new Set((document.body.className || '').split(/\s+/).filter(Boolean));
-        const relevant = ['mode-posts','mode-map','hide-posts-ui'];
-        const changed = relevant.some(cls => oldClasses.has(cls) !== newClasses.has(cls));
-        if(changed){
-          updateMetrics();
-          break;
-        }
-      }
-    });
-    bodyClassObserver.observe(document.body, {attributes:true, attributeFilter:['class'], attributeOldValue:true});
-  }
-
-  updatePreservedHeight();
-  updateMetrics();
-  window.addEventListener('resize', updateMetrics);
-  window.addEventListener('load', updateMetrics);
-
   function openImageModal(src){
     if(!imageModalContainer || !imageModal) return;
     imageModal.innerHTML='';
@@ -8904,7 +8530,6 @@ function initPostLayout(board){
     imageModal.appendChild(img);
     imageModalContainer.classList.remove('hidden');
   }
-
   if(imageModalContainer && !imageModalContainer._listenerAdded){
     imageModalContainer.addEventListener('click', e => {
       if(e.target === imageModalContainer){
@@ -8914,28 +8539,44 @@ function initPostLayout(board){
     });
     imageModalContainer._listenerAdded = true;
   }
-
-  if(thumbRow){
+  if(thumbRow && !thumbRow._imageModalListener){
     thumbRow.addEventListener('dblclick', e => {
       const img = e.target.closest('img');
       if(img) openImageModal(img.src);
     });
+    thumbRow._imageModalListener = true;
   }
-
-  if(selectedImageBox){
+  if(selectedImageBox && !selectedImageBox._imageModalListener){
     selectedImageBox.addEventListener('click', () => {
       const img = selectedImageBox.querySelector('img');
       if(img) openImageModal(img.src);
     });
+    selectedImageBox._imageModalListener = true;
   }
-
+  if(typeof updateStickyImages === 'function'){
+    updateStickyImages();
+  }
+  const updateMetrics = () => {
+    if(typeof updateStickyImages === 'function'){
+      updateStickyImages();
+    }
+    if(openPost){
+      const header = openPost.querySelector('.post-header');
+      if(header){
+        document.documentElement.style.setProperty('--post-header-h', header.offsetHeight + 'px');
+      } else {
+        document.documentElement.style.removeProperty('--post-header-h');
+      }
+    }
+    triggerDetailMapResize(secondCol);
+    if(typeof window.adjustBoards === 'function') window.adjustBoards();
+  };
+  updateMetrics();
+  window.addEventListener('resize', updateMetrics);
+  window.addEventListener('load', updateMetrics);
   boardAdjustCleanup = () => {
     window.removeEventListener('resize', updateMetrics);
     window.removeEventListener('load', updateMetrics);
-    if(bodyClassObserver){
-      bodyClassObserver.disconnect();
-      bodyClassObserver = null;
-    }
   };
 }
 


### PR DESCRIPTION
## Summary
- hide the ad board by default and only reveal it on viewports that are at least 1920px wide
- pin the filter panel to the left with a 380px max width on large screens and remove its lateral navigation controls
- remove the detached second-column scaffold so post details render inline with the board and apply the solid #555555 background to open posts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9de4f4bc833182a460dc809147f6