### PR TITLE
Ensure cluster count stays above cluster layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -6380,7 +6380,7 @@ function makePosts(){
               paint:{}
             });
         }
-      ['hover-fill','hover-ring','cluster-count','clusters','unclustered'].forEach(id=>{
+      ['hover-fill','hover-ring','clusters','cluster-count','unclustered'].forEach(id=>{
         if(map.getLayer(id)){
           try{ map.moveLayer(id); }catch(e){}
         }


### PR DESCRIPTION
## Summary
- reorder the layer reattachment sequence in addPostSource so the cluster count text layer is moved after the cluster layer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd2e553b08331bfbd9908ed9939db