### PR TITLE
Update popup styling and ensure square imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -852,7 +852,7 @@ button[aria-expanded="true"] .results-arrow{
   position:absolute;
   width:600px;
   max-width:600px;
-  background:rgba(0,0,0,0.7);
+  background:none;
   border-radius:0;
   display:flex;
   flex-direction:column;
@@ -2016,7 +2016,7 @@ body.hide-ads .ad-board{
   display:none;
 }
 
-@media (min-width:1920px){
+@media (min-width:1900px){
   .ad-board{
     display:block;
   }
@@ -2691,7 +2691,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   .open-post .image-box img{
     width:100%;
     height:100%;
-    object-fit:contain;
+    object-fit:cover;
     object-position:center;
   }
   .open-post .thumbnail-row{
@@ -3401,7 +3401,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     .open-post .image-box img{
       width:100%;
       height:100%;
-      object-fit:contain;
+      object-fit:cover;
       margin-left:0;
       margin-right:0;
     }
@@ -3654,7 +3654,9 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   object-fit: cover;
   display: block;
   background: var(--panel-bg);
-  flex: 0 0 auto;
+  flex: 0 0 64px;
+  min-width: 64px;
+  min-height: 64px;
 }
 
 .multi-item.map-card .t{
@@ -3678,11 +3680,12 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .mapboxgl-popup,
 .mapboxgl-popup-content{
   border-radius:8px !important;
-  color: var(--popup-text) !important;
 }
 
 .mapboxgl-popup-content{
   background: var(--popup-bg) !important;
+  color: var(--popup-text) !important;
+  overflow:hidden;
 }
 
 .mapboxgl-popup-close-button{
@@ -3852,7 +3855,7 @@ img.thumb{
   .open-post .image-box img{
     width:100%;
     height:100%;
-    object-fit:contain;
+    object-fit:cover;
   }
   .second-post-column{
     width:100%;


### PR DESCRIPTION
## Summary
- remove the welcome modal panel background fill while keeping layout intact
- ensure image containers and map card thumbnails stay square-cropped and map popups keep an 8px radius
- lower the desktop ad board breakpoint to 1900px so the panel appears on wider screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc1e0296f48331b2bd0dab8239557a