### PR TITLE
Adjust post board scrollbar placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1824,7 +1824,6 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   padding:0;
   margin:0;
   overflow-y:auto;
-  overflow-y:overlay;
   overflow-x:visible;
   display:flex;
   flex-direction:column;
@@ -2410,7 +2409,12 @@ body.filters-active #filterBtn{
 
 .map-control-row .geocoder{margin:0;}
 
-.post-board .posts{overflow:auto;overflow:overlay;padding:0;margin:0;}
+.post-board .posts{
+  overflow:auto;
+  padding:0;
+  margin:0;
+  scrollbar-gutter:stable;
+}
 .post-board .posts,
 .recents-board{
   scrollbar-width:thin;


### PR DESCRIPTION
## Summary
- remove the overlay scroll behavior from the post board container so the scrollbar renders on the outer edge
- ensure the posts list reserves space for the scrollbar gutter to keep it positioned correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc79d63b4c8331a79741a86a7dbfc2