### PR TITLE
Remove scrollbar gutter from post and recents boards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2413,7 +2413,6 @@ body.filters-active #filterBtn{
   overflow:auto;
   padding:0;
   margin:0;
-  scrollbar-gutter:stable;
 }
 .post-board .posts,
 .recents-board{
@@ -2437,10 +2436,6 @@ body.filters-active #filterBtn{
 .post-board .posts::-webkit-scrollbar-corner,
 .recents-board::-webkit-scrollbar-corner{
   background-color:rgba(0,0,0,0);
-}
-.post-board,
-.recents-board{
-  scrollbar-gutter:stable;
 }
 @media (min-width:1200px){
   .post-board,


### PR DESCRIPTION
## Summary
- remove the `scrollbar-gutter: stable` rule from the post list and recents board containers so the overlay scrollbars no longer consume layout width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc7659bf38833183c7dcbf50ef6df3