### PR TITLE
Prevent wrapping of New Users toggle label

### DIFF
--- a/index.html
+++ b/index.html
@@ -2117,6 +2117,9 @@ body.hide-ads .ad-board{
   width:160px;
   min-width:140px;
 }
+.spin-type-toggle button{
+  white-space:nowrap;
+}
 body.filters-active #filterBtn{
   background: var(--filter-active-color);
   border-color: var(--filter-active-color);


### PR DESCRIPTION
## Summary
- ensure the admin map spin-type toggle buttons keep their labels on a single line

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc86c75628833196342b1d56b3f7f3