### PR TITLE
Keep map spinning during welcome control interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4316,7 +4316,7 @@ img.thumb{
       return origAddEventListener.call(this, type, listener, options);
     };
   })();
-  let startPitch, startBearing, logoEls = [], geocoder, closeWelcomeOnMove = false, welcomeCloseResetTimer = null, welcomeModalEl = null;
+  let startPitch, startBearing, logoEls = [], geocoder, closeWelcomeOnMove = false, welcomeCloseResetTimer = null, welcomeModalEl = null, welcomeControlsRow = null;
   const geocoders = [];
   let syncSpinTypeButtons = null;
 
@@ -6620,7 +6620,20 @@ function makePosts(){
 
     function haltSpin(e){
       const target = (e && e.originalEvent && e.originalEvent.target) || (e && e.target);
-      if(target instanceof Node && logoEls.some(el=>el.contains(target))) return;
+      const eventType = (e && e.type) || (e && e.originalEvent && e.originalEvent.type) || '';
+      if(target instanceof Node){
+        if(logoEls.some(el=>el.contains(target))) return;
+        if(welcomeModalEl && welcomeModalEl.classList.contains('show')){
+          if(!welcomeControlsRow && welcomeModalEl){
+            welcomeControlsRow = welcomeModalEl.querySelector('#welcomeBody .map-control-row');
+          }
+          if(welcomeControlsRow && welcomeControlsRow.contains(target)){
+            if(eventType === 'pointerdown' || eventType === 'touchstart' || eventType === 'wheel' || eventType === 'keydown'){
+              return;
+            }
+          }
+        }
+      }
       if(spinEnabled || spinning){
         spinEnabled = false;
         localStorage.setItem('spinGlobe','false');
@@ -8716,8 +8729,13 @@ function closePanel(m){
 }
 welcomeModalEl = document.getElementById('welcome-modal');
 if(welcomeModalEl){
+  welcomeControlsRow = welcomeModalEl.querySelector('#welcomeBody .map-control-row');
   welcomeModalEl.addEventListener('click', (e) => {
-    const controlsRow = welcomeModalEl.querySelector('#welcomeBody .map-control-row');
+    let controlsRow = welcomeControlsRow;
+    if(!controlsRow){
+      controlsRow = welcomeModalEl.querySelector('#welcomeBody .map-control-row');
+      if(controlsRow) welcomeControlsRow = controlsRow;
+    }
     const clickedInsideControls = e.target.closest('#welcomeBody .map-control-row');
     if(clickedInsideControls && (!controlsRow || controlsRow.contains(clickedInsideControls))){
       return;


### PR DESCRIPTION
## Summary
- prevent global spin halt when pointer and key events originate from the welcome modal map controls
- cache the welcome controls row element for reuse while keeping modal click handling intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8dce52e883318f4770e0e4f73593