### PR TITLE
Allow night sky theme on supported map styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4624,7 +4624,8 @@ img.thumb{
         const baseUrl = getStyleBase(originUrl);
         const normalizedUrl = normalizeMapStyle(baseUrl) || baseUrl || '';
         const normalizedLower = typeof normalizedUrl === 'string' ? normalizedUrl.toLowerCase() : '';
-        const skipAtmosphere = normalizedLower.includes('/streets-') || normalizedLower.includes('/standard');
+        const unsupportedAtmospherePatterns = ['/standard'];
+        const skipAtmosphere = unsupportedAtmospherePatterns.some((pattern) => normalizedLower.includes(pattern));
         if(skipAtmosphere){
           if(typeof mapInstance.setFog === 'function'){
             try { mapInstance.setFog(null); } catch(err){}


### PR DESCRIPTION
## Summary
- allow the night-sky setup to run on the default Mapbox streets style by limiting the unsupported filter to known problematic patterns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc8e02cbfc833180380f4296ee61f1