### PR TITLE
Set open post background to gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -2573,7 +2573,7 @@ body.filters-active #filterBtn{
   flex-direction:column;
   gap:0;
   position:relative;
-  background:var(--closed-card-bg);
+  background:linear-gradient(rgba(0,0,0,0.8), rgba(0,0,0,0.6));
 }
 
 .open-post .post-header{


### PR DESCRIPTION
## Summary
- update the `.open-post` rule to use the same linear-gradient background applied to post cards
- confirm that `updateOpenPostBackground` still only clears inline background styles so the stylesheet gradient remains active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc8fb4cd0483318566b9b6812359fa