### PR TITLE
Fix cluster feature lookup when cluster_id missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -6944,18 +6944,28 @@ function makePosts(){
         if(!map.getLayer('clusters')) return;
         if(hoverPopup){ hoverPopup.remove(); hoverPopup = null; }
         let feature = e && e.features && e.features[0];
-        if(!feature){
+        let clusterId = feature && feature.properties ? feature.properties.cluster_id : undefined;
+        if(clusterId === undefined){
           let features;
           try {
-            features = map.queryRenderedFeatures(e.point, { layers:['clusters'] });
+            if(e && e.point){
+              features = map.queryRenderedFeatures(e.point, { layers:['clusters','cluster-count'] });
+            }
           } catch(err){
             console.warn('cluster query failed', err);
             return;
           }
-          feature = features && features[0];
+          if(features && features.length){
+            const withClusterId = features.find(f=> f && f.properties && f.properties.cluster_id !== undefined);
+            if(withClusterId){
+              feature = withClusterId;
+              clusterId = withClusterId.properties.cluster_id;
+            }
+          }
         }
-        const clusterId = feature && feature.properties ? feature.properties.cluster_id : undefined;
-        if(clusterId === undefined) return;
+        if(clusterId === undefined){
+          return;
+        }
         const coords = feature && feature.geometry && Array.isArray(feature.geometry.coordinates) ? feature.geometry.coordinates.slice() : null;
         if(!coords || coords.length < 2) return;
         const source = typeof map.getSource === 'function' ? map.getSource('posts') : null;


### PR DESCRIPTION
## Summary
- ensure the cluster click handler queries rendered features when the initial event payload lacks a `cluster_id`
- reuse the first queried feature that exposes `cluster_id` so the existing zoom logic remains unchanged

## Testing
- npm test
- Manual verification in the browser (Playwright script) confirming both the cluster icon and count trigger a zoom


------
https://chatgpt.com/codex/tasks/task_e_68cc93e2f5dc8331abd76603a388fb12