### PR TITLE
Adjust sky sun position

### DIFF
--- a/index.html
+++ b/index.html
@@ -4768,6 +4768,7 @@ img.thumb{
         setPaint('sky-type', 'atmosphere');
         setPaint('sky-atmosphere-color', '#0b1d51');
         setPaint('sky-atmosphere-halo-color', '#1a2a6c');
+        setPaint('sky-atmosphere-sun', [90, 30]);
         setPaint('sky-atmosphere-sun-intensity', 0.1);
       }
 


### PR DESCRIPTION
## Summary
- position the atmospheric sun to the right-hand side of the view by setting the sky sun azimuth

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cca157c5108331bbe7c9a932e6aefa