### PR TITLE
Adjust filter controls to dark red when active

### DIFF
--- a/index.html
+++ b/index.html
@@ -1287,7 +1287,7 @@ button[aria-expanded="true"] .results-arrow{
 }
 #filterPanel .keyword-clear-button.active,
 #filterPanel .daterange-clear-button.active{
-  background: var(--filter-active-color);
+  background: #8B0000;
   color: var(--button-text);
   opacity:1;
 }
@@ -1691,8 +1691,8 @@ button[aria-expanded="true"] .results-arrow{
   cursor: pointer;
 }
 .reset-box .btn.active{
-  background: var(--filter-active-color);
-  border-color: var(--filter-active-color);
+  background: #8B0000;
+  border-color: #8B0000;
 }
 
 .reset-box .btn svg{
@@ -2121,9 +2121,9 @@ body.hide-ads .ad-board{
   white-space:nowrap;
 }
 body.filters-active #filterBtn{
-  background: var(--filter-active-color);
-  border-color: var(--filter-active-color);
-  }
+  background: #8B0000;
+  border-color: #8B0000;
+}
 
 .options-dropdown{ position:relative; }
 .options-menu{ position:absolute; top:calc(100% + 4px); left:0; background:var(--dropdown-bg); color:var(--dropdown-text); border:1px solid var(--border); border-radius:var(--dropdown-radius); padding:10px; display:flex; flex-direction:column; gap:6px;  z-index:30; }


### PR DESCRIPTION
## Summary
- update the header filter button's active color to dark red
- change the reset and clear buttons to use a dark red active state, including the category reset control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cca3daebbc8331b987d648b462a24b