### PR TITLE
Fix Mapbox standard style featureset source mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -4362,6 +4362,137 @@ img.thumb{
       }
     }
 
+    function installMapboxStandardStyleFix(){
+      if(typeof window === 'undefined' || typeof window.fetch !== 'function' || window.__standardStyleFixInstalled){
+        return;
+      }
+      window.__standardStyleFixInstalled = true;
+      const originalFetch = window.fetch.bind(window);
+      const styleUrlPattern = /^https:\/\/api\.mapbox\.com\/styles\/v1\/[^/]+\/standard(?:[/?]|$)/i;
+
+      const harmonizeSelectors = (root)=>{
+        if(!root || typeof root !== 'object'){
+          return false;
+        }
+        let changed = false;
+        const visited = new Set();
+        const visit = (node)=>{
+          if(!node || typeof node !== 'object'){
+            return;
+          }
+          if(visited.has(node)){
+            return;
+          }
+          visited.add(node);
+          if(Array.isArray(node)){
+            node.forEach(visit);
+            return;
+          }
+          if(Array.isArray(node.selectors)){
+            const namespaceSources = Object.create(null);
+            const pending = Object.create(null);
+            node.selectors.forEach((selector)=>{
+              if(!selector || typeof selector !== 'object'){
+                return;
+              }
+              const namespace = selector.featureNamespace;
+              if(!namespace){
+                return;
+              }
+              const source = typeof selector.source === 'string' ? selector.source : null;
+              if(source){
+                if(namespaceSources[namespace] === undefined){
+                  namespaceSources[namespace] = source;
+                  if(pending[namespace]){
+                    pending[namespace].forEach((pendingSelector)=>{
+                      if(pendingSelector.source !== source){
+                        pendingSelector.source = source;
+                        changed = true;
+                      }
+                    });
+                    delete pending[namespace];
+                  }
+                } else if(namespaceSources[namespace] !== source){
+                  selector.source = namespaceSources[namespace];
+                  changed = true;
+                }
+              } else {
+                (pending[namespace] || (pending[namespace] = [])).push(selector);
+              }
+            });
+            Object.keys(pending).forEach((namespace)=>{
+              const resolved = namespaceSources[namespace];
+              if(typeof resolved !== 'string'){
+                return;
+              }
+              pending[namespace].forEach((selector)=>{
+                if(selector.source !== resolved){
+                  selector.source = resolved;
+                  changed = true;
+                }
+              });
+            });
+          }
+          Object.keys(node).forEach((key)=>{
+            const value = node[key];
+            if(value && typeof value === 'object'){
+              visit(value);
+            }
+          });
+        };
+        visit(root);
+        return changed;
+      };
+
+      window.fetch = async function(resource, init){
+        const response = await originalFetch(resource, init);
+        try {
+          const requestUrl = typeof resource === 'string' ? resource : (resource && resource.url) ? resource.url : '';
+          if(!requestUrl || !styleUrlPattern.test(requestUrl)){
+            return response;
+          }
+          if(!response || typeof response.clone !== 'function' || response.status !== 200){
+            return response;
+          }
+          const contentType = response.headers && typeof response.headers.get === 'function' ? response.headers.get('content-type') || '' : '';
+          if(contentType && !/json/i.test(contentType)){
+            return response;
+          }
+          const cloned = response.clone();
+          let styleData;
+          try {
+            styleData = await cloned.json();
+          } catch(err){
+            return response;
+          }
+          if(!styleData || typeof styleData !== 'object'){
+            return response;
+          }
+          if(!harmonizeSelectors(styleData)){
+            return response;
+          }
+          if(!styleData.metadata || typeof styleData.metadata !== 'object'){
+            styleData.metadata = {};
+          }
+          styleData.metadata['funmap:featureset-source-fixed'] = true;
+          const headers = typeof Headers === 'function' ? new Headers(response.headers) : response.headers;
+          if(headers && typeof headers.set === 'function' && !headers.get('content-type')){
+            headers.set('content-type', 'application/json');
+          }
+          return new Response(JSON.stringify(styleData), {
+            status: response.status,
+            statusText: response.statusText,
+            headers
+          });
+        } catch(err){
+          console.warn('Failed to harmonize Mapbox standard style selectors', err);
+        }
+        return response;
+      };
+    }
+
+    installMapboxStandardStyleFix();
+
     const DESIRED_MAP_STYLE = 'mapbox://styles/mapbox/standard';
 
       const storedMapStyleRaw = localStorage.getItem('mapStyle');


### PR DESCRIPTION
## Summary
- intercept Mapbox standard style fetches and harmonize featureset selector sources to prevent namespace/source mismatches
- mark styles once normalized to avoid redundant processing while keeping metadata intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca8d8601083318a2b58ebc8148ad5