### PR TITLE
Remove scroll margin override on open post headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -7980,11 +7980,6 @@ function makePosts(){
         }
 
         await nextFrame();
-        const header = detail.querySelector('.post-header');
-        if(header){
-          const h = header.offsetHeight;
-          header.style.scrollMarginTop = h + 'px';
-        }
 
         if(fromMap){
           if(typeof detail.scrollIntoView === 'function'){


### PR DESCRIPTION
## Summary
- remove the scroll-margin override that was being applied to opened post headers so they align with their original card positions when revealed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccad32ce6c8331a3de3f3bc33bcd03