### PR TITLE
Set open post details width to auto

### DIFF
--- a/index.html
+++ b/index.html
@@ -2616,7 +2616,7 @@ body.filters-active #filterBtn{
 
 .open-post .post-details{
   margin-top:0;
-  width:100%;
+  width:auto;
   max-width:var(--post-board-max-w);
   min-width:var(--post-board-max-w);
   display:flex;


### PR DESCRIPTION
## Summary
- set the `.open-post .post-details` width to `auto` so the padding no longer forces the board wider than its max width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccad97f808833194a3e360758fa722