### PR TITLE
Handle cluster-count click fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -7099,22 +7099,17 @@ function makePosts(){
         if(hoverPopup){ hoverPopup.remove(); hoverPopup = null; }
         let feature = e && e.features && e.features[0];
         let clusterId = feature && feature.properties ? feature.properties.cluster_id : undefined;
-        if(clusterId === undefined){
-          let features;
+        if(clusterId === undefined && map && typeof map.queryRenderedFeatures === 'function' && e && e.point){
+          let fallbackFeature;
           try {
-            if(e && e.point){
-              features = map.queryRenderedFeatures(e.point, { layers:['clusters','cluster-count'] });
-            }
+            const features = map.queryRenderedFeatures(e.point, { layers:['clusters','cluster-count'] }) || [];
+            fallbackFeature = features.find(f=> f && f.properties && f.properties.cluster_id !== undefined);
           } catch(err){
             console.warn('cluster query failed', err);
-            return;
           }
-          if(features && features.length){
-            const withClusterId = features.find(f=> f && f.properties && f.properties.cluster_id !== undefined);
-            if(withClusterId){
-              feature = withClusterId;
-              clusterId = withClusterId.properties.cluster_id;
-            }
+          if(fallbackFeature){
+            feature = fallbackFeature;
+            clusterId = fallbackFeature.properties.cluster_id;
           }
         }
         if(clusterId === undefined){


### PR DESCRIPTION
## Summary
- ensure cluster click handling queries rendered features to find a cluster_id when clicking a cluster's count label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccb019338c8331a8e088d377d22d50