### PR TITLE
Improve cluster click handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7100,16 +7100,17 @@ function makePosts(){
         let feature = e && e.features && e.features[0];
         let clusterId = feature && feature.properties ? feature.properties.cluster_id : undefined;
         if(clusterId === undefined && map && typeof map.queryRenderedFeatures === 'function' && e && e.point){
-          let fallbackFeature;
           try {
             const features = map.queryRenderedFeatures(e.point, { layers:['clusters','cluster-count'] }) || [];
-            fallbackFeature = features.find(f=> f && f.properties && f.properties.cluster_id !== undefined);
+            for(const candidate of features){
+              if(candidate && candidate.properties && candidate.properties.cluster_id !== undefined){
+                feature = candidate;
+                clusterId = candidate.properties.cluster_id;
+                break;
+              }
+            }
           } catch(err){
             console.warn('cluster query failed', err);
-          }
-          if(fallbackFeature){
-            feature = fallbackFeature;
-            clusterId = fallbackFeature.properties.cluster_id;
           }
         }
         if(clusterId === undefined){


### PR DESCRIPTION
## Summary
- ensure the cluster click handler queries rendered features if the initial event feature lacks a cluster id
- use the first rendered feature that exposes a cluster id before running the zoom / fit logic

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ccb1c3760883318ef1d8bc2175da17