### PR TITLE
Harmonize Mapbox style via styledata handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -4438,53 +4438,58 @@ img.thumb{
 
     const MAPBOX_STYLE_FIX_FLAG = 'funmap:featureset-source-fixed';
 
-    function ensureMapStyleHarmonized(mapInstance){
-      if(!mapInstance || typeof mapInstance.getStyle !== 'function' || typeof mapInstance.setStyle !== 'function'){
-        return true;
+    function attachStandardStyleHarmonizer(mapInstance){
+      if(!mapInstance || typeof mapInstance.on !== 'function' || typeof mapInstance.getStyle !== 'function' || typeof mapInstance.setStyle !== 'function'){
+        return;
       }
-      let style;
-      try {
-        style = mapInstance.getStyle();
-      } catch(err){
-        console.warn('Failed to retrieve current map style', err);
-        return true;
-      }
-      if(!style || typeof style !== 'object'){
-        return true;
-      }
-      if(style.metadata && typeof style.metadata === 'object' && style.metadata[MAPBOX_STYLE_FIX_FLAG]){
-        return true;
-      }
-      let clonedStyle;
-      try {
-        if(typeof structuredClone === 'function'){
-          clonedStyle = structuredClone(style);
-        } else {
-          clonedStyle = JSON.parse(JSON.stringify(style));
+      const harmonizeStandardStyle = (event)=>{
+        if(event && event.type === 'styledata' && event.dataType !== 'style'){
+          return;
         }
-      } catch(err){
-        console.warn('Failed to clone map style for harmonization', err);
-        return true;
-      }
-      if(!clonedStyle || typeof clonedStyle !== 'object'){
-        return true;
-      }
-      if(!clonedStyle.metadata || typeof clonedStyle.metadata !== 'object'){
-        clonedStyle.metadata = {};
-      }
-      try {
-        harmonizeSelectors(clonedStyle);
-      } catch(err){
-        console.warn('Failed to harmonize Mapbox standard style selectors', err);
-      }
-      clonedStyle.metadata[MAPBOX_STYLE_FIX_FLAG] = true;
-      try {
-        mapInstance.setStyle(clonedStyle);
-      } catch(err){
-        console.warn('Failed to apply harmonized map style', err);
-        return true;
-      }
-      return false;
+        let style;
+        try {
+          style = mapInstance.getStyle();
+        } catch(err){
+          console.warn('Failed to retrieve current map style', err);
+          return;
+        }
+        if(!style || typeof style !== 'object'){
+          return;
+        }
+        const metadata = style.metadata && typeof style.metadata === 'object' ? style.metadata : null;
+        if(metadata && metadata[MAPBOX_STYLE_FIX_FLAG]){
+          return;
+        }
+        let clonedStyle;
+        try {
+          if(typeof structuredClone === 'function'){
+            clonedStyle = structuredClone(style);
+          } else {
+            clonedStyle = JSON.parse(JSON.stringify(style));
+          }
+        } catch(err){
+          console.warn('Failed to clone map style for harmonization', err);
+          return;
+        }
+        if(!clonedStyle || typeof clonedStyle !== 'object'){
+          return;
+        }
+        if(!clonedStyle.metadata || typeof clonedStyle.metadata !== 'object'){
+          clonedStyle.metadata = {};
+        }
+        try {
+          harmonizeSelectors(clonedStyle);
+        } catch(err){
+          console.warn('Failed to harmonize Mapbox standard style selectors', err);
+        }
+        clonedStyle.metadata[MAPBOX_STYLE_FIX_FLAG] = true;
+        try {
+          mapInstance.setStyle(clonedStyle);
+        } catch(err){
+          console.warn('Failed to apply harmonized map style', err);
+        }
+      };
+      mapInstance.on('styledata', harmonizeStandardStyle);
     }
 
     const DESIRED_MAP_STYLE = 'mapbox://styles/mapbox/standard';
@@ -6707,11 +6712,19 @@ function makePosts(){
             console.warn('Unknown image ID:', e.id);
           }
         });
+      attachStandardStyleHarmonizer(map);
+
       const handleStyleUpdate = (event)=>{
         if(event && event.type === 'styledata' && event.dataType !== 'style'){
           return;
         }
-        if(!ensureMapStyleHarmonized(map)){
+        let style;
+        try {
+          style = map.getStyle();
+        } catch(err){
+          return;
+        }
+        if(!style || !style.metadata || !style.metadata[MAPBOX_STYLE_FIX_FLAG]){
           return;
         }
         fixSizerankExpressions(map);
@@ -8387,6 +8400,7 @@ function makePosts(){
             zoom: 10,
             interactive: false
           });
+          attachStandardStyleHarmonizer(map);
           const mutedHandler = () => { ensureMapLightAnchor(map); applyMutedMapStyle(map); applyNightSky(map); };
           map.on('style.load', mutedHandler);
           if(typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : false){


### PR DESCRIPTION
## Summary
- add a reusable attachStandardStyleHarmonizer helper to patch Mapbox Standard styles via styledata events
- hook the helper into both primary and detail map instances and run sizerank fixes only after the harmonized style is active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccb164b284833186ff40fe3b259cd2