### PR TITLE
Use installMapboxStandardStyleFix for style harmonization

### DIFF
--- a/index.html
+++ b/index.html
@@ -4438,7 +4438,7 @@ img.thumb{
 
     const MAPBOX_STYLE_FIX_FLAG = 'funmap:featureset-source-fixed';
 
-    function attachStandardStyleHarmonizer(mapInstance){
+    function installMapboxStandardStyleFix(mapInstance){
       if(!mapInstance || typeof mapInstance.on !== 'function' || typeof mapInstance.getStyle !== 'function' || typeof mapInstance.setStyle !== 'function'){
         return;
       }
@@ -6712,7 +6712,7 @@ function makePosts(){
             console.warn('Unknown image ID:', e.id);
           }
         });
-      attachStandardStyleHarmonizer(map);
+      installMapboxStandardStyleFix(map);
 
       const handleStyleUpdate = (event)=>{
         if(event && event.type === 'styledata' && event.dataType !== 'style'){
@@ -8401,7 +8401,7 @@ function makePosts(){
             zoom: 10,
             interactive: false
           });
-          attachStandardStyleHarmonizer(map);
+          installMapboxStandardStyleFix(map);
           const mutedHandler = () => { ensureMapLightAnchor(map); applyMutedMapStyle(map); applyNightSky(map); };
           map.on('style.load', mutedHandler);
           if(typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : false){


### PR DESCRIPTION
## Summary
- rename the Mapbox style harmonizer helper to installMapboxStandardStyleFix and keep it reusable
- continue harmonizing selectors on styledata events using the metadata guard to prevent loops
- update both map initializations to invoke the new helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccb4f1b51c8331ba17cfa23bdc1b90