### PR TITLE
Handle cluster label click fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -7115,12 +7115,10 @@ function makePosts(){
         if(clusterId === undefined && map && typeof map.queryRenderedFeatures === 'function' && e && e.point){
           try {
             const features = map.queryRenderedFeatures(e.point, { layers:['clusters','cluster-count'] }) || [];
-            for(const candidate of features){
-              if(candidate && candidate.properties && candidate.properties.cluster_id !== undefined){
-                feature = candidate;
-                clusterId = candidate.properties.cluster_id;
-                break;
-              }
+            const fallback = features.find((candidate)=> candidate && candidate.properties && candidate.properties.cluster_id !== undefined);
+            if(fallback){
+              feature = fallback;
+              clusterId = fallback.properties.cluster_id;
             }
           } catch(err){
             console.warn('cluster query failed', err);


### PR DESCRIPTION
## Summary
- ensure cluster clicks without initial cluster id query rendered features for cluster layers
- reuse first feature with a cluster id to continue existing zoom behaviour

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ccb6e7c7d88331ba923b37c383f31a