### PR TITLE
Normalize Mapbox style after load without fetch override

### DIFF
--- a/index.html
+++ b/index.html
@@ -4362,7 +4362,7 @@ img.thumb{
       }
     }
 
-    const harmonizeSelectors = (root)=>{
+    function harmonizeSelectors(root){
       if(!root || typeof root !== 'object'){
         return false;
       }
@@ -4434,62 +4434,58 @@ img.thumb{
       };
       visit(root);
       return changed;
-    };
+    }
 
     const MAPBOX_STYLE_FIX_FLAG = 'funmap:featureset-source-fixed';
 
-    function installMapboxStandardStyleFix(mapInstance){
-      if(!mapInstance || typeof mapInstance.on !== 'function' || typeof mapInstance.getStyle !== 'function' || typeof mapInstance.setStyle !== 'function'){
-        return;
+    function harmonizeMapStyleIfNeeded(mapInstance){
+      if(!mapInstance || typeof mapInstance.getStyle !== 'function' || typeof mapInstance.setStyle !== 'function'){
+        return false;
       }
-      const harmonizeStandardStyle = (event)=>{
-        if(event && event.type === 'styledata' && event.dataType !== 'style'){
-          return;
+      let style;
+      try {
+        style = mapInstance.getStyle();
+      } catch(err){
+        console.warn('Failed to retrieve current map style', err);
+        return false;
+      }
+      if(!style || typeof style !== 'object'){
+        return false;
+      }
+      const metadata = style.metadata && typeof style.metadata === 'object' ? style.metadata : null;
+      if(metadata && metadata[MAPBOX_STYLE_FIX_FLAG]){
+        return false;
+      }
+      let clonedStyle;
+      try {
+        if(typeof structuredClone === 'function'){
+          clonedStyle = structuredClone(style);
+        } else {
+          clonedStyle = JSON.parse(JSON.stringify(style));
         }
-        let style;
-        try {
-          style = mapInstance.getStyle();
-        } catch(err){
-          console.warn('Failed to retrieve current map style', err);
-          return;
-        }
-        if(!style || typeof style !== 'object'){
-          return;
-        }
-        const metadata = style.metadata && typeof style.metadata === 'object' ? style.metadata : null;
-        if(metadata && metadata[MAPBOX_STYLE_FIX_FLAG]){
-          return;
-        }
-        let clonedStyle;
-        try {
-          if(typeof structuredClone === 'function'){
-            clonedStyle = structuredClone(style);
-          } else {
-            clonedStyle = JSON.parse(JSON.stringify(style));
-          }
-        } catch(err){
-          console.warn('Failed to clone map style for harmonization', err);
-          return;
-        }
-        if(!clonedStyle || typeof clonedStyle !== 'object'){
-          return;
-        }
-        if(!clonedStyle.metadata || typeof clonedStyle.metadata !== 'object'){
-          clonedStyle.metadata = {};
-        }
-        try {
-          harmonizeSelectors(clonedStyle);
-        } catch(err){
-          console.warn('Failed to harmonize Mapbox standard style selectors', err);
-        }
-        clonedStyle.metadata[MAPBOX_STYLE_FIX_FLAG] = true;
-        try {
-          mapInstance.setStyle(clonedStyle);
-        } catch(err){
-          console.warn('Failed to apply harmonized map style', err);
-        }
-      };
-      mapInstance.on('styledata', harmonizeStandardStyle);
+      } catch(err){
+        console.warn('Failed to clone map style for harmonization', err);
+        return false;
+      }
+      if(!clonedStyle || typeof clonedStyle !== 'object'){
+        return false;
+      }
+      if(!clonedStyle.metadata || typeof clonedStyle.metadata !== 'object'){
+        clonedStyle.metadata = {};
+      }
+      try {
+        harmonizeSelectors(clonedStyle);
+      } catch(err){
+        console.warn('Failed to harmonize Mapbox standard style selectors', err);
+      }
+      clonedStyle.metadata[MAPBOX_STYLE_FIX_FLAG] = true;
+      try {
+        mapInstance.setStyle(clonedStyle, {diff:false});
+      } catch(err){
+        console.warn('Failed to apply harmonized map style', err);
+        return false;
+      }
+      return true;
     }
 
     const DESIRED_MAP_STYLE = 'mapbox://styles/mapbox/standard';
@@ -6712,7 +6708,14 @@ function makePosts(){
             console.warn('Unknown image ID:', e.id);
           }
         });
-      installMapboxStandardStyleFix(map);
+
+      const harmonizeStyleOnStyleData = (event)=>{
+        if(event && event.type === 'styledata' && event.dataType !== 'style'){
+          return;
+        }
+        harmonizeMapStyleIfNeeded(map);
+      };
+      map.on('styledata', harmonizeStyleOnStyleData);
 
       const handleStyleUpdate = (event)=>{
         if(event && event.type === 'styledata' && event.dataType !== 'style'){
@@ -8399,7 +8402,13 @@ function makePosts(){
             zoom: 10,
             interactive: false
           });
-          installMapboxStandardStyleFix(map);
+          const harmonizeDetailStyle = (event)=>{
+            if(event && event.type === 'styledata' && event.dataType !== 'style'){
+              return;
+            }
+            harmonizeMapStyleIfNeeded(map);
+          };
+          map.on('styledata', harmonizeDetailStyle);
           const mutedHandler = () => { ensureMapLightAnchor(map); applyMutedMapStyle(map); applyNightSky(map); };
           map.on('style.load', mutedHandler);
           if(typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : false){


### PR DESCRIPTION
## Summary
- convert the selector harmonization logic into reusable helpers so map styles can be normalized without overriding `fetch`
- hook the primary map's `styledata` events to clone, harmonize, and reapply the style JSON with a metadata guard
- ensure detail maps reuse the same harmonization flow so selectors stay consistent everywhere

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccb998793c833196b364e9b75d6b89