### PR TITLE
Ensure Mapbox style harmonization via styledata events

### DIFF
--- a/index.html
+++ b/index.html
@@ -4438,54 +4438,60 @@ img.thumb{
 
     const MAPBOX_STYLE_FIX_FLAG = 'funmap:featureset-source-fixed';
 
-    function harmonizeMapStyleIfNeeded(mapInstance){
+    function createMapStyleHarmonizer(mapInstance){
       if(!mapInstance || typeof mapInstance.getStyle !== 'function' || typeof mapInstance.setStyle !== 'function'){
-        return false;
+        return null;
       }
-      let style;
-      try {
-        style = mapInstance.getStyle();
-      } catch(err){
-        console.warn('Failed to retrieve current map style', err);
-        return false;
-      }
-      if(!style || typeof style !== 'object'){
-        return false;
-      }
-      const metadata = style.metadata && typeof style.metadata === 'object' ? style.metadata : null;
-      if(metadata && metadata[MAPBOX_STYLE_FIX_FLAG]){
-        return false;
-      }
-      let clonedStyle;
-      try {
-        if(typeof structuredClone === 'function'){
-          clonedStyle = structuredClone(style);
-        } else {
-          clonedStyle = JSON.parse(JSON.stringify(style));
+      const handler = (event)=>{
+        const isStyleEvent = !event || event.type !== 'styledata' || !event.dataType || event.dataType === 'style';
+        if(!isStyleEvent){
+          return;
         }
-      } catch(err){
-        console.warn('Failed to clone map style for harmonization', err);
-        return false;
-      }
-      if(!clonedStyle || typeof clonedStyle !== 'object'){
-        return false;
-      }
-      if(!clonedStyle.metadata || typeof clonedStyle.metadata !== 'object'){
-        clonedStyle.metadata = {};
-      }
-      try {
-        harmonizeSelectors(clonedStyle);
-      } catch(err){
-        console.warn('Failed to harmonize Mapbox standard style selectors', err);
-      }
-      clonedStyle.metadata[MAPBOX_STYLE_FIX_FLAG] = true;
-      try {
-        mapInstance.setStyle(clonedStyle, {diff:false});
-      } catch(err){
-        console.warn('Failed to apply harmonized map style', err);
-        return false;
-      }
-      return true;
+        let style;
+        try {
+          style = mapInstance.getStyle();
+        } catch(err){
+          console.warn('Failed to retrieve current map style', err);
+          return;
+        }
+        if(!style || typeof style !== 'object'){
+          return;
+        }
+        const metadata = style.metadata && typeof style.metadata === 'object' ? style.metadata : null;
+        if(metadata && metadata[MAPBOX_STYLE_FIX_FLAG]){
+          return;
+        }
+        let clonedStyle;
+        try {
+          if(typeof structuredClone === 'function'){
+            clonedStyle = structuredClone(style);
+          } else {
+            clonedStyle = JSON.parse(JSON.stringify(style));
+          }
+        } catch(err){
+          console.warn('Failed to clone map style for harmonization', err);
+          return;
+        }
+        if(!clonedStyle || typeof clonedStyle !== 'object'){
+          return;
+        }
+        if(!clonedStyle.metadata || typeof clonedStyle.metadata !== 'object'){
+          clonedStyle.metadata = {};
+        }
+        try {
+          harmonizeSelectors(clonedStyle);
+        } catch(err){
+          console.warn('Failed to harmonize Mapbox standard style selectors', err);
+        }
+        clonedStyle.metadata[MAPBOX_STYLE_FIX_FLAG] = true;
+        try {
+          mapInstance.setStyle(clonedStyle, {diff:false});
+        } catch(err){
+          console.warn('Failed to apply harmonized map style', err);
+        }
+      };
+      mapInstance.on('styledata', handler);
+      return handler;
     }
 
     const DESIRED_MAP_STYLE = 'mapbox://styles/mapbox/standard';
@@ -6709,13 +6715,7 @@ function makePosts(){
           }
         });
 
-      const harmonizeStyleOnStyleData = (event)=>{
-        if(event && event.type === 'styledata' && event.dataType !== 'style'){
-          return;
-        }
-        harmonizeMapStyleIfNeeded(map);
-      };
-      map.on('styledata', harmonizeStyleOnStyleData);
+      createMapStyleHarmonizer(map);
 
       const handleStyleUpdate = (event)=>{
         if(event && event.type === 'styledata' && event.dataType !== 'style'){
@@ -8387,13 +8387,7 @@ function makePosts(){
             zoom: 10,
             interactive: false
           });
-          const harmonizeDetailStyle = (event)=>{
-            if(event && event.type === 'styledata' && event.dataType !== 'style'){
-              return;
-            }
-            harmonizeMapStyleIfNeeded(map);
-          };
-          map.on('styledata', harmonizeDetailStyle);
+          createMapStyleHarmonizer(map);
           const mutedHandler = () => { ensureMapLightAnchor(map); applyMutedMapStyle(map); applyNightSky(map); };
           map.on('style.load', mutedHandler);
           if(typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : false){


### PR DESCRIPTION
## Summary
- add a styledata harmonizer that clones the map style, runs the selector normalization, and reapplies it with a metadata guard
- wire the main and detail maps to install the harmonizer so normalized selectors reach the worker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccbd4fcefc83318a444e1c5d4aad5f