### PR TITLE
Fix session time popup clipping in post calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3022,6 +3022,10 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   gap:10px;
   z-index:30;
 }
+.open-post .session-menu,
+.second-post-column .session-menu{
+  overflow:visible;
+}
 .open-post .venue-menu,
 .open-post .session-menu{
   max-width:100%;
@@ -3137,7 +3141,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   min-width:0;
   height:auto;
   border-radius:8px;
-  overflow:hidden;
+  overflow:visible;
   background:var(--dropdown-bg);
   min-height:200px;
   flex:0 0 auto;


### PR DESCRIPTION
## Summary
- allow the post session dropdown to let its calendar container overflow so the inline time picker can render fully
- relax the session menu overflow behavior to keep the popup visible while preserving existing layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccbfe37c98833181fbb0c35010e3b1