### PR TITLE
Hoist session scroll helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -8331,6 +8331,33 @@ function makePosts(){
         }
         let map, marker, sessionHasMultiple = false, lastClickedCell = null, resizeHandler = null, detailMapRef = null;
         let sessionCloseTimer = null;
+        let selectedIndex = null;
+        let currentLoc = null;
+        function scrollCalendarToIso(iso, {preferSmooth=false}={}){
+          if(!calendarEl || !calScroll || !iso) return {target:null, smooth:false};
+          const cell = calendarEl.querySelector(`.day[data-iso="${iso}"]`);
+          if(!cell) return {target:null, smooth:false};
+          const monthEl = cell.closest('.month');
+          if(!monthEl) return {target:null, smooth:false};
+          const target = monthEl.offsetLeft;
+          if(typeof calScroll.scrollTo === 'function'){
+            const difference = Math.abs(calScroll.scrollLeft - target);
+            if(preferSmooth && difference > 1){
+              calScroll.scrollTo({left:target, behavior:'smooth'});
+              return {target, smooth:true};
+            }
+            calScroll.scrollTo({left:target});
+          } else {
+            calScroll.scrollLeft = target;
+          }
+          return {target, smooth:false};
+        }
+        function scrollCalendarToSelected({preferSmooth=false}={}){
+          if(selectedIndex===null || !currentLoc) return {target:null, smooth:false};
+          const dt = currentLoc.dates[selectedIndex];
+          if(!dt) return {target:null, smooth:false};
+          return scrollCalendarToIso(dt.full, {preferSmooth});
+        }
         function scheduleSessionMenuClose({waitForScroll=false, targetLeft=null}={}){
           if(!sessMenu) return;
           if(sessionCloseTimer){
@@ -8373,6 +8400,7 @@ function makePosts(){
         }
       function updateVenue(idx){
         const loc = p.locations[idx];
+        currentLoc = loc;
         loc.dates.sort((a,b)=> a.full.localeCompare(b.full) || a.time.localeCompare(b.time));
         const currentYear = new Date().getFullYear();
         const parseDate = s => {
@@ -8514,7 +8542,7 @@ function makePosts(){
           current.setMonth(current.getMonth()+1);
         }
         calendarEl.appendChild(cal);
-        let selectedIndex = null;
+        selectedIndex = null;
         calendarEl.addEventListener('click', e=> e.stopPropagation());
         function markSelected(){
           calendarEl.querySelectorAll('.day').forEach(d=> d.classList.remove('selected'));
@@ -8523,33 +8551,6 @@ function makePosts(){
             const cell = calendarEl.querySelector(`.day[data-iso="${dt.full}"]`);
             if(cell) cell.classList.add('selected');
           }
-        }
-
-        function scrollCalendarToIso(iso, {preferSmooth=false}={}){
-          if(!calScroll || !iso) return {target:null, smooth:false};
-          const cell = calendarEl.querySelector(`.day[data-iso="${iso}"]`);
-          if(!cell) return {target:null, smooth:false};
-          const monthEl = cell.closest('.month');
-          if(!monthEl) return {target:null, smooth:false};
-          const target = monthEl.offsetLeft;
-          if(typeof calScroll.scrollTo === 'function'){
-            const difference = Math.abs(calScroll.scrollLeft - target);
-            if(preferSmooth && difference > 1){
-              calScroll.scrollTo({left:target, behavior:'smooth'});
-              return {target, smooth:true};
-            }
-            calScroll.scrollTo({left:target});
-          } else {
-            calScroll.scrollLeft = target;
-          }
-          return {target, smooth:false};
-        }
-
-        function scrollCalendarToSelected({preferSmooth=false}={}){
-          if(selectedIndex===null) return {target:null, smooth:false};
-          const dt = loc.dates[selectedIndex];
-          if(!dt) return {target:null, smooth:false};
-          return scrollCalendarToIso(dt.full, {preferSmooth});
         }
         function selectSession(i, {skipAutoClose=false, preferSmooth=true}={}){
           if(!sessMenu || !sessionOptions) return;


### PR DESCRIPTION
## Summary
- hoist the session calendar scroll helpers beside the dropdown state so they share scope with the toggle listener
- expose the current location and selected index to the shared helper while keeping calendar access intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccce4357448331a886bae306d620b3