### PR TITLE
Move calendar scroll helper to shared scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -8327,31 +8327,6 @@ function makePosts(){
         let sessionCloseTimer = null;
         let selectedIndex = null;
         let currentLoc = null;
-        function scrollCalendarToIso(iso, {preferSmooth=false}={}){
-          if(!calendarEl || !calScroll || !iso) return {target:null, smooth:false};
-          const cell = calendarEl.querySelector(`.day[data-iso="${iso}"]`);
-          if(!cell) return {target:null, smooth:false};
-          const monthEl = cell.closest('.month');
-          if(!monthEl) return {target:null, smooth:false};
-          const target = monthEl.offsetLeft;
-          if(typeof calScroll.scrollTo === 'function'){
-            const difference = Math.abs(calScroll.scrollLeft - target);
-            if(preferSmooth && difference > 1){
-              calScroll.scrollTo({left:target, behavior:'smooth'});
-              return {target, smooth:true};
-            }
-            calScroll.scrollTo({left:target});
-          } else {
-            calScroll.scrollLeft = target;
-          }
-          return {target, smooth:false};
-        }
-        function scrollCalendarToSelected({preferSmooth=false}={}){
-          if(selectedIndex===null || !currentLoc) return {target:null, smooth:false};
-          const dt = currentLoc.dates[selectedIndex];
-          if(!dt) return {target:null, smooth:false};
-          return scrollCalendarToIso(dt.full, {preferSmooth});
-        }
         function scheduleSessionMenuClose({waitForScroll=false, targetLeft=null}={}){
           if(!sessMenu) return;
           if(sessionCloseTimer){
@@ -8656,6 +8631,31 @@ function makePosts(){
           });
         }
       }
+        function scrollCalendarToIso(iso, {preferSmooth=false}={}){
+          if(!calendarEl || !calScroll || !iso) return {target:null, smooth:false};
+          const cell = calendarEl.querySelector(`.day[data-iso="${iso}"]`);
+          if(!cell) return {target:null, smooth:false};
+          const monthEl = cell.closest('.month');
+          if(!monthEl) return {target:null, smooth:false};
+          const target = monthEl.offsetLeft;
+          if(typeof calScroll.scrollTo === 'function'){
+            const difference = Math.abs(calScroll.scrollLeft - target);
+            if(preferSmooth && difference > 1){
+              calScroll.scrollTo({left:target, behavior:'smooth'});
+              return {target, smooth:true};
+            }
+            calScroll.scrollTo({left:target});
+          } else {
+            calScroll.scrollLeft = target;
+          }
+          return {target, smooth:false};
+        }
+        function scrollCalendarToSelected({preferSmooth=false}={}){
+          if(selectedIndex===null || !currentLoc) return {target:null, smooth:false};
+          const dt = currentLoc.dates[selectedIndex];
+          if(!dt) return {target:null, smooth:false};
+          return scrollCalendarToIso(dt.full, {preferSmooth});
+        }
         if(mapEl){
           setTimeout(()=>{
             loadMapbox(()=>{


### PR DESCRIPTION
## Summary
- relocate the session calendar scroll helpers so the dropdown toggle shares the same scope
- retain access to the current selection data so reopening the session menu scrolls correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd1a2e6b88331818ed52237efa145