### PR TITLE
Hide post board overlay in map mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1829,6 +1829,13 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   flex:0 0 var(--post-board-max-w);
 }
 
+.mode-map .post-board-scroll{
+  background:transparent;
+  opacity:0;
+  visibility:hidden;
+  pointer-events:none;
+}
+
 .recents-board-scroll{
   width:var(--post-board-max-w);
   max-width:var(--post-board-max-w);


### PR DESCRIPTION
## Summary
- hide the post board wrapper whenever the site is in map mode so the blank panel no longer overlays the map during load

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd2e5184048331a19cc97a4a37fac9