### PR TITLE
Fix welcome modal map controls event propagation

### DIFF
--- a/index.html
+++ b/index.html
@@ -8739,12 +8739,6 @@ function closePanel(m){
 }
 const welcomeModalEl = document.getElementById('welcome-modal');
 if(welcomeModalEl){
-  const controlRow = welcomeModalEl.querySelector('.map-controls-welcome');
-  if(controlRow){
-    ['click','mousedown','touchstart'].forEach(evt => {
-      controlRow.addEventListener(evt, e => e.stopPropagation(), {capture:true});
-    });
-  }
   welcomeModalEl.addEventListener('click', event => {
     if(event.target.closest('.map-controls-welcome')) return;
     closePanel(welcomeModalEl);


### PR DESCRIPTION
## Summary
- remove the capture-phase stopPropagation handlers from the welcome modal map controls row
- rely on the modal click guard so Mapbox control widgets inside the welcome modal can receive user interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3a892240833192c61a29a7b9a754