### PR TITLE
Adjust geocoder icon overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -2524,8 +2524,7 @@ body.filters-active #filterBtn{
   min-width:0;
 }
 
-.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button,
-.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   color:#000000;
   fill:#000000;
   display:flex;
@@ -2535,6 +2534,11 @@ body.filters-active #filterBtn{
   width:var(--geocoder-h);
   min-width:var(--geocoder-h);
   padding:0;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
+  color:inherit;
+  fill:inherit;
 }
 
 .panel-body .map-control-row{


### PR DESCRIPTION
## Summary
- keep custom sizing limited to the geocoder button so the Mapbox icon can use its default layout
- let the geocoder icon inherit color and fill without overriding its display or sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce03e94b888331baad1ccd38d7e2fb