### PR TITLE
Adjust geocoder button visibility overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -2537,13 +2537,11 @@ body.filters-active #filterBtn{
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   color:#000000;
   fill:#000000;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  height:100%;
-  width:var(--geocoder-h);
-  min-width:var(--geocoder-h);
   padding:0;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-search{
+  display:none;
 }
 
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{


### PR DESCRIPTION
## Summary
- remove custom display and sizing overrides on the geocoder button so Mapbox can control its visibility
- keep the geocoder search icon hidden even when Mapbox shows the button by explicitly hiding the icon sprite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce073f861883319b932f5dbfaaf06e