### PR TITLE
Adjust geocoder control styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2516,9 +2516,6 @@ body.filters-active #filterBtn{
   background:#ffffff;
   border-radius:8px;
   color:#000000;
-  display:flex;
-  align-items:center;
-  gap:0;
   height:var(--geocoder-h);
   min-height:var(--geocoder-h);
   overflow:hidden;
@@ -2529,7 +2526,8 @@ body.filters-active #filterBtn{
   background:#ffffff;
   color:#000000;
   height:100%;
-  padding:0 calc(var(--geocoder-h) + 20px) 0 12px;
+  padding:0 12px;
+  padding-right:calc(var(--geocoder-h) + 20px);
   line-height:var(--geocoder-h);
   flex:1 1 auto;
   min-width:0;
@@ -2538,11 +2536,6 @@ body.filters-active #filterBtn{
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   color:#000000;
   fill:#000000;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  height:var(--geocoder-h);
-  min-width:var(--geocoder-h);
   padding:0;
   position:absolute;
   right:10px;
@@ -2553,6 +2546,10 @@ body.filters-active #filterBtn{
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
   color:inherit;
   fill:inherit;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-search{
+  display:none;
 }
 
 .panel-body .map-control-row{


### PR DESCRIPTION
## Summary
- remove custom flex layout constraints from the geocoder control button so Mapbox can manage its visibility
- hide the geocoder search icon and keep the button positioned within the control container
- update input padding to accommodate the repositioned button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce087f0fc883318d66952eca5d9dcb