### PR TITLE
Adjust small-screen breakpoint to 440px

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@ button[aria-expanded="true"] .results-arrow{
   overflow:hidden;
   pointer-events:auto;
 }
-  @media (max-width:600px){
+  @media (max-width:440px){
   #adminPanel .panel-content,
   #memberPanel .panel-content,
   #filterPanel .panel-content{
@@ -1825,7 +1825,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   max-width:var(--post-board-max-w);
   flex-shrink:0;
 }
-@media (max-width:439px){
+@media (max-width:440px){
   .post-board,
   .recents-board,
   .second-post-column.is-visible{
@@ -1900,7 +1900,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   flex-direction:column;
 }
 
-@media (max-width:439px){
+@media (max-width:440px){
   .main-post-column{
     flex:0 0 auto;
     width:100%;
@@ -2700,7 +2700,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   z-index:1;
 }
 
-@media (max-width: 450px){
+@media (max-width: 440px){
   .post-board .posts{padding:0;}
   .post-board .post-card{
     grid-template-columns:1fr;
@@ -3371,7 +3371,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 }
 
 
-@media (max-width:650px){
+@media (max-width:440px){
   .mode-toggle .mode-icon{
     display:inline-flex;
   }
@@ -3381,7 +3381,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 }
 
 
-@media (max-width:650px){
+@media (max-width:440px){
   html{
     touch-action:pan-x pan-y;
   }
@@ -3393,7 +3393,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   }
 }
 
-@media (max-width:650px){
+@media (max-width:440px){
   .post-mode-boards{
     top:calc(var(--header-h) + var(--safe-top));
     bottom:0;
@@ -3510,7 +3510,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   }
 }
 
-@media (max-width:840px){
+@media (max-width:440px){
   .open-post .post-body{
     flex-direction:column;
     gap:var(--gap);
@@ -3552,7 +3552,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   }
 }
 
-  @media (max-width:450px){
+  @media (max-width:440px){
     .post-board,
     .post-board .post-card,
     .open-post{
@@ -3594,7 +3594,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     }
   }
 
-@media (max-width:450px){
+@media (max-width:440px){
   .open-post .venue-dropdown > button,
   .open-post .session-dropdown > button{
     height:50px;
@@ -3661,10 +3661,10 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     background:var(--list-background);
     border-radius:8px;
   }
-    @media (max-width:879px){
+    @media (max-width:440px){
       #post-modal-container .post-modal{width:440px;}
     }
-    @media (max-width:439px){
+    @media (max-width:440px){
       #post-modal-container .post-modal{width:100%;min-width:0;}
     }
 
@@ -3977,7 +3977,7 @@ img.thumb{
 
 
 
-@media (max-width:649px){
+@media (max-width:440px){
   #filterPanel .panel-content{
     top:calc(var(--header-h) + var(--safe-top));
     left:0;
@@ -3994,7 +3994,7 @@ img.thumb{
   }
 }
 
-@media (max-width:449px){
+@media (max-width:440px){
   .post-board .posts{
     padding:0;
     margin:0;
@@ -4054,7 +4054,7 @@ img.thumb{
 }
 
 
-@media (max-width:450px){
+@media (max-width:440px){
   :root{
     --footer-h:0;
   }


### PR DESCRIPTION
## Summary
- update all small-screen media queries to use a single 440px breakpoint
- ensure panels, boards, and the mode toggle switch to full-width, icon-focused layouts below 440px

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce16aedb948331915b9e54efb76f5b