### PR TITLE
Add spiral marker for multi-post venues

### DIFF
--- a/index.html
+++ b/index.html
@@ -5004,6 +5004,39 @@ function buildClusterListHTML(items){
     const subcategoryMarkerIds = window.subcategoryMarkerIds = {};
     const categoryShapes = window.categoryShapes = {};
 
+    const MULTI_VENUE_MARKER_ID = 'multi-venue-marker';
+    const MULTI_VENUE_MARKER_URL = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <defs>
+    <radialGradient id="multiOuter" cx="50%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#7c8ed5"/>
+      <stop offset="65%" stop-color="#3e4f8c"/>
+      <stop offset="100%" stop-color="#121d3f"/>
+    </radialGradient>
+    <linearGradient id="multiInner" x1="28%" y1="18%" x2="72%" y2="82%">
+      <stop offset="0%" stop-color="#f9fbff" stop-opacity="0.95"/>
+      <stop offset="45%" stop-color="#c8d2ff" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#6b77c2" stop-opacity="0.6"/>
+    </linearGradient>
+  </defs>
+  <path d="M48 4C29 4 14 19 14 38c0 21 17 34.5 34 54 17-19.5 34-33 34-54 0-19-15-34-34-34z" fill="url(#multiOuter)" stroke="#0b1623" stroke-width="3.5" stroke-linejoin="round"/>
+  <path d="M48 11c-15 0-27 11-27 27 0 16 13 28 27 44 14-16 27-28 27-44 0-16-12-27-27-27z" fill="url(#multiInner)"/>
+  <path d="M32 56c0-14 16-24 30-18 12 5 10 20-4 23-12 2-20-9-13-17 7-8 23-4 24 9 1 13-14 21-26 16-12-5-16-19-7-28" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
+  <g stroke="#14264f" stroke-width="1.2" stroke-linejoin="round">
+    <path d="M0-6C3-6 6-3 6 0 6 3 3 6 0 10 -3 6 -6 3 -6 0 -6-3 -3-6 0-6Z" fill="#ffc107" transform="translate(48 54) scale(0.92) rotate(8)"/>
+    <path d="M0-6C3-6 6-3 6 0 6 3 3 6 0 10 -3 6 -6 3 -6 0 -6-3 -3-6 0-6Z" fill="#7c4dff" transform="translate(40 44) scale(0.78) rotate(-18)"/>
+    <path d="M0-6C3-6 6-3 6 0 6 3 3 6 0 10 -3 6 -6 3 -6 0 -6-3 -3-6 0-6Z" fill="#24c6dc" transform="translate(46 33) scale(0.72) rotate(24)"/>
+    <path d="M0-6C3-6 6-3 6 0 6 3 3 6 0 10 -3 6 -6 3 -6 0 -6-3 -3-6 0-6Z" fill="#f7797d" transform="translate(58 30) scale(0.66) rotate(58)"/>
+    <path d="M0-6C3-6 6-3 6 0 6 3 3 6 0 10 -3 6 -6 3 -6 0 -6-3 -3-6 0-6Z" fill="#51cf66" transform="translate(64 42) scale(0.6) rotate(102)"/>
+  </g>
+  <circle cx="38" cy="28" r="7" fill="#fff" opacity="0.6"/>
+  <circle cx="36" cy="26" r="4" fill="#fff" opacity="0.8"/>
+</svg>
+`.replace(/\s{2,}/g,' ').trim());
+    const MULTI_VENUE_COORD_PRECISION = 6;
+    const venueKey = (lng, lat) => `${lng.toFixed(MULTI_VENUE_COORD_PRECISION)},${lat.toFixed(MULTI_VENUE_COORD_PRECISION)}`;
+    subcategoryMarkers[MULTI_VENUE_MARKER_ID] = MULTI_VENUE_MARKER_URL;
+
     function ensureSvgDimensions(svg){
       try{
         const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
@@ -6655,17 +6688,39 @@ function makePosts(){
 
     // Map layers
     function postsToGeoJSON(list){
+      const coordCounts = new Map();
+      list.forEach(p => {
+        if(Number.isFinite(p.lng) && Number.isFinite(p.lat)){
+          const key = venueKey(p.lng, p.lat);
+          coordCounts.set(key, (coordCounts.get(key) || 0) + 1);
+        }
+      });
       return {
         type:'FeatureCollection',
-          features: list
-            .filter(p => Number.isFinite(p.lng) && Number.isFinite(p.lat))
-            .map(p => ({
+        features: list
+          .filter(p => Number.isFinite(p.lng) && Number.isFinite(p.lat))
+          .map(p => {
+            const baseSub = subcategoryMarkerIds[p.subcategory] || slugify(p.subcategory);
+            const key = venueKey(p.lng, p.lat);
+            const isMultiVenue = (coordCounts.get(key) || 0) > 1;
+            return {
               type:'Feature',
-              properties:{id:p.id, title:p.title, city:p.city, cat:p.category, sub:(subcategoryMarkerIds[p.subcategory] || slugify(p.subcategory)), layer:'poi', sizerank:1},
+              properties:{
+                id:p.id,
+                title:p.title,
+                city:p.city,
+                cat:p.category,
+                sub: isMultiVenue ? MULTI_VENUE_MARKER_ID : baseSub,
+                baseSub,
+                layer:'poi',
+                sizerank:1,
+                multi:isMultiVenue ? 1 : 0
+              },
               geometry:{type:'Point', coordinates:[p.lng, p.lat]}
-            }))
-        };
-      }
+            };
+          })
+      };
+    }
 
     let addingPostSource = false;
     async function addPostSource(){


### PR DESCRIPTION
## Summary
- add an inline SVG spiral marker for venues with multiple posts and register it with the map icon registry
- update GeoJSON feature generation to swap to the spiral marker when multiple posts share coordinates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce20ea45d48331a09160da0d1d6b65