### PR TITLE
Fix geocoder alignment and mobile post thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -2327,6 +2327,11 @@ body.filters-active #filterBtn{
 .map-control-row .geocoder{
   background-color:#ffffff;
   border-radius:8px;
+  flex:1 1 240px;
+  min-width:0;
+  width:100%;
+  max-width:360px;
+  display:flex;
 }
 #filterPanel .map-control-row .geocoder,
 #filterPanel .map-control-row .mapboxgl-ctrl-geocoder,
@@ -2378,17 +2383,65 @@ body.filters-active #filterBtn{
   background:#ffffff;
   border-radius:8px;
   color:#000000;
+  display:flex;
+  align-items:center;
+  gap:0;
+  height:var(--geocoder-h);
+  min-height:var(--geocoder-h);
+  width:100%;
+  max-width:100%;
+  min-width:0;
 }
 
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--input{
   background:#ffffff;
   color:#000000;
+  flex:1 1 auto;
+  width:100%;
+  height:100%;
+  padding-top:0;
+  padding-bottom:0;
+  line-height:var(--geocoder-h);
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder input.mapboxgl-ctrl-geocoder--input{
+  height:100%;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--pin-right{
+  display:flex;
+  align-items:center;
+  height:100%;
 }
 
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button,
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
   color:#000000;
   fill:#000000;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  height:100%;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  height:100%;
+  padding:0 8px;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
+  min-width:var(--geocoder-h);
+  width:var(--geocoder-h);
+  background-position:center;
+  background-repeat:no-repeat;
+}
+
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-loading,
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-search{
+  background-size:20px;
 }
 
 .panel-body .map-control-row:not(.map-controls-welcome){
@@ -2746,18 +2799,17 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 @media (max-width: 440px){
   .post-board .posts{padding:0;}
   .post-board .post-card{
-    grid-template-columns:1fr;
-    gap:0;
-    padding:0;
+    grid-template-columns:80px 1fr 36px;
+    gap:12px;
+    padding:12px;
     margin:10px 0 12px;
-    border-radius:8px;
-  }
-  .post-board .post-card .thumb{
-    width:100%;
-    height:100vw;
     border-radius:0;
   }
-  .post-board .post-card .meta{padding:12px;}
+  .post-board .post-card .thumb{
+    width:80px;
+    height:80px;
+  }
+  .post-board .post-card .meta{padding:0;}
   .open-post{
     margin:10px 0 12px;
   }


### PR DESCRIPTION
## Summary
- align the geocoder control contents vertically and limit its width to 360px
- extend the width constraint to the geocoder wrapper used across panels
- revert mobile post board cards to compact thumbnails so they match the recents board

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce324521dc83319f8b8d8c39b2d2ca