### PR TITLE
Adjust mobile layout and geocoder controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2402,6 +2402,8 @@ body.filters-active #filterBtn{
   height:100%;
   padding-top:0;
   padding-bottom:0;
+  padding-left:12px;
+  padding-right:12px;
   line-height:var(--geocoder-h);
 }
 
@@ -2410,39 +2412,14 @@ body.filters-active #filterBtn{
 }
 
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--pin-right{
-  display:flex;
-  align-items:center;
-  height:100%;
+  display:none;
 }
 
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button,
-.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
-  color:#000000;
-  fill:#000000;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  height:100%;
-}
-
-.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  height:100%;
-  padding:0 8px;
-}
-
-.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
-  min-width:var(--geocoder-h);
-  width:var(--geocoder-h);
-  background-position:center;
-  background-repeat:no-repeat;
-}
-
+.map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon,
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-loading,
 .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon-search{
-  background-size:20px;
+  display:none;
 }
 
 .panel-body .map-control-row:not(.map-controls-welcome){
@@ -2501,20 +2478,15 @@ body.filters-active #filterBtn{
   height:100%;
   padding-top:0;
   padding-bottom:0;
+  padding-left:12px;
+  padding-right:12px;
   line-height:var(--control-h);
 }
 #welcomeBody .map-controls-welcome .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  height:100%;
-  padding:0 8px;
+  display:none;
 }
 #welcomeBody .map-controls-welcome .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--icon{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  height:100%;
+  display:none;
 }
 #welcomeBody .map-control-row .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--input{
   width:100%;
@@ -3507,11 +3479,20 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     right:0;
     padding:0;
     border-radius:0;
+    flex:1 1 auto;
+    min-height:0;
+    height:100%;
   }
   .quick-list-board{
     position:relative;
     top:0;
     bottom:auto;
+  }
+  .panel-content{
+    top:calc(var(--header-h) + var(--safe-top));
+    bottom:var(--footer-h);
+    height:calc(100vh - var(--header-h) - var(--safe-top) - var(--footer-h));
+    min-height:0;
   }
   .card,
   .recents-card,
@@ -3519,6 +3500,11 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     margin:0;
     border-radius:0;
     padding:12px;
+  }
+  .post-board .post-card,
+  .recents-board .recents-card{
+    margin:0;
+    border-radius:0;
   }
   .thumb,
   .post-card .thumb,
@@ -4097,16 +4083,16 @@ img.thumb{
   }
   .post-board .post-card{
     width:100%;
-    margin:10px 0 12px;
-    border-radius:8px;
+    margin:0;
+    border-radius:0;
   }
   .post-board .open-post{
-    margin:10px 0 12px;
+    margin:0;
   }
   .open-post{
     width:100%;
-    border-radius:8px;
-    margin:10px 0 12px;
+    border-radius:0;
+    margin:0;
   }
   .open-post .post-images{
     flex:0 0 100%;


### PR DESCRIPTION
## Summary
- hide extraneous Mapbox geocoder affordances and adjust field padding
- tighten mobile boards/cards so they fill the viewport without gaps on small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce37677ecc8331846174092241a166