### PR TITLE
Align map geocoder width with welcome modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -2499,8 +2499,13 @@ body.filters-active #filterBtn{
   left:50%;
   top:calc(var(--header-h) + 10px);
   transform:translateX(-50%);
-  width:auto;
+  width:min(600px, 90vw);
+  max-width:90vw;
   z-index:1;
+}
+
+.map-controls-map .geocoder{
+  max-width:100%;
 }
 
 .map-control-row .geocoder{margin:0;}


### PR DESCRIPTION
## Summary
- set the floating map controls to use the same width as the welcome modal layout
- allow the map geocoder container to expand to the full control width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce3a9239508331ac2ab5a82408ad9e