### PR TITLE
Ensure post boards respect width constraints

### DIFF
--- a/index.html
+++ b/index.html
@@ -1822,7 +1822,6 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   flex-direction:column;
   gap:0;
   pointer-events:auto;
-  scrollbar-gutter:stable;
 }
 
 .post-board{
@@ -1873,14 +1872,20 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   background:rgba(0,0,0,0.7);
   pointer-events:auto;
   transition:left 0.3s ease, opacity 0.3s ease, margin 0.3s ease;
-  scrollbar-gutter:stable;
 }
 .post-board .post-card{
   width:100%;
+  max-width:100%;
+}
+
+.post-board .open-post{
+  width:100%;
+  max-width:100%;
 }
 
 .recents-board .recents-card{
   width:100%;
+  max-width:100%;
 }
 .recents-board .recents-card{
   margin:0;
@@ -2534,7 +2539,6 @@ body.filters-active #filterBtn{
   overflow-x:hidden;
   padding:0;
   margin:0;
-  scrollbar-gutter:stable;
 }
 .post-board .posts,
 .recents-board{
@@ -2696,8 +2700,8 @@ body.filters-active #filterBtn{
 
 .open-post .post-details{
   margin-top:0;
-  width:100%;
-  max-width:100%;
+  width:calc(100% - 20px);
+  max-width:calc(100% - 20px);
   min-width:0;
   display:flex;
   flex-direction:column;
@@ -2705,6 +2709,8 @@ body.filters-active #filterBtn{
   padding:10px;
   flex:1 1 auto;
   box-sizing:border-box;
+  margin-left:auto;
+  margin-right:auto;
 }
 
 .open-post:not(.desc-expanded) .post-venue-selection-container,
@@ -4131,10 +4137,12 @@ img.thumb{
     width:100%;
   }
   .open-post .post-details{
-    width:100%;
-    max-width:100%;
+    width:calc(100% - 20px);
+    max-width:calc(100% - 20px);
     min-width:0;
     padding:10px 0;
+    margin-left:auto;
+    margin-right:auto;
   }
   .open-post .image-box{
     width:100%;


### PR DESCRIPTION
## Summary
- constrain post and recents cards as well as open posts to their board width limits
- shrink the post details container by 20px and center it across viewports so content stays within the board
- drop reserved scrollbar gutters from the post board scrolling area

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce3b7d917883318b20e95711022928