### PR TITLE
Fix mobile post image aspect ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -4154,7 +4154,7 @@ img.thumb{
     max-width:100%;
     aspect-ratio:1/1;
     height:auto;
-    flex:0 0 100%;
+    flex:0 0 auto;
     border-radius:8px;
     display:grid;
     place-items:center;


### PR DESCRIPTION
## Summary
- ensure the mobile post image box uses auto flex sizing so it stays square and matches the board width

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf805df2b48331ba7ff0e42184801b