### PR TITLE
Ensure mobile boards fill available height

### DIFF
--- a/index.html
+++ b/index.html
@@ -4949,9 +4949,10 @@ img.thumb{
       const subH = parseFloat(rootStyles.getPropertyValue('--subheader-h')) || 0;
       const footerH = parseFloat(rootStyles.getPropertyValue('--footer-h')) || 0;
       const safeTop = parseFloat(rootStyles.getPropertyValue('--safe-top')) || 0;
-      const availableHeight = window.innerHeight - headerH - subH - footerH - safeTop;
-      document.querySelectorAll('.recents-board, .posts').forEach(list=>{
+      const availableHeight = Math.max(0, window.innerHeight - headerH - subH - footerH - safeTop);
+      document.querySelectorAll('.recents-board, .quick-list-board, .post-board, .posts').forEach(list=>{
         list.style.maxHeight = `${availableHeight}px`;
+        list.style.minHeight = `${availableHeight}px`;
       });
     }
     window.adjustListHeight = adjustListHeight;


### PR DESCRIPTION
## Summary
- clamp the computed available height used for list sizing to non-negative values
- apply the calculated height to all boards so narrow viewports keep them stretched to the viewport

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf8608f7c483319b68fbc62dc6f228