### PR TITLE
Ensure image box images remain square

### DIFF
--- a/index.html
+++ b/index.html
@@ -2777,6 +2777,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .open-post .image-box img{
   width:100%;
   height:100%;
+  aspect-ratio:1/1;
   object-fit:cover;
   object-position:center;
   display:block;
@@ -2861,6 +2862,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   .open-post .image-box img{
     width:100%;
     height:100%;
+    aspect-ratio:1/1;
     object-fit:cover;
     object-position:center;
   }
@@ -3620,6 +3622,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     border-radius:0;
     width:100%;
     height:100%;
+    aspect-ratio:1/1;
     object-fit:cover;
     display:block;
   }
@@ -3662,10 +3665,11 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     display:grid;
     place-items:center;
   }
-  .open-post .image-box img{
-    width:100%;
-    height:100%;
-  }
+    .open-post .image-box img{
+      width:100%;
+      height:100%;
+      aspect-ratio:1/1;
+    }
   .open-post .post-calendar{
     display:none;
   }
@@ -3709,6 +3713,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
       object-fit:cover;
       margin:0;
       border-radius:0;
+      aspect-ratio:1/1;
     }
     .open-post .post-body{
       padding:0;
@@ -4163,6 +4168,7 @@ img.thumb{
     width:100%;
     height:100%;
     object-fit:cover;
+    aspect-ratio:1/1;
   }
   .second-post-column{
     width:100%;


### PR DESCRIPTION
## Summary
- enforce a 1:1 aspect ratio on image-box images across styles so hero media always renders square

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfae43105c83319487448187f86af0