### PR TITLE
Adjust open post header padding and description spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2024,6 +2024,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 .post-details-description-container .desc,
 .post-details-description-container .desc-wrap{
   border:none;
+  padding:0;
 }
 
 .ad-board{
@@ -2669,7 +2670,7 @@ body.filters-active #filterBtn{
   display:flex;
   justify-content:space-between;
   align-items:center;
-  padding:6px 12px;
+  padding:6px 20px;
   opacity:1;
   border-top-left-radius:inherit;
   border-top-right-radius:inherit;
@@ -2834,7 +2835,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     padding:0;
   }
   .open-post .post-header{
-    padding:6px 0;
+    padding:6px 20px;
   }
   .open-post .post-images,
   .open-post .venue-dropdown,


### PR DESCRIPTION
## Summary
- add 20px horizontal padding to the open post header for consistent spacing
- remove padding from the post description container so the copy sits flush

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfce522c648331a9386a2b26e66569