### PR TITLE
Adjust post layout spacing and thumbnail styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2670,7 +2670,7 @@ body.filters-active #filterBtn{
   display:flex;
   justify-content:space-between;
   align-items:center;
-  padding:6px 20px;
+  padding:10px;
   opacity:1;
   border-top-left-radius:inherit;
   border-top-right-radius:inherit;
@@ -2835,7 +2835,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     padding:0;
   }
   .open-post .post-header{
-    padding:6px 20px;
+    padding:10px;
   }
   .open-post .post-images,
   .open-post .venue-dropdown,
@@ -3635,7 +3635,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   .open-post .thumbnail-row img{
     width:60px;
     height:60px;
-    border-radius:0;
+    border-radius:8px;
   }
 }
 
@@ -4151,7 +4151,7 @@ img.thumb{
     width:calc(100% - 20px);
     max-width:calc(100% - 20px);
     min-width:0;
-    padding:10px 0;
+    padding:10px;
     margin-left:auto;
     margin-right:auto;
   }
@@ -4161,7 +4161,7 @@ img.thumb{
     aspect-ratio:1/1;
     height:auto;
     flex:0 0 auto;
-    border-radius:8px;
+    border-radius:0;
     display:grid;
     place-items:center;
   }
@@ -4202,7 +4202,7 @@ img.thumb{
     transform:none;
   }
   .open-post .post-header{
-    padding-bottom:0;
+    padding:10px;
   }
   .open-post .post-body{
     padding:0;


### PR DESCRIPTION
## Summary
- standardize the open post header padding to 10px across breakpoints
- keep post details padded by 10px and remove border radius from the image box in responsive views
- ensure post image thumbnails consistently use an 8px border radius

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd0953e348331846a3a9d44f4af15