### PR TITLE
Ensure post details description aligns with board edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -3590,7 +3590,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     max-width:100%;
   }
   .post-details-description-container .desc-wrap{
-    margin:10px 10px 0;
+    margin:10px 0 0;
   }
   .post-details-description-container .desc{
     margin:0;


### PR DESCRIPTION
## Summary
- update the mobile `.post-details-description-container .desc-wrap` margins so the description stays 10px from the board edges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd3e3e81c83319df305c3a1430f94