### PR TITLE
Adjust image spacing and marker styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1980,6 +1980,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   width:100%;
   max-width:var(--post-board-max-w);
   padding:0 10px;
+  margin:0 5px;
   box-sizing:border-box;
   gap:5px;
 }
@@ -2286,23 +2287,30 @@ body.filters-active #filterBtn{
 .quick-list-board .info > div{
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0;
 }
 
 .post-board .info > div{
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0;
 }
 
 .badge{
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  display: inline-grid;
-  place-items: center;
-  border: 1px solid rgba(255,255,255,.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-size: 14px;
+  padding-right: 5px;
+  border: 0;
+  border-radius: 0;
+  width: auto;
+  height: auto;
+  line-height: 1;
+}
+
+.info > div > :not(.badge) + *{
+  margin-left: 5px;
 }
 
 .fav{
@@ -2774,7 +2782,7 @@ body.filters-active #filterBtn{
 .open-post .post-images{
   display:flex;
   flex-direction:column;
-  gap:var(--gap);
+  gap:5px;
   width:100%;
   max-width:var(--post-board-max-w);
   flex:0 0 100%;
@@ -2837,7 +2845,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   overflow-x:auto;
   gap:4px;
   position:relative;
-  margin:0 auto;
+  margin:0 5px;
 }
 
 .open-post .thumbnail-row img{
@@ -2914,7 +2922,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     width:100%;
     max-width:100%;
     padding:0 10px;
-    margin:0 auto;
+    margin:0 5px;
   }
   .open-post .venue-dropdown,
   .open-post .session-dropdown{
@@ -3675,7 +3683,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     display:block;
   }
   .open-post .thumbnail-row{
-    padding:10px 0 0;
+    padding:0;
     justify-content:center;
     gap:8px;
   }
@@ -3998,6 +4006,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   border-radius: 8px;
   cursor: pointer;
   min-width: 0;
+  box-sizing: border-box;
 }
 
 
@@ -4096,6 +4105,18 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .multi-hover .soonest{
   color: var(--ink-d);
   font-weight: 600;
+}
+
+@media (max-width:600px){
+  .mapboxgl-popup.map-card .multi-hover,
+  .mapboxgl-popup.map-card .multi-list,
+  .mapboxgl-popup.map-card .multi-item.map-card{
+    width: 90vw;
+    max-width: 90vw;
+  }
+  .mapboxgl-popup.map-card .multi-item.map-card .hover-card{
+    max-width: 100%;
+  }
 }
 
 .hero img.lqip{
@@ -7216,7 +7237,7 @@ function makePosts(){
       // Hover ring layer for individual points
       map.addLayer({ id:'hover-ring', type:'circle', source:'posts', filter:['==',['get','id'],'__none__'], paint:{
         'circle-color': '#ffffff', 'circle-opacity': 0, 'circle-stroke-color':'#fff', 'circle-stroke-opacity':0.95,
-        'circle-stroke-width': 2, 'circle-radius': 12
+        'circle-stroke-width': 2, 'circle-radius': 20
       }});
 
       // Cursor + popup for unclustered points


### PR DESCRIPTION
## Summary
- adjust thumbnail row margins and image spacing so post thumbnails sit 5px from the sides and closer to the main image
- restyle badges with inline padding instead of circular borders and improve map marker highlighting
- expand multi-venue map popup cards to 90% viewport width on narrow screens for better readability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfffa003ec83318ff4228a5482b5db