### PR TITLE
Adjust post description font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -2102,6 +2102,10 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   padding:0;
 }
 
+.post-details-description-container .desc{
+  font-size:13px;
+}
+
 .ad-board{
   position:fixed;
   top:calc(var(--header-h) + var(--safe-top));


### PR DESCRIPTION
## Summary
- set the post description text to 13px for consistent typography

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d07f8a36d8833196951d07b14f4ebc