### PR TITLE
Replace posts/map buttons with toggle control

### DIFF
--- a/index.html
+++ b/index.html
@@ -2103,7 +2103,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 }
 
 .post-details-description-container .desc{
-  font-size:13px;
+  font-size:14px;
 }
 
 .ad-board{
@@ -2195,7 +2195,7 @@ body.hide-ads .ad-board{
 }
 .mode-toggle{
   display:grid;
-  grid-template-columns:repeat(3,1fr);
+  grid-template-columns:repeat(2,1fr);
   flex:0 1 auto;
   min-width:0;
   height:40px;
@@ -2233,6 +2233,26 @@ body.hide-ads .ad-board{
 .mode-toggle button[aria-pressed="true"]{
   background:var(--btn-selected);
   color:var(--button-active-text);
+}
+.mode-toggle #viewToggle{
+  gap:8px;
+}
+.mode-toggle #viewToggle .toggle-option{
+  opacity:0.6;
+  transition:opacity .2s;
+  font-weight:600;
+}
+.mode-toggle #viewToggle .toggle-divider{
+  opacity:0.5;
+}
+.mode-toggle #viewToggle[data-mode="posts"] .toggle-option[data-toggle-label="posts"],
+.mode-toggle #viewToggle[data-mode="map"] .toggle-option[data-toggle-label="map"]{
+  opacity:1;
+  font-weight:700;
+}
+.mode-toggle #viewToggle[data-mode="history"] .toggle-option{
+  opacity:0.4;
+  font-weight:600;
 }
 body.filters-active #filterBtn{
   background: var(--filter-active-color);
@@ -4416,25 +4436,10 @@ img.thumb{
           </span>
           <span class="mode-label">Recents</span>
         </button>
-        <button id="postsToggle" aria-pressed="false" aria-label="Posts">
-          <span class="mode-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="3" y="4" width="18" height="4" rx="1"></rect>
-              <rect x="3" y="10" width="18" height="4" rx="1"></rect>
-              <rect x="3" y="16" width="18" height="4" rx="1"></rect>
-            </svg>
-          </span>
-          <span class="mode-label">Posts</span>
-        </button>
-        <button id="mapToggle" aria-pressed="true" aria-label="Map">
-          <span class="mode-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21"></polygon>
-              <line x1="9" y1="3" x2="9" y2="18"></line>
-              <line x1="15" y1="6" x2="15" y2="21"></line>
-            </svg>
-          </span>
-          <span class="mode-label">Map</span>
+        <button id="viewToggle" aria-pressed="false" aria-label="Toggle between Posts and Map views" data-mode="map">
+          <span class="toggle-option" data-toggle-label="posts">Posts</span>
+          <span class="toggle-divider" aria-hidden="true">/</span>
+          <span class="toggle-option" data-toggle-label="map">Map</span>
         </button>
       </div>
     </nav>
@@ -6473,15 +6478,18 @@ function makePosts(){
       const boardsContainer = $('.post-mode-boards');
       const postBoard = $('.post-board');
       const recentsButton = $('#recents-button');
-      const postsToggle = $('#postsToggle');
-      const mapToggle = $('#mapToggle');
+      const viewToggle = $('#viewToggle');
 
       function updateModeToggle(){
         const historyActive = document.body.classList.contains('show-history');
         const currentMode = document.body.classList.contains('mode-posts') ? 'posts' : 'map';
         recentsButton && recentsButton.setAttribute('aria-pressed', historyActive ? 'true' : 'false');
-        postsToggle && postsToggle.setAttribute('aria-pressed', !historyActive && currentMode === 'posts' ? 'true' : 'false');
-        mapToggle && mapToggle.setAttribute('aria-pressed', !historyActive && currentMode === 'map' ? 'true' : 'false');
+        if(viewToggle){
+          viewToggle.setAttribute('aria-pressed', !historyActive && currentMode === 'posts' ? 'true' : 'false');
+          viewToggle.setAttribute('data-mode', historyActive ? 'history' : currentMode);
+          const toggleLabel = currentMode === 'posts' ? 'Switch to Map view' : 'Switch to Posts view';
+          viewToggle.setAttribute('aria-label', historyActive ? 'Toggle between Posts and Map views' : toggleLabel);
+        }
       }
 
       function adjustBoards(){
@@ -6573,22 +6581,20 @@ function makePosts(){
         updateModeToggle();
       });
 
-      postsToggle && postsToggle.addEventListener('click', ()=>{
+      viewToggle && viewToggle.addEventListener('click', ()=>{
+        const currentMode = document.body.classList.contains('mode-posts') ? 'posts' : 'map';
+        const nextMode = currentMode === 'posts' ? 'map' : 'posts';
         document.body.classList.remove('show-history');
-        setMode('posts');
-        window.adjustListHeight();
-        setTimeout(()=>{
-          if(map && typeof map.resize === 'function'){
-            map.resize();
-            updatePostPanel();
-          }
-        }, 0);
-        updateModeToggle();
-      });
-
-      mapToggle && mapToggle.addEventListener('click', ()=>{
-        document.body.classList.remove('show-history');
-        setMode('map');
+        setMode(nextMode);
+        if(nextMode === 'posts'){
+          window.adjustListHeight();
+          setTimeout(()=>{
+            if(map && typeof map.resize === 'function'){
+              map.resize();
+              updatePostPanel();
+            }
+          }, 0);
+        }
         updateModeToggle();
       });
 


### PR DESCRIPTION
## Summary
- replace the separate posts and map buttons with a single Posts/Map toggle control in the header
- update styling and behavior to support the new toggle and accessibility labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d081d63c6883319e887bd8bacead71