### PR TITLE
Replace posts/map buttons with toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2195,7 +2195,7 @@ body.hide-ads .ad-board{
 }
 .mode-toggle{
   display:grid;
-  grid-template-columns:repeat(3,1fr);
+  grid-template-columns:repeat(2,1fr);
   flex:0 1 auto;
   min-width:0;
   height:40px;
@@ -2226,6 +2226,25 @@ body.hide-ads .ad-board{
 }
 .mode-toggle .mode-label{
   white-space:nowrap;
+}
+.mode-toggle #viewToggle{
+  gap:4px;
+}
+#viewToggle .toggle-option{
+  opacity:0.6;
+  transition:opacity .2s;
+}
+#viewToggle .toggle-divider{
+  opacity:0.4;
+  transition:opacity .2s;
+}
+#viewToggle[data-mode="posts"] .toggle-option-posts,
+#viewToggle[data-mode="map"] .toggle-option-map{
+  opacity:1;
+}
+#viewToggle[data-mode="posts"] .toggle-divider,
+#viewToggle[data-mode="map"] .toggle-divider{
+  opacity:0.8;
 }
 .mode-toggle button + button{
   border-left:1px solid var(--btn);
@@ -4416,25 +4435,10 @@ img.thumb{
           </span>
           <span class="mode-label">Recents</span>
         </button>
-        <button id="postsToggle" aria-pressed="false" aria-label="Posts">
-          <span class="mode-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="3" y="4" width="18" height="4" rx="1"></rect>
-              <rect x="3" y="10" width="18" height="4" rx="1"></rect>
-              <rect x="3" y="16" width="18" height="4" rx="1"></rect>
-            </svg>
-          </span>
-          <span class="mode-label">Posts</span>
-        </button>
-        <button id="mapToggle" aria-pressed="true" aria-label="Map">
-          <span class="mode-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21"></polygon>
-              <line x1="9" y1="3" x2="9" y2="18"></line>
-              <line x1="15" y1="6" x2="15" y2="21"></line>
-            </svg>
-          </span>
-          <span class="mode-label">Map</span>
+        <button id="viewToggle" aria-pressed="false" aria-label="Switch to Posts view" data-mode="map">
+          <span class="toggle-option toggle-option-posts">Posts</span>
+          <span class="toggle-divider" aria-hidden="true">|</span>
+          <span class="toggle-option toggle-option-map">Map</span>
         </button>
       </div>
     </nav>
@@ -6473,15 +6477,18 @@ function makePosts(){
       const boardsContainer = $('.post-mode-boards');
       const postBoard = $('.post-board');
       const recentsButton = $('#recents-button');
-      const postsToggle = $('#postsToggle');
-      const mapToggle = $('#mapToggle');
+      const viewToggle = $('#viewToggle');
 
       function updateModeToggle(){
         const historyActive = document.body.classList.contains('show-history');
         const currentMode = document.body.classList.contains('mode-posts') ? 'posts' : 'map';
         recentsButton && recentsButton.setAttribute('aria-pressed', historyActive ? 'true' : 'false');
-        postsToggle && postsToggle.setAttribute('aria-pressed', !historyActive && currentMode === 'posts' ? 'true' : 'false');
-        mapToggle && mapToggle.setAttribute('aria-pressed', !historyActive && currentMode === 'map' ? 'true' : 'false');
+        if(viewToggle){
+          const postsActive = !historyActive && currentMode === 'posts';
+          viewToggle.setAttribute('aria-pressed', postsActive ? 'true' : 'false');
+          viewToggle.setAttribute('data-mode', postsActive ? 'posts' : 'map');
+          viewToggle.setAttribute('aria-label', postsActive ? 'Switch to Map view' : 'Switch to Posts view');
+        }
       }
 
       function adjustBoards(){
@@ -6573,22 +6580,22 @@ function makePosts(){
         updateModeToggle();
       });
 
-      postsToggle && postsToggle.addEventListener('click', ()=>{
-        document.body.classList.remove('show-history');
-        setMode('posts');
-        window.adjustListHeight();
-        setTimeout(()=>{
-          if(map && typeof map.resize === 'function'){
-            map.resize();
-            updatePostPanel();
-          }
-        }, 0);
-        updateModeToggle();
-      });
-
-      mapToggle && mapToggle.addEventListener('click', ()=>{
-        document.body.classList.remove('show-history');
-        setMode('map');
+      viewToggle && viewToggle.addEventListener('click', ()=>{
+        const postsActive = document.body.classList.contains('mode-posts') && !document.body.classList.contains('show-history');
+        if(postsActive){
+          document.body.classList.remove('show-history');
+          setMode('map');
+        } else {
+          document.body.classList.remove('show-history');
+          setMode('posts');
+          window.adjustListHeight();
+          setTimeout(()=>{
+            if(map && typeof map.resize === 'function'){
+              map.resize();
+              updatePostPanel();
+            }
+          }, 0);
+        }
         updateModeToggle();
       });
 


### PR DESCRIPTION
## Summary
- replace the separate Posts and Map buttons with a single toggle control that displays both labels
- adjust styling and mode management logic to support the new toggle states and accessibility labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0854487c0833192e48c57a4211034