### PR TITLE
Set post description font size to 14px

### DIFF
--- a/index.html
+++ b/index.html
@@ -3623,6 +3623,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .desc{
   margin-top:8px;
   cursor:pointer;
+  font-size:14px;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure `.desc` elements display post description text at 14px for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0861383788331a430670968369b41