### PR TITLE
Limit random post descriptions to 50-200 words

### DIFF
--- a/index.html
+++ b/index.html
@@ -5600,7 +5600,7 @@ function uniqueTitle(seed, cityName, idx){
     return [hero, ...others];
   }
 
-  function randomText(min=100,max=500){
+  function randomText(min=50,max=200){
     const lorem = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua".split(' ');
     const count = min + Math.floor(rnd()*(max-min+1));
     const words = [];


### PR DESCRIPTION
## Summary
- reduce the random post description generator to produce 50-200 word entries so posts meet the requested length range

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d08af16a2883318d5c609e87e6775b