### PR TITLE
Prevent sticky post header from blocking cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2780,6 +2780,12 @@ body.filters-active #filterBtn{
   top:0;
   z-index:3;
   background:transparent;
+  pointer-events:none;
+}
+.open-post .post-header button,
+.open-post .post-header [role="button"],
+.open-post .post-header a{
+  pointer-events:auto;
 }
 .post-card .post-header{
   background-color:transparent;


### PR DESCRIPTION
## Summary
- disable pointer events on the sticky open-post header so underlying cards remain clickable
- re-enable pointer events on interactive controls within the header to keep share and favourite buttons functional

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d138efd1c8833189f74c272a11e1eb