### PR TITLE
Fix post board layout overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1843,7 +1843,7 @@ button[aria-expanded="true"] .results-arrow{
   padding-right:0;
   display:flex;
   justify-content:center;
-  align-items:stretch;
+  align-items:flex-start;
   gap:var(--gap);
   z-index:2;
   pointer-events:none;
@@ -1900,7 +1900,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   opacity:1;
   display:flex;
   flex-direction:column;
-  height:100%;
+  height:auto;
   min-height:0;
   max-height:100%;
   transition:left 0.3s ease, opacity 0.3s ease;
@@ -1910,7 +1910,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   width:var(--post-board-max-w);
   max-width:var(--post-board-max-w);
   flex-shrink:0;
-  height:100%;
+  height:auto;
   min-height:0;
   max-height:100%;
 }
@@ -3630,7 +3630,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     padding:0;
     gap:0;
     flex-direction:column;
-    align-items:stretch;
+    align-items:flex-start;
   }
   .quick-list-board,
   .post-board,
@@ -3641,9 +3641,10 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
     right:0;
     padding:0;
     border-radius:0;
-    flex:1 1 auto;
+    flex:0 0 auto;
     min-height:0;
-    height:100%;
+    height:auto;
+    max-height:100%;
   }
   .quick-list-board{
     position:relative;
@@ -5169,9 +5170,9 @@ img.thumb{
       document.querySelectorAll('.recents-board, .quick-list-board, .post-board, .posts').forEach(list=>{
         if(availableHeight > 0){
           const value = `${availableHeight}px`;
-          list.style.height = value;
           list.style.maxHeight = value;
-          list.style.minHeight = value;
+          list.style.removeProperty('height');
+          list.style.removeProperty('min-height');
         } else {
           list.style.removeProperty('height');
           list.style.removeProperty('max-height');


### PR DESCRIPTION
## Summary
- let the post and recents boards size to their content instead of stretching across the viewport
- tweak the mobile board layout to avoid forcing fixed heights
- update the list height adjustment script to clamp max-height without overriding height/min-height

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d140b8af808331a2fb4ec32d5d0f74