### PR TITLE
Adjust mobile open post stacking

### DIFF
--- a/index.html
+++ b/index.html
@@ -4379,6 +4379,16 @@ img.thumb{
   .open-post .post-body{
     padding:0;
   }
+  .open-post .post-header{
+    position:static;
+    top:auto;
+    z-index:auto;
+  }
+  body.open-post-sticky-images .open-post .post-images{
+    position:static;
+    top:auto;
+    align-self:stretch;
+  }
 }
 
 </style>


### PR DESCRIPTION
## Summary
- stop using sticky positioning for open post headers on narrow screens so they no longer overlap cards
- disable sticky image behavior for open posts in mobile layouts to eliminate the large transparent overlay area

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c8cf55448331a41199ef21995552