### PR TITLE
Ensure mode-posts restored after closing post details

### DIFF
--- a/index.html
+++ b/index.html
@@ -8094,8 +8094,15 @@ function makePosts(){
       }
 
       function closeActivePost(){
+        const ensurePostMode = () => {
+          if(mode === 'posts'){
+            document.body.classList.add('mode-posts');
+            document.body.classList.remove('mode-map');
+          }
+        };
         const openEl = document.querySelector('.post-board .open-post, #recentsBoard .open-post');
         if(!openEl){
+          ensurePostMode();
           document.body.classList.remove('detail-open');
           if(typeof initPostLayout === 'function') initPostLayout(postsWideEl);
           if(typeof window.adjustBoards === 'function') window.adjustBoards();
@@ -8117,6 +8124,7 @@ function makePosts(){
           if(detachedColumn.dataset) delete detachedColumn.dataset.openPostId;
           detachedColumn.remove();
         }
+        ensurePostMode();
         document.body.classList.remove('detail-open');
         $$('.recents-card[aria-selected="true"], .post-card[aria-selected="true"]').forEach(el=> el.removeAttribute('aria-selected'));
         if(post){


### PR DESCRIPTION
## Summary
- ensure closing a post detail re-applies post mode classes so the list remains interactive when it should stay visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2219ed154833195bdd7e4fcd37c79