### PR TITLE
Refine touch detection for unclustered marker clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -7369,7 +7369,15 @@ function makePosts(){
           }
         }
         const id = f.properties.id;
-        const touchClick = isTouchDevice || (e.originalEvent && (e.originalEvent.pointerType === 'touch' || e.originalEvent.pointerType === 'pen'));
+        const originalEvent = e.originalEvent || {};
+        let pointerType = '';
+        if(typeof originalEvent.pointerType === 'string'){
+          pointerType = originalEvent.pointerType.toLowerCase();
+        } else if(typeof originalEvent.pointerType === 'number'){
+          pointerType = ({2:'touch',3:'pen',4:'mouse'})[originalEvent.pointerType] || '';
+        }
+        const inferredTouch = !pointerType && typeof TouchEvent !== 'undefined' && originalEvent instanceof TouchEvent;
+        const touchClick = pointerType === 'touch' || pointerType === 'pen' || inferredTouch;
         if(touchClick){
           if(touchMarker === id){
             touchMarker = null;


### PR DESCRIPTION
## Summary
- update the unclustered marker click handler to rely on the event pointer type instead of device capability flags
- keep the two-tap protection for genuine touch and pen pointers while allowing mouse clicks to open immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d225b747608331b2601c16daa0b3e9