### PR TITLE
Add standard line-clamp property for descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3074,6 +3074,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 
 .second-post-column .desc{
   display:-webkit-box;
+  line-clamp:2;
   -webkit-line-clamp:2;
   -webkit-box-orient:vertical;
   overflow:hidden;
@@ -3088,6 +3089,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 
 .second-post-column .desc.expanded{
   display:block;
+  line-clamp:unset;
   -webkit-line-clamp:unset;
   overflow:visible;
   text-overflow:unset;


### PR DESCRIPTION
## Summary
- add the standard `line-clamp` property alongside existing vendor-prefixed declarations for post descriptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d26264fb58833183848d1ba0de1b50