### PR TITLE
Expose closestElement helper globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -4739,6 +4739,16 @@ img.thumb{
   </div>
 
   <script>
+  function closestElement(target, selector){
+    if(!target) return null;
+    if(target instanceof Element){
+      return target.closest(selector);
+    }
+    const parent = target.parentElement || (target.parentNode instanceof Element ? target.parentNode : null);
+    return parent ? parent.closest(selector) : null;
+  }
+  window.closestElement = closestElement;
+
   (function(){
     const origAddEventListener = EventTarget.prototype.addEventListener;
     EventTarget.prototype.addEventListener = function(type, listener, options){
@@ -4760,16 +4770,6 @@ img.thumb{
   const geocoders = [];
   const CARD_SURFACE = 'linear-gradient(rgba(0,0,0,0.8),rgba(0,0,0,0.6))';
   const IMAGE_FALLBACK = 'assets/balloons/balloons-icon-16185.png';
-
-  function closestElement(target, selector){
-    if(!target) return null;
-    if(target instanceof Element){
-      return target.closest(selector);
-    }
-    const parent = target.parentElement || (target.parentNode instanceof Element ? target.parentNode : null);
-    return parent ? parent.closest(selector) : null;
-  }
-  window.closestElement = closestElement;
 
   function addImageFallback(img, extraFallbacks){
     if(!(img instanceof Element)) return;


### PR DESCRIPTION
## Summary
- move the closestElement helper definition ahead of the main map IIFE and bind it to window so global handlers can access it

## Testing
- Manual: Served index.html locally and opened it in a headless browser to confirm no "closestElement is not defined" errors (only WebGL warnings observed)


------
https://chatgpt.com/codex/tasks/task_e_68d265c4411c833190a45eba540a38fb