### PR TITLE
Expose closestElement globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -4739,15 +4739,14 @@ img.thumb{
   </div>
 
   <script>
-  function closestElement(target, selector){
+  window.closestElement = function closestElement(target, selector){
     if(!target) return null;
     if(target instanceof Element){
       return target.closest(selector);
     }
     const parent = target.parentElement || (target.parentNode instanceof Element ? target.parentNode : null);
     return parent ? parent.closest(selector) : null;
-  }
-  window.closestElement = closestElement;
+  };
 
   (function(){
     const origAddEventListener = EventTarget.prototype.addEventListener;


### PR DESCRIPTION
## Summary
- attach the `closestElement` helper to `window` so event handlers can resolve the global function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d26a2f4c748331bcd6eec8ff5d823b