### PR TITLE
Expose closestElement helper globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -4739,14 +4739,15 @@ img.thumb{
   </div>
 
   <script>
-  window.closestElement = function closestElement(target, selector){
+  function closestElement(target, selector){
     if(!target) return null;
     if(target instanceof Element){
       return target.closest(selector);
     }
     const parent = target.parentElement || (target.parentNode instanceof Element ? target.parentNode : null);
     return parent ? parent.closest(selector) : null;
-  };
+  }
+  window.closestElement = closestElement;
 
   (function(){
     const origAddEventListener = EventTarget.prototype.addEventListener;


### PR DESCRIPTION
## Summary
- define the `closestElement` helper before the main IIFE and attach it to `window` so external handlers can use it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d284b550f08331955d8e12b36023fb