### PR TITLE
Expose closestElement helper globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -4739,15 +4739,14 @@ img.thumb{
   </div>
 
   <script>
-  function closestElement(target, selector){
+  const closestElement = window.closestElement = (target, selector) => {
     if(!target) return null;
     if(target instanceof Element){
       return target.closest(selector);
     }
     const parent = target.parentElement || (target.parentNode instanceof Element ? target.parentNode : null);
     return parent ? parent.closest(selector) : null;
-  }
-  window.closestElement = closestElement;
+  };
 
   (function(){
     const origAddEventListener = EventTarget.prototype.addEventListener;


### PR DESCRIPTION
## Summary
- assign the closestElement helper to both a top-level constant and window.closestElement so it can be used outside the IIFE wrappers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d287f8316c8331ae5f0172d39e1526