### PR TITLE
Remove unused Mapbox properties from post features

### DIFF
--- a/index.html
+++ b/index.html
@@ -6844,8 +6844,6 @@ function makePosts(){
                 cat:p.category,
                 sub: isMultiVenue ? MULTI_VENUE_MARKER_ID : baseSub,
                 baseSub,
-                layer:'poi',
-                sizerank:1,
                 multi:isMultiVenue ? 1 : 0
               },
               geometry:{type:'Point', coordinates:[p.lng, p.lat]}


### PR DESCRIPTION
## Summary
- remove unused Mapbox style properties from postsToGeoJSON output to avoid console warnings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2a0ff13a483318584fd08bb4c6a64