### PR TITLE
Update Mapbox CDN to v3.16.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
   <link rel="manifest" href="assets/favicons/site.webmanifest" />
   <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
-  <link href='https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css' rel='stylesheet' />
+  <link href='https://api.mapbox.com/mapbox-gl-js/v3.16.0/mapbox-gl.css' rel='stylesheet' />
   <link
     rel="stylesheet"
-    href="https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css"
-    data-fallback="https://unpkg.com/mapbox-gl@3.14.0/dist/mapbox-gl.css"
+    href="https://api.mapbox.com/mapbox-gl-js/v3.16.0/mapbox-gl.css"
+    data-fallback="https://unpkg.com/mapbox-gl@3.16.0/dist/mapbox-gl.css"
     onerror="if(this.dataset.fallback && this.href !== this.dataset.fallback){this.dataset.fallbackState='retry';this.href=this.dataset.fallback;}else{this.dataset.fallbackState='failed';}"
   />
   <link
@@ -6434,8 +6434,8 @@ function makePosts(){
       const cssSources = [
         {
           selector: 'link[href*="mapbox-gl.css"], link[href*="mapbox-gl@"], style[data-mapbox]',
-          primary: 'https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css',
-          fallback: 'https://unpkg.com/mapbox-gl@3.14.0/dist/mapbox-gl.css'
+          primary: 'https://api.mapbox.com/mapbox-gl-js/v3.16.0/mapbox-gl.css',
+          fallback: 'https://unpkg.com/mapbox-gl@3.16.0/dist/mapbox-gl.css'
         },
         {
           selector: 'link[href*="mapbox-gl-geocoder.css"], link[href*="mapbox-gl-geocoder@"]',
@@ -6560,7 +6560,7 @@ function makePosts(){
 
       function loadScripts(){
         const s = document.createElement('script');
-        s.src='https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.js';
+        s.src='https://api.mapbox.com/mapbox-gl-js/v3.16.0/mapbox-gl.js';
         s.onload = ()=>{
           const g = document.createElement('script');
           g.src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js';


### PR DESCRIPTION
## Summary
- bump Mapbox GL CDN references in index.html to version 3.16.0
- keep fallback loader logic in sync with the new Mapbox GL version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2acc117548331898de18758a65061