### PR TITLE
Fix console errors for detail map and icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9035,8 +9035,7 @@ function makePosts(){
         }
         runNext();
       }
-
-      }
+        
         if(mapEl){
           setTimeout(()=>{
             loadMapbox(()=>{
@@ -9983,7 +9982,12 @@ document.addEventListener('pointerdown', handleDocInteract);
 </script>
 <script>
 (function(){
-  const shapeList = Object.keys(SHAPES);
+  const ICON_BASE = window.ICON_BASE || {};
+  const subcategoryIcons = window.subcategoryIcons || (window.subcategoryIcons = {});
+  const subcategoryMarkers = window.subcategoryMarkers || (window.subcategoryMarkers = {});
+  const subcategoryMarkerIds = window.subcategoryMarkerIds || (window.subcategoryMarkerIds = {});
+  const categoryShapes = window.categoryShapes || (window.categoryShapes = {});
+  const shapeList = Object.keys(window.SHAPES || {});
   let colorIdx = 0;
   const cats = window.categories || [];
   cats.forEach((cat, idx) => {


### PR DESCRIPTION
## Summary
- remove an extra closing brace so the detail-map script parses correctly
- ensure the category icon bootstrap script reads/writes shared globals on window before use

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e63fbff08331a24e371715360102