### PR TITLE
Guard detail map fog clearing until style ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -9041,7 +9041,11 @@ function openPostModal(id){
               armPointerOnSymbolLayers(map);
 
               // No sky/fog
-              if (typeof map.setFog === 'function') map.setFog(null);
+              if (typeof map.setFog === 'function') {
+                whenStyleReady(map, () => {
+                  try { map.setFog(null); } catch(e){}
+                });
+              }
 
               // Keep 404 icon spam away while reusing existing assets
               map.on('styleimagemissing', (e) => {


### PR DESCRIPTION
## Summary
- ensure the detail venue map waits for the style to load before clearing fog to avoid Mapbox errors and lingering night sky visuals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d41a198cf88331b2f71342c36e685f