### PR TITLE
Add standard line-clamp property

### DIFF
--- a/index.html
+++ b/index.html
@@ -3111,6 +3111,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .second-post-column .desc{
   display:-webkit-box;
   -webkit-line-clamp:2;
+  line-clamp:2;
   -webkit-box-orient:vertical;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -3125,6 +3126,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .second-post-column .desc.expanded{
   display:block;
   -webkit-line-clamp:unset;
+  line-clamp:unset;
   overflow:visible;
   text-overflow:unset;
 }


### PR DESCRIPTION
## Summary
- add the standard `line-clamp` property alongside the existing `-webkit-line-clamp` for truncated descriptions
- ensure the expanded state also resets both properties for consistent behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d41c8780388331a7e8bf271bb25281