### PR TITLE
Restore night sky theme and align open posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4811,7 +4811,6 @@ img.thumb{
         const board = document.querySelector('.post-board');
         if (board) board.prepend(el);
       }
-      el.scrollIntoView({ block: 'start', behavior: 'smooth' });
     }
   </script>
 
@@ -4907,6 +4906,60 @@ img.thumb{
     if (map.isStyleLoaded && map.isStyleLoaded()) { fn(); return; }
     const onLoad = () => { map.off('load', onLoad); fn(); };
     map.on('load', onLoad);
+  }
+
+  function applyNightSky(mapInstance){
+    if(!mapInstance) return;
+    if(typeof mapInstance.setFog === 'function'){
+      try {
+        mapInstance.setFog({
+          color: 'rgba(11,13,23,0.6)',
+          'high-color': 'rgba(27,32,53,0.7)',
+          'horizon-blend': 0.15,
+          'space-color': '#010409',
+          'star-intensity': 0.6
+        });
+      } catch(err){}
+    }
+    if(typeof mapInstance.getLayer !== 'function'){
+      return;
+    }
+    let skyLayerId = null;
+    try {
+      if(mapInstance.getLayer('sky')){
+        skyLayerId = 'sky';
+      } else if(mapInstance.getLayer('night-sky')){
+        skyLayerId = 'night-sky';
+      } else if(typeof mapInstance.addLayer === 'function'){
+        mapInstance.addLayer({
+          id:'night-sky',
+          type:'sky',
+          paint:{
+            'sky-type':'atmosphere',
+            'sky-atmosphere-color':'#0b1d51',
+            'sky-atmosphere-halo-color':'#1a2a6c',
+            'sky-atmosphere-sun-intensity':0.1
+          }
+        });
+        skyLayerId = 'night-sky';
+      }
+    } catch(err){
+      if(!skyLayerId && typeof mapInstance.getLayer === 'function' && mapInstance.getLayer('sky')){
+        skyLayerId = 'sky';
+      }
+    }
+    if(!skyLayerId || typeof mapInstance.setPaintProperty !== 'function'){
+      return;
+    }
+    const paintUpdates = [
+      ['sky-type', 'atmosphere'],
+      ['sky-atmosphere-color', '#0b1d51'],
+      ['sky-atmosphere-halo-color', '#1a2a6c'],
+      ['sky-atmosphere-sun-intensity', 0.1]
+    ];
+    paintUpdates.forEach(([prop, value]) => {
+      try { mapInstance.setPaintProperty(skyLayerId, prop, value); } catch(err){}
+    });
   }
 
   // Attach pointer cursor only after style is ready, and re-attach if style changes later.
@@ -7294,9 +7347,7 @@ function makePosts(){
             attributionControl:true
           });
         map.on('style.load', () => {
-          if (typeof map.setFog === 'function') {
-            map.setFog(null);
-          }
+          applyNightSky(map);
         });
         ensureMapIcon = attachIconLoader(map);
       map.on('zoomstart', ()=>{
@@ -7330,6 +7381,7 @@ function makePosts(){
         map.scrollZoom.setZoomRate(1/240);
       }catch(e){}
       map.on('load', ()=>{
+        applyNightSky(map);
         $$('.map-overlay').forEach(el=>el.remove());
         if(spinEnabled){
           startSpin(true);
@@ -9071,12 +9123,7 @@ function openPostModal(id){
               // Arm pointer on symbol layers *without* touching getStyle until loaded
               armPointerOnSymbolLayers(map);
 
-              // No sky/fog
-              if (typeof map.setFog === 'function') {
-                whenStyleReady(map, () => {
-                  try { map.setFog(null); } catch(e){}
-                });
-              }
+              whenStyleReady(map, () => applyNightSky(map));
 
               // Keep 404 icon spam away while reusing existing assets
               map.on('styleimagemissing', (e) => {


### PR DESCRIPTION
## Summary
- reintroduce the night sky fog and sky layer so stars appear on both the main map and detail maps
- remove extra auto-scrolling so opened posts stay aligned with the originating card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4feaeb5a48331a9a709368b883191