### PR TITLE
Allow Mapbox canvas to use pointer cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -4428,8 +4428,8 @@ img.thumb{
   <style id="cursor-fixes">
     html, body { cursor: auto !important; }
     a, button, [role="button"], .clickable { cursor: pointer !important; }
-    .mapboxgl-canvas { cursor: grab !important; }
-    .mapboxgl-canvas:active { cursor: grabbing !important; }
+    .mapboxgl-canvas { cursor: grab; }
+    .mapboxgl-canvas:active { cursor: grabbing; }
     * { -webkit-tap-highlight-color: transparent; }
   </style>
   <script>


### PR DESCRIPTION
## Summary
- remove the `!important` cursor override from the Mapbox canvas so inline pointer styles can take effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d505bf0eec8331a24931011a39a483