### PR TITLE
Adjust thumbnail row padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2057,7 +2057,7 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   width:100%;
   max-width:var(--post-board-max-w);
   box-sizing:border-box;
-  padding:0 15px calc(var(--scrollbar-h) + 5px) 0;
+  padding:0 15px 10px 0;
   margin:0;
   gap:5px;
   overflow-x:auto;


### PR DESCRIPTION
## Summary
- reduce the bottom padding for the post image thumbnail row to 10px to tighten spacing below the thumbnails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d50b6b91088331b5f834125091f731