### PR TITLE
Stop auto-scrolling post board on open

### DIFF
--- a/index.html
+++ b/index.html
@@ -7016,20 +7016,6 @@ function makePosts(){
 
         await nextFrame();
 
-        if(!fromMap && container){
-          let targetTop = Number.isFinite(targetAlignTop) ? targetAlignTop : detail.offsetTop;
-          if(!Number.isFinite(targetTop)) targetTop = detail.offsetTop;
-          if(!Number.isFinite(targetTop)) targetTop = 0;
-          if(targetTop < 0) targetTop = 0;
-          requestAnimationFrame(() => {
-            if(typeof container.scrollTo === 'function'){
-              container.scrollTo({top: targetTop, behavior:'auto'});
-            } else {
-              container.scrollTop = targetTop;
-            }
-          });
-        }
-
         const header = detail.querySelector('.post-header');
         if(header){
           const h = header.offsetHeight;


### PR DESCRIPTION
## Summary
- prevent the post board from auto-scrolling when a post card is opened so the detail stays in place

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d51134d1308331bde319ddad815621