### PR TITLE
Improve header logo loading spinner behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,225 @@
     };
   </script>
 
+  <script>
+    (function(){
+    // Inline 40x40 dodger-blue loading spinner GIF
+    const LOADING_GIF_SRC = 'data:image/gif;base64,R0lGODlhKAAoAJEAAAAAAP///4CAgEBAQCH/C05FVFNDQVBFMi4wAwEAAAAh+QQJBgAAACwAAAAAKAAoAAACLYQPU5fbH4xy0movznrz7j8wFEeyNE80VZ8AaNe0fWG6tm8813e+93/AoPBQAAAh+QQJBgAAACwAAAAAKAAoAAACK4QPU5fbH4xy0movznrz7j8wFEeyNE80VVe2dV84RgNaHunA1ne+939AVwEAIfkECQYAAAAsAAAAACgAKAAAAi2ED1OX2x+MctJqL8568+4/MBRHsjRPNFVXtnVfOJZnum4DAEdx/eRtwKAwVgAAIfkECQYAAAAsAAAAACgAKAAAAi2ED1OX2x+MctJqL8568+4/MBRHsjRPNFVXtnVfOJZnura3AMjvLt95wKDwUAAAIfkECQYAAAAsAAAAACgAKAAAAi2ED1OX2x+MctJqL8568+4/MBRHsjRPNFVXtnVfOJZnuv4CPMUDPbd/wKAQUQAAIfkECQYAAAAsAAAAACgAKAAAAiyED1OX2x+MctJqL8568+4/MBRHsjRPNFVXtnVfOH4CWh7pwNZ3vvd/wCCkAAAh+QQJBgAAACwAAAAAKAAoAAACLIQPU5fbH4xy0movznrz7j8wFEeyNE80zQKAVVXWfWe6tm8813e+93/AoK4AACH5BAkGAAAALAAAAAAoACgAAAIuhA9Tl9sfjHLSai/OevPuPzAUs6AclTI4k3R1XziWZ7q2bzzXd773f8CgcHgpAAAh+QQJBgAAACwAAAAAKAAoAAACLoQPU5fbH4xy0movzjhwPbnAk0CxNE80VVe2dV84lme6tm8813e+93/AoHBoKAAAIfkECQYAAAAsAAAAACgAKAAAAiyED1OX2x+MctJqV8h385qDLhRHsjRPNFVXtnVfOJZnurZvPNd3vvd/wCCqAAAh+QQJBgAAACwAAAAAKAAoAAACLoQPU5fbH4xy0movzjoG0DfOA8NvNE80VVe2dV84lme6tm8813e+93/AoHDYKAAAIfkECQYAAAAsAAAAACgAKAAAAi6ED1OX2x+MctJqL8568+4/MBSVoBxJ80TKQHVfOJZnurZvPNd3vvd/wKBw6CoAADs=';
+    const MIN_VISIBLE_MS = 350;
+    const now = () => (typeof performance === 'object' && typeof performance.now === 'function') ? performance.now() : Date.now();
+    let logoImg = null;
+    let originalSrc = '';
+    let originalAlt = '';
+    let hadOriginalAlt = false;
+    let updatePending = false;
+    let activeRequests = 0;
+    let spinnerVisible = false;
+    let initialLoadPending = document.readyState !== 'complete';
+    let lastShownAt = 0;
+    let hideTimerId = null;
+
+    function ensureLogo(){
+      if(!logoImg){
+        logoImg = document.querySelector('.logo img');
+        if(logoImg){
+          if(!originalSrc){
+            originalSrc = logoImg.getAttribute('src') || '';
+          }
+          if(!hadOriginalAlt){
+            hadOriginalAlt = logoImg.hasAttribute('alt');
+            originalAlt = logoImg.getAttribute('alt') || '';
+          }
+          if(!logoImg.dataset.loadingGif){
+            logoImg.dataset.loadingGif = 'inline-data-url';
+          }
+        }
+      }
+      return logoImg;
+    }
+
+    function applyState(){
+      updatePending = false;
+      const img = ensureLogo();
+      if(!img || !originalSrc){
+        return;
+      }
+      if(spinnerVisible){
+        if(img.getAttribute('src') !== LOADING_GIF_SRC){
+          img.setAttribute('src', LOADING_GIF_SRC);
+        }
+        img.setAttribute('alt', 'Loading…');
+      } else {
+        if(img.getAttribute('src') !== originalSrc){
+          img.setAttribute('src', originalSrc);
+        }
+        if(hadOriginalAlt){
+          img.setAttribute('alt', originalAlt);
+        } else {
+          img.removeAttribute('alt');
+        }
+      }
+    }
+
+    function scheduleUpdate(){
+      if(updatePending){
+        return;
+      }
+      updatePending = true;
+      if(typeof requestAnimationFrame === 'function'){
+        requestAnimationFrame(applyState);
+      } else {
+        setTimeout(applyState, 0);
+      }
+    }
+
+    function shouldShowSpinner(){
+      return initialLoadPending || activeRequests > 0;
+    }
+
+    function showSpinnerNow(){
+      if(hideTimerId){
+        clearTimeout(hideTimerId);
+        hideTimerId = null;
+      }
+      if(!spinnerVisible){
+        spinnerVisible = true;
+        lastShownAt = now();
+        scheduleUpdate();
+      }
+    }
+
+    function hideSpinnerWhenAllowed(){
+      if(!spinnerVisible){
+        return;
+      }
+      const elapsed = now() - lastShownAt;
+      const remaining = Math.max(MIN_VISIBLE_MS - elapsed, 0);
+      if(remaining <= 0){
+        spinnerVisible = false;
+        scheduleUpdate();
+      } else {
+        if(hideTimerId){
+          clearTimeout(hideTimerId);
+        }
+        hideTimerId = setTimeout(() => {
+          hideTimerId = null;
+          if(!shouldShowSpinner()){
+            spinnerVisible = false;
+            scheduleUpdate();
+          }
+        }, remaining);
+      }
+    }
+
+    function reevaluateSpinner(){
+      if(shouldShowSpinner()){
+        showSpinnerNow();
+      } else {
+        hideSpinnerWhenAllowed();
+      }
+    }
+
+    function begin(){
+      activeRequests++;
+      reevaluateSpinner();
+    }
+
+    function end(){
+      if(activeRequests > 0){
+        activeRequests--;
+      }
+      reevaluateSpinner();
+    }
+
+    if(initialLoadPending){
+      showSpinnerNow();
+      window.addEventListener('load', () => {
+        initialLoadPending = false;
+        reevaluateSpinner();
+      }, { once: true });
+    }
+
+    if(document.readyState === 'complete' || document.readyState === 'interactive'){
+      ensureLogo();
+      scheduleUpdate();
+    } else {
+      document.addEventListener('DOMContentLoaded', () => {
+        ensureLogo();
+        scheduleUpdate();
+      }, { once: true });
+    }
+
+    window.addEventListener('pageshow', () => {
+      activeRequests = 0;
+      initialLoadPending = false;
+      spinnerVisible = false;
+      if(hideTimerId){
+        clearTimeout(hideTimerId);
+        hideTimerId = null;
+      }
+      logoImg = null;
+      ensureLogo();
+      scheduleUpdate();
+    });
+
+    const originalFetch = window.fetch;
+    if(typeof originalFetch === 'function'){
+      window.fetch = function(...args){
+        begin();
+        let finished = false;
+        const finalize = () => {
+          if(finished) return;
+          finished = true;
+          end();
+        };
+        try{
+          const response = originalFetch.apply(this, args);
+          Promise.resolve(response).then(finalize, finalize);
+          return response;
+        } catch(err){
+          finalize();
+          throw err;
+        }
+      };
+    }
+
+    if('XMLHttpRequest' in window && XMLHttpRequest.prototype){
+      const originalSend = XMLHttpRequest.prototype.send;
+      if(typeof originalSend === 'function'){
+        XMLHttpRequest.prototype.send = function(...args){
+          begin();
+          let finalized = false;
+          const finalize = () => {
+            if(finalized) return;
+            finalized = true;
+            this.removeEventListener('loadend', finalize);
+            end();
+          };
+          this.addEventListener('loadend', finalize);
+          try{
+            return originalSend.apply(this, args);
+          } catch(err){
+            finalize();
+            throw err;
+          }
+        };
+      }
+    }
+
+    if(typeof navigator === 'object' && navigator && typeof navigator.sendBeacon === 'function'){
+      const originalSendBeacon = navigator.sendBeacon.bind(navigator);
+      navigator.sendBeacon = function(...args){
+        begin();
+        try{
+          return originalSendBeacon(...args);
+        } finally {
+          end();
+        }
+      };
+    }
+    })();
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" id="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>Events Platform</title>


### PR DESCRIPTION
## Summary
- show a visibly distinct inline 40x40 loading GIF while requests are active or the initial page load is pending
- ensure the spinner stays up for a minimum duration, restores the original logo cleanly, and expose the inline source via a data attribute
- monitor fetch, XMLHttpRequest, and sendBeacon activity so the logo spinner tracks real network work and resets on history navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d51061f0348331ad8fff10a1fdb400