### PR TITLE
Fix admin and member panel alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,6 +863,8 @@ button[aria-expanded="true"] .results-arrow{
     flex-direction:column;
     overflow-y:auto;
     overflow-y:overlay;
+    left:auto;
+    right:0;
   }
 
   #adminPanel .panel-content{


### PR DESCRIPTION
## Summary
- ensure the admin and member panels default to the right edge so they no longer flash in the center before animating in

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d51df12cb88331b8a22ef724967bcd