### PR TITLE
Adjust options menu button styling for Mapbox controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -647,7 +647,7 @@ input[type="checkbox"]{
 
 
 .header button,
-.options-menu button{
+.options-menu button:not([class*="mapboxgl-ctrl"]){
   height:40px;
   display:flex;
   align-items:center;
@@ -658,7 +658,7 @@ input[type="checkbox"]{
 .header button{
   border-radius:8px;
 }
-.options-menu button{
+.options-menu button:not([class*="mapboxgl-ctrl"]){
   border-radius:0;
 }
 .header .gear,


### PR DESCRIPTION
## Summary
- update the options menu button selector so Mapbox attribution controls keep their default styling and remain unobstructed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5226112308331a00578d5b9891298