### PR TITLE
Adjust cluster fit bounds padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -8178,7 +8178,7 @@ function makePosts(){
           const lngSpan = Math.abs(ne.lng - sw.lng);
           const latSpan = Math.abs(ne.lat - sw.lat);
           if((lngSpan > 0.00001 || latSpan > 0.00001) && typeof map.fitBounds === 'function'){
-            map.fitBounds(bounds, {padding:10});
+            map.fitBounds(bounds, { padding: { top: 80, bottom: 80, left: 100, right: 100 } });
             return;
           }
         }


### PR DESCRIPTION
## Summary
- increase the map.fitBounds padding when expanding a cluster so its markers stay away from viewport edges

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5250dd56883319c062bac95b638a2