### PR TITLE
Fix map filter order to prevent stale markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -7864,9 +7864,9 @@ function makePosts(){
           if(bVal) bVal.textContent = map.getBearing().toFixed(0);
         });
         const refreshMapView = () => {
+          updatePostPanel();
           updateFilterCounts();
           refreshMarkers();
-          updatePostPanel();
           const center = map.getCenter().toArray();
           const zoom = map.getZoom();
           const pitch = map.getPitch();


### PR DESCRIPTION
## Summary
- ensure the map refresh uses the latest bounds before recomputing filtered markers
- prevent previously filtered markers from briefly reappearing after map interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d527122ff88331b5b7a80f21498549