### PR TITLE
Adjust welcome geolocate dropdown text alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2845,6 +2845,12 @@ body.filters-active #filterBtn{
   padding-right:12px;
   line-height:var(--control-h);
 }
+#welcomeBody .map-controls-welcome .mapboxgl-ctrl-geocoder,
+#welcomeBody .map-controls-welcome .mapboxgl-ctrl-geocoder *,
+#welcomeBody .map-controls-welcome .mapboxgl-ctrl-geolocate,
+#welcomeBody .map-controls-welcome .mapboxgl-ctrl-geolocate *{
+  text-align:left;
+}
 #welcomeBody .map-controls-welcome .mapboxgl-ctrl-geocoder .mapboxgl-ctrl-geocoder--button{
   display:none;
 }


### PR DESCRIPTION
## Summary
- ensure the welcome modal geolocate and geocoder controls keep their text left-aligned so autofill suggestions are no longer centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d528b081408331b1b6317dce6a6a44