### PR TITLE
Ensure logo completes rotation after geolocate

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,12 +53,76 @@
       let pendingCount = 0;
       let logoImg = null;
       let updatePending = false;
+      let stopRequested = false;
+      let stopTimeoutId = null;
+
+      function handleAnimationLoop(){
+        if(stopRequested && pendingCount === 0){
+          finalizeStop();
+        }
+      }
 
       function ensureLogo(){
         if(!logoImg){
           logoImg = document.querySelector('.logo img');
+          if(logoImg && !logoImg.__logoAnimationBound){
+            try{
+              logoImg.addEventListener('animationiteration', handleAnimationLoop);
+              logoImg.addEventListener('animationend', handleAnimationLoop);
+            }catch(err){}
+            logoImg.__logoAnimationBound = true;
+          }
         }
         return logoImg;
+      }
+
+      function finalizeStop(){
+        const img = ensureLogo();
+        if(!img){
+          return;
+        }
+        stopRequested = false;
+        if(stopTimeoutId){
+          clearTimeout(stopTimeoutId);
+          stopTimeoutId = null;
+        }
+        if(img.classList && img.classList.contains(LOADING_CLASS)){
+          img.classList.remove(LOADING_CLASS);
+        } else if(!img.classList && img.style){
+          img.style.animation = '';
+        }
+      }
+
+      function requestStop(){
+        const img = ensureLogo();
+        if(!img){
+          return;
+        }
+        if(pendingCount > 0){
+          return;
+        }
+        let isAnimating = false;
+        if(img.classList){
+          isAnimating = img.classList.contains(LOADING_CLASS);
+        } else if(img.style){
+          isAnimating = typeof img.style.animation === 'string' && img.style.animation !== '';
+        }
+        if(!isAnimating){
+          finalizeStop();
+          return;
+        }
+        if(stopRequested){
+          return;
+        }
+        stopRequested = true;
+        if(stopTimeoutId){
+          clearTimeout(stopTimeoutId);
+        }
+        stopTimeoutId = setTimeout(()=>{
+          if(stopRequested && pendingCount === 0){
+            finalizeStop();
+          }
+        }, 1200);
       }
 
       function applyState(){
@@ -68,17 +132,18 @@
           return;
         }
         if(pendingCount > 0){
+          stopRequested = false;
+          if(stopTimeoutId){
+            clearTimeout(stopTimeoutId);
+            stopTimeoutId = null;
+          }
           if(img.classList && !img.classList.contains(LOADING_CLASS)){
             img.classList.add(LOADING_CLASS);
           } else if(!img.classList){
             img.style.animation = 'logo-rotate 1s linear infinite';
           }
         } else {
-          if(img.classList){
-            img.classList.remove(LOADING_CLASS);
-          } else {
-            img.style.animation = '';
-          }
+          requestStop();
         }
       }
 


### PR DESCRIPTION
## Summary
- track loader state to keep the logo spinning until a full rotation is finished
- listen for animation loop events and fall back to a timeout to gracefully stop the spinner
- cancel pending stop requests whenever new loading begins so the logo always spins on geolocate clicks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d56bf4e674833192a43d0b0df5160e