### PR TITLE
Fix session menu toggle handler scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -9683,6 +9683,31 @@ function openPostModal(id){
           },0);
         }
 
+        function attachSessionButtonHandler(){
+          if(!sessBtn || !sessMenu) return;
+          const handler = ()=>{
+            const expanded = sessBtn.getAttribute('aria-expanded') === 'true';
+            const opening = !expanded;
+            sessBtn.setAttribute('aria-expanded', String(opening));
+            if(opening){
+              showMenu(sessMenu);
+              if(selectedIndex !== null){
+                const dt = loc.dates[selectedIndex];
+                if(dt){
+                  requestAnimationFrame(()=> scrollCalendarToMonth(dt));
+                }
+              }
+            } else {
+              hideMenu(sessMenu);
+            }
+          };
+          if(sessBtn._sessionToggle){
+            sessBtn.removeEventListener('click', sessBtn._sessionToggle);
+          }
+          sessBtn._sessionToggle = handler;
+          sessBtn.addEventListener('click', handler);
+        }
+
         ensureMapForVenue = async function(){
           if(!mapEl) return;
 
@@ -9831,6 +9856,7 @@ function openPostModal(id){
           tasks.push(()=> finalizeCalendar());
         }
         tasks.push(()=> updateSessionOptionsList());
+        tasks.push(()=> attachSessionButtonHandler());
 
         function runNext(){
           const task = tasks.shift();
@@ -9890,23 +9916,16 @@ function openPostModal(id){
                 document.addEventListener('click', e=>{ if(venueDropdown && !venueDropdown.contains(e.target)){ hideMenu(venueMenu); venueBtn.setAttribute('aria-expanded','false'); } });
               }
               if(sessBtn && sessMenu){
-                sessBtn.addEventListener('click', ()=>{
-                  const expanded = sessBtn.getAttribute('aria-expanded') === 'true';
-              const opening = !expanded;
-              sessBtn.setAttribute('aria-expanded', String(opening));
-              if(opening){
-                showMenu(sessMenu);
-                if(selectedIndex !== null){
-                  const dt = loc.dates[selectedIndex];
-                  if(dt){
-                    requestAnimationFrame(()=> scrollCalendarToMonth(dt));
-                  }
+                if(!sessDropdown._sessionOutsideHandler){
+                  const outsideHandler = e=>{
+                    if(sessDropdown && !sessDropdown.contains(e.target)){
+                      hideMenu(sessMenu);
+                      sessBtn.setAttribute('aria-expanded','false');
+                    }
+                  };
+                  sessDropdown._sessionOutsideHandler = outsideHandler;
+                  document.addEventListener('click', outsideHandler);
                 }
-              } else {
-                hideMenu(sessMenu);
-              }
-            });
-                document.addEventListener('click', e=>{ if(sessDropdown && !sessDropdown.contains(e.target)){ hideMenu(sessMenu); sessBtn.setAttribute('aria-expanded','false'); } });
               }
               if(map && typeof map.resize === 'function') map.resize();
             });


### PR DESCRIPTION
## Summary
- add a dedicated session button handler inside updateVenue so it closes over the current location data
- prevent duplicate outside-click listeners and rely on the new handler for toggling the session menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56ca5badc8331a342229c21ca1f24