### PR TITLE
Ensure geolocate button immediately spins logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -7767,6 +7767,14 @@ function makePosts(){
             try{ logoLoader.end(); }catch(err){}
           }
         };
+        if(geolocate && typeof geolocate.trigger === 'function' && !geolocate.__logoLoadingWrapped){
+          const originalTrigger = geolocate.trigger.bind(geolocate);
+          geolocate.trigger = function(...args){
+            try{ startGeolocateLoading(); }catch(err){}
+            return originalTrigger(...args);
+          };
+          geolocate.__logoLoadingWrapped = true;
+        }
         geolocate.on('trackuserlocationstart', () => { startGeolocateLoading(); });
         geolocate.on('geolocate', (event)=>{
           stopGeolocateLoading();


### PR DESCRIPTION
## Summary
- wrap the Mapbox geolocate control trigger so the site logo's loading animation starts as soon as the control fires

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5713e4fe8833183df0150a70403d8