### PR TITLE
Fix selected map marker ring filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -5597,14 +5597,15 @@ img.thumb{
     function updateSelectedMarkerRing(){
       if(!map || typeof map.getLayer !== 'function') return;
       if(!map.getLayer(SELECTED_RING_LAYER)) return;
-      const hasSelection = !!activePostId;
+      const hasSelection = activePostId !== null && activePostId !== undefined && activePostId !== '';
       let filter;
       if(hasSelection){
+        const idFilter = ['==', ['to-string', ['get','id']], String(activePostId)];
         filter = selectedVenueKey
-          ? ['all', ['==',['get','id'], activePostId], ['==',['get','venueKey'], selectedVenueKey]]
-          : ['==',['get','id'], activePostId];
+          ? ['all', idFilter, ['==',['get','venueKey'], selectedVenueKey]]
+          : idFilter;
       } else {
-        filter = ['==',['get','id'],'__none__'];
+        filter = ['==',['to-string',['get','id']],'__none__'];
       }
       try{ map.setFilter(SELECTED_RING_LAYER, filter); }catch(e){}
       try{ map.setPaintProperty(SELECTED_RING_LAYER, 'circle-stroke-opacity', hasSelection ? 0.95 : 0); }catch(e){}


### PR DESCRIPTION
## Summary
- ensure the selected marker ring filter always compares marker ids as strings
- restore robust active post detection so the 5px selection ring stays visible when a post is open

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5972142fc83319b4f6ad18f5eed41