### PR TITLE
Remove heavy map mousemove and add runtime patch

### DIFF
--- a/index.html
+++ b/index.html
@@ -9907,12 +9907,6 @@ function openPostModal(id){
               MapRegistry.register(map);
               attachIconLoader(map);
 
-              // Safe "hover pointer" for any rendered features (doesn't touch getStyle)
-              map.on('mousemove', (e) => {
-                const has = !!(e.features && e.features.length);
-                map.getCanvas().style.cursor = has ? 'pointer' : '';
-              });
-
               // Arm pointer on symbol layers *without* touching getStyle until loaded
               armPointerOnSymbolLayers(map);
 
@@ -11496,6 +11490,135 @@ document.addEventListener('DOMContentLoaded', () => {
   window.__wrapForInputYield = function(name){
     applyWrapper(name);
   };
+})();
+</script>
+<script>
+/* Events Platform runtime patch: selected ring + perf */
+(function(){
+  if (window.__EP_PATCH_APPLIED__) return;
+  window.__EP_PATCH_APPLIED__ = true;
+
+  // 1) throttle helper (only if missing)
+  if (!window.rafThrottle) {
+    window.rafThrottle = function(fn){
+      let scheduled=false, lastArgs, lastThis;
+      return function throttled(){ lastArgs=arguments; lastThis=this;
+        if (scheduled) return;
+        scheduled=true;
+        requestAnimationFrame(function(){ scheduled=false; fn.apply(lastThis, lastArgs); });
+      };
+    };
+  }
+
+  // 2) wait for a Mapbox map instance commonly stored on window.map
+  function onMapReady(cb){
+    function tryNow(){
+      var m = (window.map && typeof window.map.addLayer === 'function') ? window.map : null;
+      if (m && m.style && (m.isStyleLoaded ? m.isStyleLoaded() : true)) { cb(m); return true; }
+      if (m) { m.once && m.once('load', function(){ cb(m); }); return true; }
+      return false;
+    }
+    if (tryNow()) return;
+    var t = setInterval(function(){ if (tryNow()) clearInterval(t); }, 200);
+    setTimeout(function(){ clearInterval(t); }, 8000);
+  }
+
+  function firstExistingLayer(map, ids){
+    for (var i=0;i<ids.length;i++){ if (map.getLayer(ids[i])) return ids[i]; }
+    return null;
+  }
+  function firstExistingSource(map, ids){
+    for (var i=0;i<ids.length;i++){ if (map.getSource(ids[i])) return map.getSource(ids[i]); }
+    return null;
+  }
+
+  // 3) keep a persistent "selected" ring above markers
+  function ensureSelectedRing(map){
+    var pointsLayer = firstExistingLayer(map, ['unclustered','venues','points','markers']);
+    if (!pointsLayer) return;
+
+    var srcId = map.getLayer(pointsLayer).source;
+    if (!srcId) return;
+
+    var RING_ID = 'selected-ring';
+    if (!map.getLayer(RING_ID)) {
+      map.addLayer({
+        id: RING_ID,
+        type: 'circle',
+        source: srcId,
+        filter: ['==', ['get','id'], '__none__'],
+        paint: {
+          'circle-radius': ['interpolate',['linear'],['zoom'], 8,10, 16,18],
+          'circle-color': 'transparent',
+          'circle-stroke-color': '#00BFFF',
+          'circle-stroke-width': 4,
+          'circle-stroke-opacity': 0.9
+        }
+      }, pointsLayer);
+    }
+
+    // put overlays on top so the selected halo stays visible
+    ['hover-fill', RING_ID, 'hover-ring'].forEach(function(id){
+      if (map.getLayer(id)) { try { map.moveLayer(id); } catch(e) {} }
+    });
+
+    // click to select (persist ring); do not clear on mouseleave
+    if (!map.__epSelectHandlerBound) {
+      map.on('click', pointsLayer, function(e){
+        var f = e && e.features && e.features[0];
+        var id = f && f.properties && (f.properties.id || f.properties.post_id || f.properties._id);
+        if (id !== undefined && id !== null) {
+          map.setFilter(RING_ID, ['==', ['get','id'], id]);
+        }
+      });
+      map.__epSelectHandlerBound = true;
+    }
+  }
+
+  // 4) throttle any hot layer mousemoves to 1/frame (reduces Violation spam)
+  function throttleHotMoves(map){
+    ['unclustered','clusters','venues','markers'].forEach(function(id){
+      if (!map.getLayer(id)) return;
+      if (map['__epMove_'+id]) return;
+      var handler = window.rafThrottle(function(e){
+        // keep this light: if you have a hoverPopup, update its position only
+        if (window.hoverPopup && e && e.lngLat) window.hoverPopup.setLngLat(e.lngLat);
+      });
+      map.on('mousemove', id, handler);
+      map['__epMove_'+id] = handler;
+    });
+  }
+
+  // 5) faster cluster opening (avoid heavy leaves->bounds path)
+  function patchClusters(map){
+    if (!map.getLayer('clusters')) return;
+    if (map.__epFastCluster) return;
+
+    var src = firstExistingSource(map, ['posts','venues','points']);
+    if (!src || typeof src.getClusterExpansionZoom !== 'function') return;
+
+    map.on('click','clusters', function(e){
+      var f = e && e.features && e.features[0];
+      if (!f || !f.properties) return;
+      var cid = f.properties.cluster_id;
+      src.getClusterExpansionZoom(cid, function(err, zoom){
+        if (err) return;
+        map.easeTo({ center: f.geometry.coordinates, zoom: zoom });
+      });
+    });
+    map.__epFastCluster = true;
+  }
+
+  function apply(map){
+    // initial apply
+    ensureSelectedRing(map);
+    throttleHotMoves(map);
+    patchClusters(map);
+    // re-apply after any style change (layers can be re-created)
+    map.on && map.on('styledata', function(){ ensureSelectedRing(map); });
+  }
+
+  onMapReady(apply);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Remove the global map mousemove feature-scan handler to reduce unnecessary pointer updates.
- Add a runtime patch that ensures a persistent selected ring, throttles hot mousemove handlers, and accelerates cluster expansion.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a2db2ca8833190ffee5b9d8c0189