### PR TITLE
Ensure overlays stay on top after map load

### DIFF
--- a/index.html
+++ b/index.html
@@ -8035,6 +8035,9 @@ function makePosts(){
         map.scrollZoom.setZoomRate(1/240);
       }catch(e){}
       map.on('load', ()=>{
+        // keep overlays on top so the selected ring is visible
+        ['hover-fill', (typeof SELECTED_RING_LAYER==='string' ? SELECTED_RING_LAYER : 'selected-ring'), 'hover-ring']
+          .forEach(id => { if (map.getLayer(id)) try { map.moveLayer(id); } catch (_) {} });
         applyNightSky(map);
         $$('.map-overlay').forEach(el=>el.remove());
         if(spinEnabled){


### PR DESCRIPTION
## Summary
- ensure hover and selected overlay layers remain above the base style once the map finishes loading

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5ab56bcfc8331bea2315c4afb8229