### PR TITLE
Reorder head resources for faster initial paint

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,24 +1,16 @@
 <!doctype html> 
 <html lang="en">
 <head>
-  <script>
-    // Use the same version everywhere
-    window.MAPBOX_VERSION = "v3.15.0";
-  </script>
-
-  <script>
-    // Throttle any hot handler to 1 call per animation frame
-    window.rafThrottle = fn => {
-      let scheduled = false, lastArgs, lastThis;
-      return function throttled(...args){
-        lastArgs = args; lastThis = this;
-        if (scheduled) return;
-        scheduled = true;
-        requestAnimationFrame(() => { scheduled = false; fn.apply(lastThis, lastArgs); });
-      };
-    };
-  </script>
-
+  <meta charset="utf-8" />
+  <meta name="viewport" id="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+  <title>Events Platform</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/favicons/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicons/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicons/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/favicons/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
+  <link rel="manifest" href="assets/favicons/site.webmanifest" />
+  <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
   <link id="mapbox-gl-css" rel="stylesheet"
         href="https://api.mapbox.com/mapbox-gl-js/v3.15.0/mapbox-gl.css" />
 
@@ -48,17 +40,6 @@
       .post-card, .post { position: relative; z-index: 2; }
     }
   </style>
-
-  <script>
-    window.callWhenDefined = window.callWhenDefined || function(name, cb, timeoutMs){
-      const start = performance.now(), max = timeoutMs ?? 5000;
-      (function check(){
-        const fn = window[name];
-        if (typeof fn === 'function') { try { cb(fn); } catch(e){} return; }
-        if (performance.now() - start < max) requestAnimationFrame(check);
-      })();
-    };
-  </script>
 
   <script>
     (function(){
@@ -276,16 +257,6 @@
     })();
   </script>
 
-  <meta charset="utf-8" />
-  <meta name="viewport" id="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
-  <title>Events Platform</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="assets/favicons/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicons/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicons/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="assets/favicons/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="assets/favicons/android-chrome-512x512.png" />
-  <link rel="manifest" href="assets/favicons/site.webmanifest" />
-  <link rel="shortcut icon" href="assets/favicons/favicon.ico" />
   <style id="mapboxgl-critical-css">
     .mapboxgl-map{position:relative;width:100%;height:100%}
     .mapboxgl-canvas{position:absolute;left:0;top:0}


### PR DESCRIPTION
## Summary
- move critical metadata and favicons to the top of the document head before any blocking scripts
- drop redundant inline helpers that are redefined later in the page to keep the head lightweight

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e6d0de648331a748c76c2bda484a