### PR TITLE
Reduce Mapbox console noise

### DIFF
--- a/index.html
+++ b/index.html
@@ -7931,6 +7931,9 @@ function makePosts(){
         await ensureMapboxCssFor(document.body);
       }catch(err){}
           mapboxgl.accessToken = MAPBOX_TOKEN;
+        if(typeof mapboxgl.setLogLevel === 'function'){
+          mapboxgl.setLogLevel('error');
+        }
         map = new mapboxgl.Map({
           container:'map',
           style:'mapbox://styles/mapbox/standard',


### PR DESCRIPTION
## Summary
- ensure Mapbox GL JS only logs errors by setting the log level before map initialization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5f5cc4f4883319c8c9fca06bc788b