### PR TITLE
Adjust map markers and favourites behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -2373,6 +2373,10 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   display:none;
 }
 
+body.mode-map .ad-board{
+  display:none !important;
+}
+
 body.hide-ads .ad-board{
   transform:translateX(100%);
   pointer-events:none;
@@ -4294,6 +4298,30 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   cursor: pointer;
 }
 
+.mapboxgl-popup.map-card .mapboxgl-popup-content > .hover-card{
+  position: relative;
+  padding-right: 110px;
+  margin-right: -100px;
+  border-top-right-radius: 50%;
+  border-bottom-right-radius: 50%;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+  background: var(--popup-bg);
+}
+
+.mapboxgl-popup.map-card .mapboxgl-popup-content > .hover-card::after{
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -100px;
+  width: 100px;
+  height: 100%;
+  background: var(--popup-bg);
+  border-top-right-radius: 50%;
+  border-bottom-right-radius: 50%;
+  pointer-events: none;
+}
+
 .hover-card img{
   width: 64px;
   height: 64px;
@@ -4316,6 +4344,10 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden;
+}
+
+.mapboxgl-popup.map-card .mapboxgl-popup-content > .hover-card .t{
+  color: #fff;
 }
 
 .hover-card .s{
@@ -4400,6 +4432,10 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   background: var(--popup-bg) !important;
   color: var(--popup-text) !important;
   overflow:hidden;
+}
+
+.mapboxgl-popup.map-card .mapboxgl-popup-content{
+  overflow: visible;
 }
 
 .mapboxgl-popup-close-button{
@@ -5460,13 +5496,15 @@ img.thumb{
     // 'Post Panel' is defined as the current map bounds
     let postPanel = null;
     let posts = [], filtered = [], adPosts = [], adIndex = -1, adTimer = null, adPanel = null, adIdsKey = '', pendingPostLoad = false;
-    let favToTop = false, currentSort = 'az';
+    let favToTop = false, favSortDirty = true, currentSort = 'az';
     let selection = { cats: new Set(), subs: new Set() };
     let viewHistory = loadHistory();
     let hoverPopup = null, hoverId = null;
     let postSourceEventsBound = false;
     let touchMarker = null;
     const isTouchDevice = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (window.matchMedia && window.matchMedia('(pointer: coarse)').matches);
+    const markerIconSize = isTouchDevice ? 1.35 : 1;
+    const markerOutlineBase = isTouchDevice ? 28 : 24;
     let activePostId = null;
     let selectedVenueKey = null;
     const BASE_URL = (()=>{ let b = location.origin + location.pathname.split('/post/')[0]; if(!b.endsWith('/')) b+='/'; return b; })();
@@ -5705,7 +5743,7 @@ function buildClusterListHTML(items){
     let ref = {lng:0,lat:0}; if(map){ const c = map.getCenter(); ref = {lng:c.lng,lat:c.lat}; }
     arr.sort((a,b)=> distKm({lng:a.lng,lat:a.lat}, ref) - distKm({lng:b.lng,lat:b.lat}, ref));
   }
-  if(favToTop) arr.sort((a,b)=> (b.fav - a.fav));
+  if(favToTop && !favSortDirty) arr.sort((a,b)=> (b.fav - a.fav));
   const list = arr.map(p => {
     return `
       <div class="multi-item map-card" data-id="${p.id}">
@@ -7040,6 +7078,7 @@ function makePosts(){
 
     favToggle.addEventListener('click', ()=>{
       favToTop = !favToTop;
+      favSortDirty = favToTop ? false : true;
       favToggle.setAttribute('aria-pressed', favToTop);
       renderLists(filtered);
     });
@@ -7498,6 +7537,7 @@ function makePosts(){
       const resLists = $$('.recents-board');
       resLists.forEach(list=>{
           list.addEventListener('click', (e)=>{
+            if(e.target.closest('.fav')) return;
             const cardEl = e.target.closest('.recents-card');
             if(!cardEl) return;
             e.preventDefault();
@@ -7517,6 +7557,7 @@ function makePosts(){
       const postsWide = $('.post-board');
       if(postsWide){
         postsWide.addEventListener('click', e=>{
+          if(e.target.closest('.fav')) return;
           const cardEl = e.target.closest('.post-card');
           if(cardEl){
             const id = cardEl.getAttribute('data-id');
@@ -8254,7 +8295,7 @@ function makePosts(){
       const opts = existing && typeof existing.serialize === 'function' ? existing.serialize() : null;
       const sourceNeedsRebuild = !existing || !opts || opts.cluster !== shouldCluster || opts.clusterRadius !== clusterRadius || opts.clusterMaxZoom !== clusterMaxZoom;
       if(sourceNeedsRebuild){
-        ['cluster-count','clusters','unclustered','posts-heat','hover-ring','hover-fill'].forEach(id=>{ if(map.getLayer(id)) map.removeLayer(id); });
+        ['cluster-count','clusters','marker-outline','unclustered','posts-heat','hover-ring','hover-fill'].forEach(id=>{ if(map.getLayer(id)) map.removeLayer(id); });
         if(existing) map.removeSource('posts');
         map.addSource('posts', { type:'geojson', data: geojson, cluster: shouldCluster, clusterRadius: clusterRadius, clusterMaxZoom: clusterMaxZoom });
       } else if(existing){
@@ -8273,6 +8314,7 @@ function makePosts(){
       const usingSvgClusters = shouldCluster && clusterIconType === 'svg' && clusterSvg;
       const multiLabelExpression = ['case', ['==', ['get', 'multi'], 1], ['coalesce', ['get', 'multiLabel'], ''], ''];
       const svgHash = usingSvgClusters ? hashString(clusterSvg) : '';
+      const markerOutlineExpression = ['interpolate', ['linear'], ['zoom'], 8, markerOutlineBase, 16, markerOutlineBase + 6];
       const clusterVisualKey = shouldCluster ? (usingSvgClusters ? `svg:${svgHash}` : 'circle') : 'none';
       const visualsChanged = clusterVisualKey !== currentClusterVisualKey || sourceNeedsRebuild;
 
@@ -8364,6 +8406,7 @@ function makePosts(){
           source:'posts',
           layout:{
             'icon-image':['get','sub'],
+            'icon-size': markerIconSize,
             'icon-allow-overlap': true,
             'icon-ignore-placement': true,
             'icon-anchor': 'center',
@@ -8385,6 +8428,7 @@ function makePosts(){
         });
       }
       try{ map.setLayoutProperty('unclustered','icon-image',['get','sub']); }catch(e){}
+      try{ map.setLayoutProperty('unclustered','icon-size', markerIconSize); }catch(e){}
       try{ map.setLayoutProperty('unclustered','icon-allow-overlap', true); }catch(e){}
       try{ map.setLayoutProperty('unclustered','icon-ignore-placement', true); }catch(e){}
       try{ map.setLayoutProperty('unclustered','icon-anchor', 'center'); }catch(e){}
@@ -8400,12 +8444,32 @@ function makePosts(){
       try{ map.setLayoutProperty('unclustered','text-ignore-placement', true); }catch(e){}
       try{ map.setLayoutProperty('unclustered','text-pitch-alignment','viewport'); }catch(e){}
       try{ map.setPaintProperty('unclustered','text-color','#fff'); }catch(e){}
+      if(!map.getLayer('marker-outline')){
+        map.addLayer({
+          id:'marker-outline',
+          type:'circle',
+          source:'posts',
+          filter:['!', ['has','point_count']],
+          paint:{
+            'circle-radius': markerOutlineExpression,
+            'circle-color': 'rgba(0,0,0,0)',
+            'circle-stroke-color': '#000',
+            'circle-stroke-width': isTouchDevice ? 3.5 : 3,
+            'circle-stroke-opacity': 0.9
+          }
+        }, 'unclustered');
+      }
+      try{ map.setPaintProperty('marker-outline','circle-radius', markerOutlineExpression); }catch(e){}
+      try{ map.setPaintProperty('marker-outline','circle-stroke-width', isTouchDevice ? 3.5 : 3); }catch(e){}
+      try{ map.setPaintProperty('marker-outline','circle-stroke-opacity', 0.9); }catch(e){}
       if(shouldCluster){
         try{ map.setFilter('unclustered', ['!', ['has','point_count']]); }catch(e){}
+        try{ map.setFilter('marker-outline', ['!', ['has','point_count']]); }catch(e){}
       } else {
         try{ map.setFilter('unclustered', null); }catch(e){}
+        try{ map.setFilter('marker-outline', null); }catch(e){}
       }
-      ['hover-fill',SELECTED_RING_LAYER,'hover-ring','clusters','cluster-count','unclustered'].forEach(id=>{
+      ['hover-fill',SELECTED_RING_LAYER,'hover-ring','clusters','cluster-count','marker-outline','unclustered'].forEach(id=>{
         if(map.getLayer(id)){
           try{ map.moveLayer(id); }catch(e){}
         }
@@ -8414,6 +8478,7 @@ function makePosts(){
         ['clusters','circle-opacity-transition'],
         ['clusters','icon-opacity-transition'],
         ['cluster-count','text-opacity-transition'],
+        ['marker-outline','circle-opacity-transition'],
         ['unclustered','icon-opacity-transition']
       ].forEach(([layer, prop])=>{
         if(map.getLayer(layer)){
@@ -8808,7 +8873,7 @@ function makePosts(){
         let ref = {lng:0,lat:0}; if(map){ const c = map.getCenter(); ref = {lng:c.lng,lat:c.lat}; }
         arr.sort((a,b)=> distKm({lng:a.lng,lat:a.lat}, ref) - distKm({lng:b.lng,lat:b.lat}, ref));
       }
-      if(favToTop) arr.sort((a,b)=> (b.fav - a.fav));
+      if(favToTop && !favSortDirty) arr.sort((a,b)=> (b.fav - a.fav));
 
       sortedPostList = arr;
       renderedPostCount = 0;
@@ -8998,6 +9063,7 @@ function makePosts(){
       el.querySelector('.fav').addEventListener('click', (e)=>{
         e.stopPropagation();
         p.fav = !p.fav;
+        favSortDirty = true;
         document.querySelectorAll(`[data-id="${p.id}"] .fav`).forEach(btn=>{
           btn.setAttribute('aria-pressed', p.fav ? 'true' : 'false');
         });
@@ -9259,6 +9325,7 @@ function openPostModal(id){
         favBtn.addEventListener('click', (e)=>{
           e.stopPropagation();
           p.fav = !p.fav;
+          favSortDirty = true;
           document.querySelectorAll(`[data-id="${p.id}"] .fav`).forEach(btn=>{
             btn.setAttribute('aria-pressed', p.fav ? 'true' : 'false');
           });


### PR DESCRIPTION
## Summary
- hide the ad board when map mode is active and restyle map hover cards with a rounded right-hand extension and white titles
- enlarge map markers on touch devices and add a black circular outline around single-location markers
- require toggling the favourites-on-top control to resurface favourites and stop favourite buttons from opening or closing posts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d608c40e188331a4f4beaf9937c463