### PR TITLE
Handle missing marker label background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -5935,6 +5935,7 @@ function buildClusterListHTML(items){
       }
 
       mapInstance.on('style.load', async () => {
+        try{ ensureMarkerLabelBackground(mapInstance); }catch(err){}
         const markers = window.subcategoryMarkers || {};
         const preload = new Set([...KNOWN, ...Object.keys(markers)]);
         for(const iconName of preload){
@@ -5944,6 +5945,10 @@ function buildClusterListHTML(items){
 
       mapInstance.on('styleimagemissing', e => {
         if(!e || !e.id) return;
+        if(e.id === 'marker-label-bg'){
+          try{ ensureMarkerLabelBackground(mapInstance); }catch(err){}
+          return;
+        }
         addIcon(e.id);
       });
 


### PR DESCRIPTION
## Summary
- ensure the marker label background sprite is restored whenever the map style loads
- re-add the generated marker label background image if Mapbox reports it as missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d616f177408331913b708234c5f003