### PR TITLE
Adjust map marker label spacing and width

### DIFF
--- a/index.html
+++ b/index.html
@@ -5292,11 +5292,13 @@ if (typeof slugify !== 'function') {
   const markerIconBaseSizePx = 30;
   const markerLabelBackgroundWidthPx = 150;
   const markerLabelBackgroundHeightPx = 40;
-  const markerLabelBgTranslatePx = -(markerIconBaseSizePx * markerIconSize / 2 + 5);
   const markerLabelTextPaddingPx = 8;
+  const markerLabelTextGapPx = 5;
+  const markerLabelTextAreaWidthPx = 105;
   const markerLabelTextSize = 12;
+  const markerLabelBgTranslatePx = markerIconBaseSizePx * markerIconSize / 2 + markerLabelTextGapPx - markerLabelTextPaddingPx;
   const markerLabelTextTranslatePx = markerLabelBgTranslatePx + markerLabelTextPaddingPx;
-  const markerLabelTextMaxWidth = Math.max(3, (markerLabelBackgroundWidthPx - markerLabelTextPaddingPx * 2) / markerLabelTextSize);
+  const markerLabelTextMaxWidth = Math.max(3, markerLabelTextAreaWidthPx / markerLabelTextSize);
 
   const MARKER_LABEL_BG_ID = 'marker-label-bg';
 


### PR DESCRIPTION
## Summary
- ensure marker label translations leave a consistent 5px gap from the marker icon
- cap the marker label text area width at 105px for better readability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63db65d4883318ea03b35ea0ca3f2