### PR TITLE
Fix flex detachment during board transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -7475,6 +7475,7 @@ function makePosts(){
       const mapButton = $('#map-button');
       const boardStates = new WeakMap();
       const boardDisplayCache = new WeakMap();
+      const boardMetrics = new WeakMap();
       let boardsInitialized = false;
 
       function getDefaultBoardDisplay(board){
@@ -7493,6 +7494,80 @@ function makePosts(){
         return value;
       }
 
+      function captureBoardMetrics(board){
+        if(!board || board.style.display === 'none') return null;
+        const parent = board.parentElement;
+        if(!parent) return null;
+        const parentRect = parent.getBoundingClientRect();
+        const rect = board.getBoundingClientRect();
+        return {
+          width: rect.width,
+          height: rect.height,
+          left: rect.left - parentRect.left,
+          top: rect.top - parentRect.top
+        };
+      }
+
+      function applyDetachedStyle(board, metrics){
+        if(!board) return;
+        const parent = board.parentElement;
+        let parentRect = null;
+        try{
+          parentRect = parent ? parent.getBoundingClientRect() : null;
+        }catch(err){ parentRect = null; }
+        let width = metrics && isFinite(metrics.width) ? metrics.width : null;
+        let height = metrics && isFinite(metrics.height) ? metrics.height : null;
+        let left = metrics && isFinite(metrics.left) ? metrics.left : null;
+        let top = metrics && isFinite(metrics.top) ? metrics.top : null;
+        if((!width || width <= 0) && parentRect){
+          try{
+            const style = getComputedStyle(board);
+            width = parseFloat(style.width) || parseFloat(style.maxWidth) || parentRect.width;
+            height = height || parseFloat(style.height) || parseFloat(style.maxHeight) || parentRect.height;
+          }catch(err){ width = parentRect ? parentRect.width : width; }
+        }
+        if(parentRect){
+          if(!width || width > parentRect.width){
+            width = parentRect.width;
+          }
+          if(left === null || left === undefined){
+            left = Math.max((parentRect.width - width) / 2, 0);
+          }
+          if(top === null || top === undefined){
+            top = Math.max((parentRect.height - (height || parentRect.height)) / 2, 0);
+          }
+        } else {
+          if(left === null || left === undefined) left = 0;
+          if(top === null || top === undefined) top = 0;
+        }
+        board.classList.add('board-transitioning');
+        board.style.position = 'absolute';
+        board.style.top = `${top}px`;
+        board.style.left = `${left}px`;
+        board.style.right = '';
+        board.style.bottom = '';
+        board.style.width = width ? `${width}px` : '';
+        if(height && height > 0){
+          board.style.height = `${height}px`;
+        }
+        board.style.margin = '0';
+        board.style.pointerEvents = 'none';
+      }
+
+      function cleanupDetached(board){
+        if(!board) return;
+        board.classList.remove('board-transitioning');
+        board.style.position = '';
+        board.style.top = '';
+        board.style.left = '';
+        board.style.right = '';
+        board.style.bottom = '';
+        board.style.width = '';
+        board.style.height = '';
+        board.style.margin = '';
+        board.style.pointerEvents = '';
+      }
+
       function animateBoard(board, shouldShow, immediate=false){
         if(!board) return;
         board.classList.add('board-animate');
@@ -7504,11 +7579,17 @@ function makePosts(){
             board.classList.remove('board-hidden');
             board.setAttribute('aria-hidden','false');
             boardStates.set(board, 'visible');
+            const metrics = captureBoardMetrics(board);
+            if(metrics) boardMetrics.set(board, metrics);
+            cleanupDetached(board);
           } else {
             board.classList.add('board-hidden');
             board.style.display = 'none';
             board.setAttribute('aria-hidden','true');
             boardStates.set(board, 'hidden');
+            const metrics = captureBoardMetrics(board);
+            if(metrics) boardMetrics.set(board, metrics);
+            cleanupDetached(board);
           }
           return;
         }
@@ -7519,15 +7600,42 @@ function makePosts(){
             board.classList.remove('board-hidden');
             board.setAttribute('aria-hidden','false');
             boardStates.set(board, 'visible');
+            const metrics = captureBoardMetrics(board);
+            if(metrics) boardMetrics.set(board, metrics);
+            cleanupDetached(board);
             return;
           }
-          board.style.display = defaultDisplay;
           board.setAttribute('aria-hidden','false');
+          board.style.display = 'none';
           board.classList.add('board-hidden');
           requestAnimationFrame(()=>{
             if(!board.isConnected) return;
-            board.classList.remove('board-hidden');
-            boardStates.set(board, 'visible');
+            applyDetachedStyle(board, boardMetrics.get(board));
+            board.style.display = defaultDisplay;
+            void board.offsetWidth;
+            requestAnimationFrame(()=>{
+              if(!board.isConnected) return;
+              board.classList.remove('board-hidden');
+              let finished = false;
+              let onTransitionEnd;
+              const finalize = ()=>{
+                if(finished) return;
+                finished = true;
+                if(onTransitionEnd) board.removeEventListener('transitionend', onTransitionEnd);
+                cleanupDetached(board);
+                boardStates.set(board, 'visible');
+                requestAnimationFrame(()=>{
+                  const metrics = captureBoardMetrics(board);
+                  if(metrics) boardMetrics.set(board, metrics);
+                });
+              };
+              onTransitionEnd = event => {
+                if(event && event.target !== board) return;
+                finalize();
+              };
+              board.addEventListener('transitionend', onTransitionEnd);
+              setTimeout(finalize, 400);
+            });
           });
         } else {
           if(currentState === 'hidden'){
@@ -7535,8 +7643,14 @@ function makePosts(){
             board.style.display = 'none';
             board.setAttribute('aria-hidden','true');
             boardStates.set(board, 'hidden');
+            const metrics = captureBoardMetrics(board);
+            if(metrics) boardMetrics.set(board, metrics);
+            cleanupDetached(board);
             return;
           }
+          const metrics = captureBoardMetrics(board);
+          if(metrics) boardMetrics.set(board, metrics);
+          applyDetachedStyle(board, metrics);
           board.setAttribute('aria-hidden','true');
           board.classList.remove('board-hidden');
           void board.offsetWidth;
@@ -7549,6 +7663,7 @@ function makePosts(){
             if(onTransitionEnd) board.removeEventListener('transitionend', onTransitionEnd);
             board.style.display = 'none';
             boardStates.set(board, 'hidden');
+            cleanupDetached(board);
           };
           onTransitionEnd = event => {
             if(event && event.target !== board) return;


### PR DESCRIPTION
## Summary
- track board layout metrics to allow detaching boards from the flex flow during animations
- update animateBoard to keep boards out of the layout while sliding in or out and clean up afterwards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d72bbeed108331bf40e0c8a864c4c6