### PR TITLE
Prevent board slide animations from disturbing layout flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -7617,30 +7617,33 @@ function makePosts(){
           requestAnimationFrame(()=>{
             if(!board.isConnected) return;
             applyDetachedStyle(board, boardMetrics.get(board));
-            board.style.display = defaultDisplay;
-            void board.offsetWidth;
             requestAnimationFrame(()=>{
               if(!board.isConnected) return;
-              board.classList.remove('board-hidden');
-              let finished = false;
-              let onTransitionEnd;
-              const finalize = ()=>{
-                if(finished) return;
-                finished = true;
-                if(onTransitionEnd) board.removeEventListener('transitionend', onTransitionEnd);
-                cleanupDetached(board);
-                boardStates.set(board, 'visible');
-                requestAnimationFrame(()=>{
-                  const metrics = captureBoardMetrics(board);
-                  if(metrics) boardMetrics.set(board, metrics);
-                });
-              };
-              onTransitionEnd = event => {
-                if(event && event.target !== board) return;
-                finalize();
-              };
-              board.addEventListener('transitionend', onTransitionEnd);
-              setTimeout(finalize, 400);
+              board.style.display = defaultDisplay;
+              void board.offsetWidth;
+              requestAnimationFrame(()=>{
+                if(!board.isConnected) return;
+                board.classList.remove('board-hidden');
+                let finished = false;
+                let onTransitionEnd;
+                const finalize = ()=>{
+                  if(finished) return;
+                  finished = true;
+                  if(onTransitionEnd) board.removeEventListener('transitionend', onTransitionEnd);
+                  cleanupDetached(board);
+                  boardStates.set(board, 'visible');
+                  requestAnimationFrame(()=>{
+                    const metrics = captureBoardMetrics(board);
+                    if(metrics) boardMetrics.set(board, metrics);
+                  });
+                };
+                onTransitionEnd = event => {
+                  if(event && event.target !== board) return;
+                  finalize();
+                };
+                board.addEventListener('transitionend', onTransitionEnd);
+                setTimeout(finalize, 400);
+              });
             });
           });
         } else {
@@ -7658,25 +7661,28 @@ function makePosts(){
           if(metrics) boardMetrics.set(board, metrics);
           applyDetachedStyle(board, metrics);
           board.setAttribute('aria-hidden','true');
-          board.classList.remove('board-hidden');
-          void board.offsetWidth;
-          board.classList.add('board-hidden');
-          let finished = false;
-          let onTransitionEnd;
-          const finish = ()=>{
-            if(finished) return;
-            finished = true;
-            if(onTransitionEnd) board.removeEventListener('transitionend', onTransitionEnd);
-            board.style.display = 'none';
-            boardStates.set(board, 'hidden');
-            cleanupDetached(board);
-          };
-          onTransitionEnd = event => {
-            if(event && event.target !== board) return;
-            finish();
-          };
-          board.addEventListener('transitionend', onTransitionEnd);
-          setTimeout(finish, 350);
+          requestAnimationFrame(()=>{
+            if(!board.isConnected) return;
+            board.classList.remove('board-hidden');
+            void board.offsetWidth;
+            board.classList.add('board-hidden');
+            let finished = false;
+            let onTransitionEnd;
+            const finish = ()=>{
+              if(finished) return;
+              finished = true;
+              if(onTransitionEnd) board.removeEventListener('transitionend', onTransitionEnd);
+              board.style.display = 'none';
+              boardStates.set(board, 'hidden');
+              cleanupDetached(board);
+            };
+            onTransitionEnd = event => {
+              if(event && event.target !== board) return;
+              finish();
+            };
+            board.addEventListener('transitionend', onTransitionEnd);
+            setTimeout(finish, 350);
+          });
         }
       }
 


### PR DESCRIPTION
## Summary
- delay reintroducing a board to the flex layout until after its slide-in finishes
- detach boards from the layout in advance of slide-out transitions so the remaining board stays in place

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7429081c88331a0bd530994903c96