### PR TITLE
Improve map card layout and ad board animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2289,7 +2289,9 @@ body.hide-ads .post-mode-boards{padding-right:0;}
 }
 
 .ad-board.board-animate.board-hidden{
-  transform:translateX(110%);
+  transform:translateX(32px);
+  opacity:0;
+  pointer-events:none;
 }
 
 .board-transitioning{
@@ -2503,8 +2505,9 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   pointer-events:auto;
   z-index:2;
   transform:translateX(0);
-  transition:transform var(--panel-transition-duration, 0.3s) ease;
-  will-change:transform;
+  opacity:1;
+  transition:transform 0.45s cubic-bezier(0.33, 1, 0.68, 1), opacity 0.45s ease;
+  will-change:transform, opacity;
   display:none;
   height:var(--panel-area-height, calc((var(--vh, 1vh) * 100) - var(--header-h) - var(--safe-top) - var(--footer-h)));
   max-height:var(--panel-area-height, calc((var(--vh, 1vh) * 100) - var(--header-h) - var(--safe-top) - var(--footer-h)));
@@ -4491,12 +4494,13 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .multi-item.map-card{
   display: flex;
   gap: 8px;
-  align-items: center;
-  padding: 4px 6px;
+  align-items: flex-start;
+  padding: 5px;
   border-radius: 8px;
   cursor: pointer;
   min-width: 0;
   box-sizing: border-box;
+  min-height: 74px;
 }
 
 .multi-item.map-card img{
@@ -4526,9 +4530,9 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   font-weight: 400;
   opacity: .85;
   margin-top: 2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .mapboxgl-popup,
@@ -4587,8 +4591,12 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 
 .multi-item.map-card .hover-card .t{
   max-width: none;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- allow map cards to show fuller text with consistent padding and layout for stability
- smooth the ad board transition with a refined slide-and-fade animation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d743c93a108331951f5bbfdfc9e5c7