### PR TITLE
Disable clustering for small marker counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -8879,7 +8879,7 @@ if (!map.__pillHooksInstalled) {
       addingPostSource = true;
       try{
       const geojson = postsToGeoJSON(posts);
-      const shouldCluster = posts.length > 1 && clusterRadius > 0;
+      const shouldCluster = posts.length >= 10 && clusterRadius > 0;
       const existing = map.getSource('posts');
       const opts = existing && typeof existing.serialize === 'function' ? existing.serialize() : null;
       const sourceNeedsRebuild = !existing || !opts || opts.cluster !== shouldCluster || opts.clusterRadius !== clusterRadius || opts.clusterMaxZoom !== clusterMaxZoom;


### PR DESCRIPTION
## Summary
- require at least ten posts before enabling Mapbox clustering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d744e9a36c8331b35332b73c0fa84b