### PR TITLE
Adjust ad board container opacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -2501,11 +2501,10 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   right:0;
   width:440px;
   padding:10px;
-  background:#000;
+  background:rgba(0,0,0,0.7);
   pointer-events:auto;
   z-index:2;
   transform:translateX(0);
-  opacity:0.7;
   transition:transform 0.45s cubic-bezier(0.33, 1, 0.68, 1), opacity 0.45s ease;
   will-change:transform, opacity;
   display:none;


### PR DESCRIPTION
## Summary
- update the ad board styling to use a semi-transparent background color instead of lowering element opacity
- ensure ads within the board remain fully opaque while the container appears at 70% opacity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d748c120ac8331b3b57687b2525685