### PR TITLE
Set multi-venue markers to show post counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5519,8 +5519,8 @@ if (typeof slugify !== 'function') {
     };
   }
 
-  function buildMarkerLabelText(p){
-    const lines = getMarkerLabelLines(p);
+  function buildMarkerLabelText(p, overrideLines){
+    const lines = overrideLines || getMarkerLabelLines(p);
     if(lines.line2){
       return `${lines.line1}\n${lines.line2}`;
     }
@@ -8847,7 +8847,10 @@ if (!map.__pillHooksInstalled) {
             const isMultiVenue = count > 1;
             const labelLines = getMarkerLabelLines(p);
             const primaryVenue = getPrimaryVenueName(p);
-            const combinedLabel = buildMarkerLabelText(p);
+            if(isMultiVenue){
+              labelLines.line1 = shortenMarkerLabelText(`${count} posts`);
+            }
+            const combinedLabel = buildMarkerLabelText(p, labelLines);
             return {
               type:'Feature',
               properties:{


### PR DESCRIPTION
## Summary
- ensure multi-venue markers reuse the existing multi-post icon asset
- show the number of posts as the first line of each multi-venue marker label
- allow marker label text builder to accept overridden label lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d754f442208331865846057d32d31e