### PR TITLE
Remove Mapbox cluster popup messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -9450,23 +9450,13 @@ if (!map.__pillHooksInstalled) {
       };
       MARKER_INTERACTIVE_LAYERS.forEach(layer => map.on('mouseleave', layer, handleMarkerMouseLeave));
 
-      // Popups for clusters (shows count)
-      map.on('mouseenter','clusters', (e)=>{
+      // Maintain pointer cursor for clusters without showing popups
+      map.on('mouseenter','clusters', ()=>{
         map.getCanvas().style.cursor='pointer';
-        const f = e.features && e.features[0]; if(!f) return;
-        const count = f.properties.point_count_abbreviated;
-        if(hoverPopup) hoverPopup.remove();
-        hoverPopup = new mapboxgl.Popup({closeButton:false, closeOnClick:false, className:'hover-pop map-card', offset:15})
-          .setLngLat(e.lngLat).setHTML(`<div class='map-card map-card--popup map-card--count'><img class='map-card-pill' src='assets/icons-30/225x60-pill-99.webp' alt=''/><div class='map-card-text'><div class='map-card-title'>${count} nearby posts</div></div></div>`).addTo(map);
-        const _el = hoverPopup && hoverPopup.getElement ? hoverPopup.getElement() : null;
-        if(_el){ _el.style.pointerEvents = 'none'; }
-        registerPopup(hoverPopup);
       });
-      const onClusterMove = window.rafThrottle((e)=>{
-        if(hoverPopup) hoverPopup.setLngLat(e.lngLat);
+      map.on('mouseleave','clusters', ()=>{
+        map.getCanvas().style.cursor='';
       });
-        map.on('mousemove','clusters', onClusterMove);
-        map.on('mouseleave','clusters', ()=>{ map.getCanvas().style.cursor=''; if(hoverPopup){ hoverPopup.remove(); hoverPopup=null; } });
         postSourceEventsBound = true;
       }
       } catch (err) {


### PR DESCRIPTION
## Summary
- remove the Mapbox cluster hover popup that displayed nearby post counts
- keep basic cursor handling when hovering over clusters to preserve interaction feedback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d75669a20483318c46ae7129ad5798