### PR TITLE
Restore multi-post map card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4442,6 +4442,48 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   box-sizing: border-box;
 }
 
+.multi-item.map-card{
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 6px;
+  border-radius: 8px;
+  cursor: pointer;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.multi-item.map-card img{
+  width: 64px;
+  height: 64px;
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
+  object-fit: cover;
+  display: block;
+  background: var(--panel-bg);
+  flex: 0 0 64px;
+  min-width: 64px;
+  min-height: 64px;
+}
+
+.multi-item.map-card .t{
+  white-space: normal;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.multi-item.map-card .s{
+  font-size: 14px;
+  opacity: .8;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .map-card--popup,
 .map-card--list{
   pointer-events: auto;
@@ -4515,6 +4557,26 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   cursor: pointer;
 }
 
+.multi-item.map-card > div{
+  min-width: 0;
+}
+
+.multi-item.map-card .hover-card{
+  width: 100%;
+}
+
+.hover-card > div{
+  min-width: 0;
+  flex: 1;
+}
+
+.multi-item.map-card .hover-card .t{
+  max-width: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 .nowrap{
   white-space: nowrap;
 }
@@ -4530,6 +4592,13 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   .mapboxgl-popup.map-card .map-card{
     width: 90vw;
     max-width: 90vw;
+  }
+  .mapboxgl-popup.map-card .multi-item.map-card{
+    width: 90vw;
+    max-width: 90vw;
+  }
+  .mapboxgl-popup.map-card .multi-item.map-card .hover-card{
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- restore the multi-post map card styles in `index.html`
- reintroduce responsive rules to maintain the original layout in map popups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d756bd4e7883319da44dcc24fd3beb