### PR TITLE
Clamp cluster max zoom to 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -5768,7 +5768,11 @@ if (typeof slugify !== 'function') {
           spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
           mapStyle = window.mapStyle = 'mapbox://styles/mapbox/standard',
           clusterRadius = parseInt(localStorage.getItem('clusterRadius') || '52', 10),
-          clusterMaxZoom = parseInt(localStorage.getItem('clusterMaxZoom') || '14', 10),
+          clusterMaxZoom = (()=>{
+            let storedValue = parseInt(localStorage.getItem('clusterMaxZoom') || '14', 10);
+            if(Number.isNaN(storedValue)) storedValue = 14;
+            return Math.min(storedValue, 10);
+          })(),
           clusterIconType = localStorage.getItem('clusterIconType') || 'circle',
           clusterSvg = localStorage.getItem('clusterSvg') || '',
           currentClusterVisualKey = '',


### PR DESCRIPTION
## Summary
- clamp the map cluster max zoom value to 10 so clusters are disabled past zoom level 10

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d758a7a71c8331a321c76a691f9c57