### PR TITLE
Limit geocoder width for map and welcome modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -2993,10 +2993,11 @@ body.filters-active #filterBtn{
   flex:1 1 240px;
   min-width:0;
   width:100%;
+  max-width:360px;
 }
 #welcomeBody .map-control-row .mapboxgl-ctrl-geocoder{
   width:100% !important;
-  max-width:100% !important;
+  max-width:360px !important;
   min-width:0 !important;
 }
 #welcomeBody .map-controls-welcome .mapboxgl-ctrl-geocoder{
@@ -3043,7 +3044,7 @@ body.filters-active #filterBtn{
 }
 
 .map-controls-map .geocoder{
-  max-width:100%;
+  max-width:360px;
 }
 
 .map-control-row .geocoder{margin:0;}


### PR DESCRIPTION
## Summary
- limit the map geocoder container to a 360px maximum width
- apply the same 360px maximum width to the welcome modal geocoder and its control

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d7590cb6008331a3c8d08844bfdac0