### PR TITLE
Adjust multi post map card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4447,11 +4447,12 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   display: flex;
   gap: 8px;
   align-items: center;
-  padding: 4px 6px;
+  padding: 10px;
   border-radius: 8px;
   cursor: pointer;
   min-width: 0;
   box-sizing: border-box;
+  width: 600px;
 }
 
 .multi-item.map-card img{


### PR DESCRIPTION
## Summary
- set the multi post map card width to 600px for consistent sizing
- increase the card padding to 10px for improved spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d75a4e86108331a98869e77204b54e