### PR TITLE
Prevent multiple image modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -12005,19 +12005,35 @@ function initPostLayout(board){
   if(thumbRow){
     thumbRow.scrollLeft = 0;
   }
+  function closeImageModal(container){
+    if(!container) return;
+    container.classList.add('hidden');
+    const inner = container.querySelector ? container.querySelector('.image-modal') : null;
+    if(inner) inner.innerHTML = '';
+    if(container.dataset) delete container.dataset.activeSrc;
+  }
+
   function openImageModal(src){
     if(!imageModalContainer || !imageModal) return;
+    document.querySelectorAll('.image-modal-container').forEach(container => {
+      if(container !== imageModalContainer && !container.classList.contains('hidden')){
+        closeImageModal(container);
+      }
+    });
+    if(!imageModalContainer.classList.contains('hidden') && imageModalContainer.dataset.activeSrc === src){
+      return;
+    }
     imageModal.innerHTML='';
     const img = document.createElement('img');
     img.src = src;
     imageModal.appendChild(img);
+    imageModalContainer.dataset.activeSrc = src;
     imageModalContainer.classList.remove('hidden');
   }
   if(imageModalContainer && !imageModalContainer._listenerAdded){
     imageModalContainer.addEventListener('click', e => {
       if(e.target === imageModalContainer){
-        imageModalContainer.classList.add('hidden');
-        if(imageModal) imageModal.innerHTML='';
+        closeImageModal(imageModalContainer);
       }
     });
     imageModalContainer._listenerAdded = true;


### PR DESCRIPTION
## Summary
- add a shared closeImageModal helper and reuse it when dismissing the modal background
- ensure only one image modal container can be displayed at once and track the active source to avoid duplicates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d75cdefb348331919ec1b652860e68