### PR TITLE
Remove legacy image popup overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -4004,23 +4004,6 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
 .open-post .session-info,
 .second-post-column .session-info{margin-top:8px;}
 
-.img-popup{
-  position:fixed;
-  inset:0;
-  background:var(--image-panel-bg);
-  display:flex;
-  justify-content:center;
-  align-items:center;
-  z-index:4000;
-  pointer-events:auto;
-}
-.img-popup img{
-  max-width:90vw;
-  max-height:90vh;
-  cursor:pointer;
-  pointer-events:auto;
-}
-
 .pill{
   border: 1px solid var(--btn);
   background: var(--btn);
@@ -4065,9 +4048,6 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   }
   .map-container{
     touch-action:auto;
-  }
-  .img-popup img{
-    touch-action:pinch-zoom;
   }
 }
 
@@ -10130,7 +10110,8 @@ function openPostModal(id){
           if(!t) return;
           const idx = clampIdx(parseInt(t.dataset.index,10));
           if(currentIdx === idx && t.classList.contains('selected')){
-            openImagePopup(idx);
+            const fullSrc = t.dataset.full || t.src;
+            openImageModal(fullSrc);
           } else {
             show(idx);
           }
@@ -10150,41 +10131,6 @@ function openPostModal(id){
             if(prevThumb) prevThumb.focus();
           }
         });
-      }
-      function openImagePopup(start){
-        const panel = document.createElement('div');
-        panel.className = 'img-popup';
-        const imgEl = document.createElement('img');
-        let idx = start;
-        imgEl.src = imgs[idx];
-        imgEl.dataset.index = idx;
-        panel.appendChild(imgEl);
-        function next(){
-          idx = (idx+1)%imgs.length;
-          imgEl.src = imgs[idx];
-          imgEl.dataset.index = idx;
-        }
-        function prev(){
-          idx = (idx-1+imgs.length)%imgs.length;
-          imgEl.src = imgs[idx];
-          imgEl.dataset.index = idx;
-        }
-        const entry = {remove: ()=> panel.remove()};
-        panel._entry = entry;
-        imgEl.addEventListener('click', e=>{ e.stopPropagation(); next(); });
-        let startX = null;
-        imgEl.addEventListener('touchstart', e=>{ startX = e.touches[0].clientX; });
-        imgEl.addEventListener('touchend', e=>{
-          if(startX===null) return;
-          const diff = e.changedTouches[0].clientX - startX;
-          if(Math.abs(diff) > 50){
-            diff < 0 ? next() : prev();
-          }
-          startX = null;
-        });
-        panel.addEventListener('click', ()=>{ const i = panelStack.indexOf(entry); if(i!==-1) panelStack.splice(i,1); panel.remove(); });
-        document.body.appendChild(panel);
-        panelStack.push(entry);
       }
       if(imageBox){
         let dragStartX = null;
@@ -10207,7 +10153,9 @@ function openPostModal(id){
           const imgTarget = e.target.closest('.image-track img');
           if(!imgTarget) return;
           e.stopPropagation();
-          openImagePopup(currentIdx);
+          const currentSlide = ensureSlide(currentIdx) || slides[currentIdx] || imgTarget;
+          const fullSrc = currentSlide ? (currentSlide.dataset.full || currentSlide.src) : imgs[currentIdx];
+          openImageModal(fullSrc);
         });
         imageBox.addEventListener('touchstart', e=>{
           if(e.touches.length !== 1) return;
@@ -11260,7 +11208,13 @@ function repositionPanels(){
 }
 function handleEsc(){
   const top = panelStack[panelStack.length-1];
-  if(!top) return;
+  if(!top){
+    const {container} = ensureImageModalReady();
+    if(container && !container.classList.contains('hidden')){
+      closeImageModal(container);
+    }
+    return;
+  }
   if(top instanceof Element){
     if(top.id === 'adminPanel' && typeof window.saveAdminChanges === 'function'){
       window.saveAdminChanges();
@@ -11286,7 +11240,7 @@ document.addEventListener('keydown', e=>{
 });
 
 function handleDocInteract(e){
-  if(e.target.closest('.img-popup')) return;
+  if(e.target.closest('.image-modal-container')) return;
   if(logoEls.some(el => el.contains(e.target))) return;
   if(e.target.closest('#filterBtn')) return;
   const welcome = document.getElementById('welcome-modal');
@@ -11305,16 +11259,6 @@ function handleDocInteract(e){
       closePanel(filterPanel);
     }
   }
-  document.querySelectorAll('.img-popup').forEach(p=>{
-    if(!p.contains(e.target)){
-      p.remove();
-      const entry = p._entry;
-      if(entry){
-        const i = panelStack.indexOf(entry);
-        if(i!==-1) panelStack.splice(i,1);
-      }
-    }
-  });
 }
 
 document.addEventListener('click', handleDocInteract);
@@ -11449,7 +11393,7 @@ document.addEventListener('pointerdown', (e) => {
   {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},
   {key:'welcome-modal', label:'Welcome Modal', selectors:{bg:['#welcome-modal .modal-content'], text:['#welcome-modal .modal-content'], title:['#welcome-modal .modal-content .t','#welcome-modal .modal-content .title'], btn:['#welcome-modal button:not([class*"mapboxgl-"])'], btnText:['#welcome-modal button:not([class*"mapboxgl-"])']}},
   {key:'memberPanel', label:'Member Panel', selectors:{bg:['#memberPanel .panel-content'], text:['#memberPanel .panel-content'], title:['#memberPanel .panel-content .t','#memberPanel .panel-content .title'], btn:['#memberPanel button'], btnText:['#memberPanel button']}},
-  {key:'imagePanel', label:'Image Popup', selectors:{bg:['.img-popup']}}
+  {key:'imagePanel', label:'Image Modal', selectors:{bg:['.image-modal-container'], text:['.image-modal-container .image-modal']}}
 ];
 
   function storeTitleDefaults(){
@@ -11993,24 +11937,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (e.touches.length < 2) startDist = null;
   });
 
-  function openImagePopup(src){
-    const overlay = document.createElement('div');
-    overlay.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.8);display:flex;align-items:center;justify-content:center;z-index:9999;';
-    const big = document.createElement('img');
-    big.src = src;
-    big.style.cssText = 'max-width:90%;max-height:90%;touch-action:pinch-zoom;';
-    overlay.appendChild(big);
-    overlay.addEventListener('click', () => overlay.remove());
-    document.body.appendChild(overlay);
-  }
-
-posts.querySelectorAll('img').forEach(img => {
-    img.addEventListener('click', e => { e.stopPropagation(); openImagePopup(img.src); });
+  posts.querySelectorAll('img').forEach(img => {
+    img.addEventListener('click', e => { e.stopPropagation(); openImageModal(img.src); });
     img.addEventListener('touchstart', e => {
       if (e.touches.length === 2) {
         e.preventDefault();
         e.stopPropagation();
-        openImagePopup(img.src);
+        openImageModal(img.src);
       }
     }, { passive: false });
   });
@@ -12046,6 +11979,49 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 <script>
 let boardAdjustCleanup = null;
+
+function ensureImageModalReady(){
+  const container = document.querySelector('.image-modal-container');
+  if(!container) return {container:null, modal:null};
+  if(!container._listenerAdded){
+    container.addEventListener('click', e => {
+      if(e.target === container){
+        closeImageModal(container);
+      }
+    });
+    container._listenerAdded = true;
+  }
+  const modal = container.querySelector('.image-modal');
+  return {container, modal};
+}
+
+function closeImageModal(container){
+  const target = container || ensureImageModalReady().container;
+  if(!target) return;
+  const modal = target.querySelector('.image-modal');
+  if(modal) modal.innerHTML = '';
+  target.classList.add('hidden');
+  if(target.dataset) delete target.dataset.activeSrc;
+}
+
+function openImageModal(src){
+  const {container, modal} = ensureImageModalReady();
+  if(!container || !modal) return;
+  document.querySelectorAll('.image-modal-container').forEach(other => {
+    if(other !== container && !other.classList.contains('hidden')){
+      closeImageModal(other);
+    }
+  });
+  if(!container.classList.contains('hidden') && container.dataset.activeSrc === src){
+    return;
+  }
+  modal.innerHTML = '';
+  const img = document.createElement('img');
+  img.src = src;
+  modal.appendChild(img);
+  container.dataset.activeSrc = src;
+  container.classList.remove('hidden');
+}
 
 function initPostLayout(board){
   if(typeof boardAdjustCleanup === 'function'){
@@ -12094,43 +12070,9 @@ function initPostLayout(board){
   triggerDetailMapResize(secondCol);
   const thumbRow = postBody ? postBody.querySelector('.thumbnail-row') : null;
   const selectedImageBox = postBody ? postBody.querySelector('.selected-image, .image-box') : null;
-  const imageModalContainer = document.querySelector('.image-modal-container');
-  const imageModal = imageModalContainer ? imageModalContainer.querySelector('.image-modal') : null;
+  ensureImageModalReady();
   if(thumbRow){
     thumbRow.scrollLeft = 0;
-  }
-  function closeImageModal(container){
-    if(!container) return;
-    container.classList.add('hidden');
-    const inner = container.querySelector ? container.querySelector('.image-modal') : null;
-    if(inner) inner.innerHTML = '';
-    if(container.dataset) delete container.dataset.activeSrc;
-  }
-
-  function openImageModal(src){
-    if(!imageModalContainer || !imageModal) return;
-    document.querySelectorAll('.image-modal-container').forEach(container => {
-      if(container !== imageModalContainer && !container.classList.contains('hidden')){
-        closeImageModal(container);
-      }
-    });
-    if(!imageModalContainer.classList.contains('hidden') && imageModalContainer.dataset.activeSrc === src){
-      return;
-    }
-    imageModal.innerHTML='';
-    const img = document.createElement('img');
-    img.src = src;
-    imageModal.appendChild(img);
-    imageModalContainer.dataset.activeSrc = src;
-    imageModalContainer.classList.remove('hidden');
-  }
-  if(imageModalContainer && !imageModalContainer._listenerAdded){
-    imageModalContainer.addEventListener('click', e => {
-      if(e.target === imageModalContainer){
-        closeImageModal(imageModalContainer);
-      }
-    });
-    imageModalContainer._listenerAdded = true;
   }
   if(thumbRow && !thumbRow._imageModalListener){
     thumbRow.addEventListener('dblclick', e => {


### PR DESCRIPTION
## Summary
- consolidate image zoom interactions onto the shared image modal
- remove the unused legacy popup styles and references

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d760e81dd48331a2e7d5a7b2878628