### PR TITLE
Fix multi-post venue detection for wrapped map coordinates

### DIFF
--- a/index.html
+++ b/index.html
@@ -6143,10 +6143,18 @@ function buildClusterListHTML(items){
   return `<div class=\"multi-hover\">${head}<div class=\"multi-list map-card-list\">${list}</div></div>`;
 }
     // 0530: group posts at the same venue (by coordinate)
+    function lngDeltaWithWrap(a, b){
+      if(!Number.isFinite(a) || !Number.isFinite(b)){
+        return Number.POSITIVE_INFINITY;
+      }
+      const delta = ((a - b + 540) % 360) - 180;
+      return Math.abs(delta);
+    }
+
     function postsAtVenue(lng, lat){
       const list = (filtered.length ? filtered : posts);
       const eps = 1e-6; // ~0.1m at equator
-      return list.filter(p => Math.abs(p.lng - lng) < eps && Math.abs(p.lat - lat) < eps);
+      return list.filter(p => lngDeltaWithWrap(p.lng, lng) < eps && Math.abs(p.lat - lat) < eps);
     }
 
     function openListPopupAtPoint(point, htmlStr){


### PR DESCRIPTION
## Summary
- treat Mapbox world copies as the same venue by normalizing longitude differences before grouping posts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d761d4cb5483319877e4f841b46a06