### PR TITLE
Fix multi-venue marker label wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -8751,8 +8751,9 @@ if (!map.__pillHooksInstalled) {
             const labelLines = getMarkerLabelLines(p);
             const primaryVenue = getPrimaryVenueName(p);
             const venueLabel = primaryVenue || p.city || '';
+            const multiTitle = `${count} posts at this venue`;
             const labelTitle = isMultiVenue
-              ? shortenMarkerLabelText(`${count} posts`)
+              ? shortenMarkerLabelText(multiTitle)
               : labelLines.line1;
             const labelVenue = isMultiVenue
               ? shortenMarkerLabelText(venueLabel)


### PR DESCRIPTION
## Summary
- ensure multi-venue marker labels use "{count} posts at this venue" messaging while retaining venue details

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d766444ea483318d1b62693fcc7662