### PR TITLE
Adjust posts mode layout recalculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -7685,8 +7685,6 @@ function makePosts(){
         setMode('posts');
         document.body.classList.add('show-history');
         renderHistoryBoard();
-        adjustBoards();
-        window.adjustListHeight();
         setTimeout(()=>{
           if(map && typeof map.resize === 'function'){
             map.resize();
@@ -7702,7 +7700,6 @@ function makePosts(){
         document.body.classList.remove('show-history');
         if(!isPostsMode || historyActive){
           setMode('posts');
-          window.adjustListHeight();
           setTimeout(()=>{
             if(map && typeof map.resize === 'function'){
               map.resize();
@@ -8086,6 +8083,9 @@ function makePosts(){
           document.body.classList.remove('show-history');
         }
         adjustBoards();
+        if(m === 'posts' && typeof window.adjustListHeight === 'function'){
+          window.adjustListHeight();
+        }
         updateModeToggle();
         if(m === 'posts'){
           const boardEl = document.querySelector('.post-board');


### PR DESCRIPTION
## Summary
- trigger list height adjustments from setMode when entering posts mode
- remove redundant button-level adjustListHeight calls now handled globally

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d769ee93e08331a5a1c3b70471870d