### PR TITLE
Adjust post mode list height timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -8082,8 +8082,9 @@ function makePosts(){
         if(m==='map'){
           document.body.classList.remove('show-history');
         }
+        const shouldAdjustListHeight = m === 'posts' && typeof window.adjustListHeight === 'function';
         adjustBoards();
-        if(m === 'posts' && typeof window.adjustListHeight === 'function'){
+        if(shouldAdjustListHeight){
           window.adjustListHeight();
         }
         updateModeToggle();


### PR DESCRIPTION
## Summary
- ensure `setMode` caches whether the posts list height adjustment is needed and invoke it immediately after updating board layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d76a8773e08331a49a51091dfa3715