### PR TITLE
Adjust map control bar width

### DIFF
--- a/index.html
+++ b/index.html
@@ -3086,12 +3086,15 @@ body.filters-active #filterBtn{
   left:50%;
   top:calc(var(--header-h) + 10px);
   transform:translateX(-50%);
-  width:min(600px, 90vw);
+  width:auto;
   max-width:90vw;
+  min-width:0;
   z-index:1;
 }
 
 .map-controls-map .geocoder{
+  flex:0 1 360px;
+  width:auto;
   max-width:360px;
 }
 


### PR DESCRIPTION
## Summary
- let the map control container size to its content while staying centered on the map
- keep the map geocoder from stretching so the controls hug their buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d76c4a4a288331aad1a6d8ffb83ae9