### PR TITLE
Fix map controls wrapping on the map view

### DIFF
--- a/index.html
+++ b/index.html
@@ -3108,6 +3108,7 @@ body.filters-active #filterBtn{
   max-width:90vw;
   min-width:0;
   z-index:1;
+  flex-wrap:nowrap;
 }
 
 .map-controls-map .geocoder{


### PR DESCRIPTION
## Summary
- prevent the map control row from wrapping to a second line on the main map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d835030044833192a16070c2e282e3