### PR TITLE
Improve detection of Mapbox featureset layers

### DIFF
--- a/index.html
+++ b/index.html
@@ -5557,15 +5557,48 @@ if (typeof slugify !== 'function') {
 
   function layerHasFeatureMetadata(layer){
     if(!layer || typeof layer !== 'object') return false;
-    const meta = layer.metadata;
-    if(!meta || typeof meta !== 'object') return false;
     const keys = [
       'mapbox:featureComponent',
       'mapbox:featureset',
       'mapbox:layerGroup',
       'mapbox:styleGroup'
     ];
-    return keys.some(key => Object.prototype.hasOwnProperty.call(meta, key));
+
+    const meta = layer.metadata;
+    if(meta && typeof meta === 'object'){
+      const hasMetaKey = keys.some(key => Object.prototype.hasOwnProperty.call(meta, key));
+      if(hasMetaKey) return true;
+    }
+
+    const filter = layer.filter;
+    if(!filter) return false;
+
+    function scanExpression(expr){
+      if(Array.isArray(expr)){
+        for(let i = 0; i < expr.length; i++){
+          if(scanExpression(expr[i])) return true;
+        }
+        return false;
+      }
+      if(expr && typeof expr === 'object'){
+        for(const key in expr){
+          if(Object.prototype.hasOwnProperty.call(expr, key)){
+            if(scanExpression(expr[key])) return true;
+          }
+        }
+        return false;
+      }
+      if(typeof expr === 'string'){
+        if(expr === 'featureNamespace' || keys.includes(expr)) return true;
+      }
+      return false;
+    }
+
+    try {
+      return scanExpression(filter);
+    } catch(err) {
+      return false;
+    }
   }
 
   function patchLayerFiltersForMissingLayer(mapInstance, style){


### PR DESCRIPTION
## Summary
- expand layerHasFeatureMetadata to detect Mapbox featureset layers by metadata keys or featureNamespace tokens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8cb3dc03c83318dcd60c6e377ed50