### PR TITLE
Improve featureset detection in layer filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -5555,51 +5555,60 @@ if (typeof slugify !== 'function') {
     try{ window.__addOrReplacePill150x40?.(mapInstance); }catch(err){}
   }
 
-  function layerHasFeatureMetadata(layer){
-    if(!layer || typeof layer !== 'object') return false;
-    const keys = [
-      'mapbox:featureComponent',
-      'mapbox:featureset',
-      'mapbox:layerGroup',
-      'mapbox:styleGroup'
-    ];
+    function layerHasFeatureMetadata(layer){
+      if(!layer || typeof layer !== 'object') return false;
+      const metadataKeys = [
+        'mapbox:featureComponent',
+        'mapbox:featureset',
+        'mapbox:layerGroup',
+        'mapbox:styleGroup'
+      ];
+      const featuresetTokens = [
+        'featureNamespace',
+        'mapbox:featureComponent',
+        'mapbox:featureset',
+        'mapbox:layerGroup',
+        'mapbox:styleGroup'
+      ];
 
-    const meta = layer.metadata;
-    if(meta && typeof meta === 'object'){
-      const hasMetaKey = keys.some(key => Object.prototype.hasOwnProperty.call(meta, key));
-      if(hasMetaKey) return true;
-    }
-
-    const filter = layer.filter;
-    if(!filter) return false;
-
-    function scanExpression(expr){
-      if(Array.isArray(expr)){
-        for(let i = 0; i < expr.length; i++){
-          if(scanExpression(expr[i])) return true;
-        }
-        return false;
+      const meta = layer.metadata;
+      if(meta && typeof meta === 'object'){
+        const hasMetaKey = metadataKeys.some(key => Object.prototype.hasOwnProperty.call(meta, key));
+        if(hasMetaKey) return true;
       }
-      if(expr && typeof expr === 'object'){
-        for(const key in expr){
-          if(Object.prototype.hasOwnProperty.call(expr, key)){
+
+      const filter = layer.filter;
+      if(!filter) return false;
+
+      const tokenSet = new Set(featuresetTokens);
+
+      function scanExpression(expr){
+        if(Array.isArray(expr)){
+          for(let i = 0; i < expr.length; i++){
+            if(scanExpression(expr[i])) return true;
+          }
+          return false;
+        }
+        if(expr && typeof expr === 'object'){
+          for(const key in expr){
+            if(!Object.prototype.hasOwnProperty.call(expr, key)) continue;
+            if(typeof key === 'string' && tokenSet.has(key)) return true;
             if(scanExpression(expr[key])) return true;
           }
+          return false;
+        }
+        if(typeof expr === 'string'){
+          if(tokenSet.has(expr)) return true;
         }
         return false;
       }
-      if(typeof expr === 'string'){
-        if(expr === 'featureNamespace' || keys.includes(expr)) return true;
-      }
-      return false;
-    }
 
-    try {
-      return scanExpression(filter);
-    } catch(err) {
-      return false;
+      try {
+        return scanExpression(filter);
+      } catch(err) {
+        return false;
+      }
     }
-  }
 
   function patchLayerFiltersForMissingLayer(mapInstance, style){
     if(!mapInstance || typeof mapInstance.setFilter !== 'function') return;


### PR DESCRIPTION
## Summary
- expand `layerHasFeatureMetadata` to recognize featureset tokens within filter expressions in addition to metadata
- ensure filter patching continues to skip featureset layers before applying mutations

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8d4335bbc83318bbbfa79478f7379