### PR TITLE
Ensure cluster zoom animation remains essential

### DIFF
--- a/index.html
+++ b/index.html
@@ -9205,7 +9205,7 @@ if (!map.__pillHooksInstalled) {
               if(!coords) { clearSuppress(); return; }
               const maxZoom = typeof map.getMaxZoom === 'function' ? map.getMaxZoom() : undefined;
               const nextZoom = typeof maxZoom === 'number' ? Math.min(zoom, maxZoom) : zoom;
-              map.easeTo({ center: coords, zoom: nextZoom });
+              map.easeTo({ center: coords, zoom: nextZoom, essential: true });
             }catch(ex){
               console.error(ex);
               clearSuppress();


### PR DESCRIPTION
## Summary
- mark the cluster zoom `easeTo` animation as essential so it still plays when reduce motion is enabled

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d99c6536788331a5b67f4d4d7bc486