### PR TITLE
Remove idle throttling from openPost

### DIFF
--- a/index.html
+++ b/index.html
@@ -12375,9 +12375,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const factories = new Map([
-    ['openPost', (orig) => rafThrottle(function(...args){
-      scheduleIdle(() => orig.apply(this, args));
-    })],
     ['hookDetailActions', (orig) => {
       const wrapped = rafThrottle(function(...args){
         scheduleIdle(() => orig.apply(this, args));
@@ -12410,7 +12407,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  ['openPost','hookDetailActions','ensureMapForVenue'].forEach(applyWrapper);
+  ['hookDetailActions','ensureMapForVenue'].forEach(applyWrapper);
 
   window.__wrapForInputYield = function(name){
     applyWrapper(name);


### PR DESCRIPTION
## Summary
- remove the idle/throttled wrapper from `openPost` so clicks dispatch immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d99d13d0388331bc2827b8c6af54cd