### PR TITLE
Add explicit duration to cluster zoom animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9231,7 +9231,7 @@ if (!map.__pillHooksInstalled) {
               if(!coords) { clearSuppress(); return; }
               const maxZoom = typeof map.getMaxZoom === 'function' ? map.getMaxZoom() : undefined;
               const nextZoom = typeof maxZoom === 'number' ? Math.min(zoom, maxZoom) : zoom;
-              map.easeTo({ center: coords, zoom: nextZoom, essential: true });
+              map.easeTo({ center: coords, zoom: nextZoom, essential: true, duration: 500 });
             }catch(ex){
               console.error(ex);
               clearSuppress();


### PR DESCRIPTION
## Summary
- add an explicit duration to the cluster click `easeTo` call so the zoom animation is consistent even with reduced motion settings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9a0ca545c83319ab5a2fbe9b2b6d0