### PR TITLE
Reset map canvas cursor to the default pointer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4748,7 +4748,7 @@ img.thumb{
   <style id="cursor-fixes">
     html, body { cursor: auto !important; }
     a, button, [role="button"], .clickable { cursor: pointer !important; }
-    .mapboxgl-canvas { cursor: grab; }
+    .mapboxgl-canvas { cursor: default; }
     .mapboxgl-canvas:active { cursor: grabbing; }
     * { -webkit-tap-highlight-color: transparent; }
   </style>


### PR DESCRIPTION
## Summary
- switch the map canvas to use the default cursor so the pointer no longer appears as a distorted hand
- keep the grabbing feedback while the map is actively dragged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d99fd93ac88331ad199be891d0f0ab