### PR TITLE
Improve board slide animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -7589,6 +7589,9 @@ function makePosts(){
           board.style.display = 'none';
           board._boardHideHandler = null;
           board._boardHideTimer = null;
+          try{
+            board.style.removeProperty('transform');
+          }catch(err){}
         };
         if(immediate){
           board.classList.remove('panel-visible');
@@ -7606,7 +7609,19 @@ function makePosts(){
         };
         board._boardHideHandler = handler;
         board.addEventListener('transitionend', handler);
-        board.classList.remove('panel-visible');
+        const removeVisible = ()=>{
+          if(!board.isConnected){
+            board.removeEventListener('transitionend', handler);
+            finalize();
+            return;
+          }
+          board.classList.remove('panel-visible');
+        };
+        if('requestAnimationFrame' in window){
+          requestAnimationFrame(removeVisible);
+        } else {
+          removeVisible();
+        }
         board._boardHideTimer = setTimeout(()=>{
           if(board._boardHideHandler){
             board._boardHideHandler();
@@ -7680,6 +7695,12 @@ function makePosts(){
         boardsContainer.style.justifyContent = 'flex-start';
         const skipAnimation = !boardsInitialized;
         toggleBoard(recentsBoard, isPostsMode && historyActive, skipAnimation);
+        if(postBoard){
+          const desiredSide = historyActive ? 'right' : 'left';
+          if(postBoard.dataset.side !== desiredSide){
+            postBoard.dataset.side = desiredSide;
+          }
+        }
         toggleBoard(postBoard, isPostsMode && !historyActive, skipAnimation);
         document.body.classList.toggle('detail-open', !!anyOpenPost);
         if(adBoard){


### PR DESCRIPTION
## Summary
- ensure post and ad boards wait for the browser frame before removing the visible state so slide-out animations play
- switch the post board slide direction when the recents board is open for a smoother entrance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a0af9c888331bd3799f544028563