### PR TITLE
Prevent board animations from retriggering on post clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -7578,7 +7578,8 @@ function makePosts(){
           board.classList.add('panel-visible');
           board.style.transform = '';
         } else {
-          schedulePanelEntrance(board, true);
+          const wasHidden = !board.classList.contains('panel-visible');
+          schedulePanelEntrance(board, wasHidden);
         }
       }
 


### PR DESCRIPTION
## Summary
- update the board display helper to avoid forcing a panel re-animation when the board is already visible
- keep the boards steady so clicking posts no longer collapses and reopens the lists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9a39ba39c8331aa4a90d7710f1744