### PR TITLE
Improve cluster animation duration scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -9253,13 +9253,34 @@ if (!map.__pillHooksInstalled) {
               if(!coords) { clearSuppress(); return; }
               const maxZoom = typeof map.getMaxZoom === 'function' ? map.getMaxZoom() : undefined;
               const nextZoom = typeof maxZoom === 'number' ? Math.min(zoom, maxZoom) : zoom;
-              map.easeTo({ center: coords, zoom: nextZoom, essential: true, duration: 500 });
+              const animationOpts = { center: coords, zoom: nextZoom, essential: true };
+              let computedDuration = 650;
+              try{
+                const getCenter = typeof map.getCenter === 'function' ? map.getCenter() : null;
+                const getZoom = typeof map.getZoom === 'function' ? map.getZoom() : null;
+                const targetLngLat = (typeof mapboxgl !== 'undefined' && mapboxgl && typeof mapboxgl.LngLat === 'function')
+                  ? new mapboxgl.LngLat(coords[0], coords[1])
+                  : null;
+                if(getCenter && targetLngLat && typeof getCenter.distanceTo === 'function'){
+                  const distanceMeters = getCenter.distanceTo(targetLngLat);
+                  const distanceMs = Math.min(1200, Math.log(distanceMeters / 1000 + 1) * 600);
+                  const zoomDelta = typeof getZoom === 'number' ? Math.abs(nextZoom - getZoom) : 0;
+                  const zoomMs = Math.min(600, zoomDelta * 120);
+                  const base = 450;
+                  computedDuration = Math.max(450, Math.min(2200, base + distanceMs + zoomMs));
+                }
+              }catch(durationErr){
+                console.error(durationErr);
+              }
+              animationOpts.duration = Math.round(computedDuration);
+              map.easeTo(animationOpts);
+              const settleDelay = Math.max(400, (animationOpts.duration || 500) + 120);
+              setTimeout(clearSuppress, settleDelay);
             }catch(ex){
               console.error(ex);
               clearSuppress();
             }
           });
-          setTimeout(clearSuppress, 400);
         });
 
         function createMapCardOverlay(post, opts = {}){


### PR DESCRIPTION
## Summary
- scale cluster zoom animation duration based on the distance to a cluster and required zoom change
- align the suppress flag reset timing with the computed animation duration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9a3fb30e08331afdf4c5abefab9ff