### PR TITLE
Ensure map cursor stays as white hand pointer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4749,7 +4749,7 @@ img.thumb{
   <style id="cursor-fixes">
     html, body { cursor: auto !important; }
     a, button, [role="button"], .clickable { cursor: pointer !important; }
-    .mapboxgl-canvas { cursor: default; }
+    .mapboxgl-canvas { cursor: pointer; }
     .mapboxgl-canvas:active { cursor: grabbing; }
     * { -webkit-tap-highlight-color: transparent; }
   </style>
@@ -5661,7 +5661,7 @@ if (typeof slugify !== 'function') {
       st.layers.forEach(l => {
         if (!shouldAttachPointer(l) || map.__cursorArmed.has(l.id)) return;
         map.on('mouseenter', l.id, () => map.getCanvas().style.cursor = 'pointer');
-        map.on('mouseleave', l.id, () => map.getCanvas().style.cursor = '');
+        map.on('mouseleave', l.id, () => map.getCanvas().style.cursor = 'pointer');
         map.__cursorArmed.add(l.id);
       });
     }
@@ -9550,7 +9550,7 @@ if (!map.__pillHooksInstalled) {
       MARKER_INTERACTIVE_LAYERS.forEach(layer => map.on('mousemove', layer, onMarkerMove));
 
       const handleMarkerMouseLeave = ()=>{
-        map.getCanvas().style.cursor = '';
+        map.getCanvas().style.cursor = 'pointer';
         if(listLocked) return;
         const currentPopup = hoverPopup;
         schedulePopupRemoval(currentPopup, 200);
@@ -9562,7 +9562,7 @@ if (!map.__pillHooksInstalled) {
         map.getCanvas().style.cursor='pointer';
       });
       map.on('mouseleave','clusters', ()=>{
-        map.getCanvas().style.cursor='';
+        map.getCanvas().style.cursor='pointer';
       });
         postSourceEventsBound = true;
       }


### PR DESCRIPTION
## Summary
- set the Mapbox canvas cursor to use the pointer style so it renders as the white hand
- keep the pointer cursor active when leaving interactive layers to prevent flicker on the map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a474594c8331a414706d683af6b7