### PR TITLE
Adjust marker layering behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       pointer-events: auto;
       opacity: 1 !important;
       mix-blend-mode: normal;
-      z-index: inherit;
+      z-index: 0;
     }
     .map-card-thumb{
       position: absolute;
@@ -106,7 +106,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       text-shadow: 0 1px 2px rgba(0,0,0,0.35);
-      z-index: inherit;
+      z-index: 1;
       pointer-events: auto;
     }
 


### PR DESCRIPTION
## Summary
- set marker pill elements to use an explicit base z-index
- raise marker label z-index so it stays above its own pill within the stacking context

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9a6c07b208331887efd9015d240ba