### PR TITLE
Adjust map cursor handling to prevent jumpy click behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -4749,7 +4749,7 @@ img.thumb{
   <style id="cursor-fixes">
     html, body { cursor: auto !important; }
     a, button, [role="button"], .clickable { cursor: pointer !important; }
-    .mapboxgl-canvas { cursor: pointer; }
+    .mapboxgl-canvas { cursor: grab; }
     .mapboxgl-canvas:active { cursor: grabbing; }
     * { -webkit-tap-highlight-color: transparent; }
   </style>
@@ -5661,7 +5661,7 @@ if (typeof slugify !== 'function') {
       st.layers.forEach(l => {
         if (!shouldAttachPointer(l) || map.__cursorArmed.has(l.id)) return;
         map.on('mouseenter', l.id, () => map.getCanvas().style.cursor = 'pointer');
-        map.on('mouseleave', l.id, () => map.getCanvas().style.cursor = 'pointer');
+        map.on('mouseleave', l.id, () => map.getCanvas().style.cursor = 'grab');
         map.__cursorArmed.add(l.id);
       });
     }
@@ -9572,7 +9572,7 @@ if (!map.__pillHooksInstalled) {
       MARKER_INTERACTIVE_LAYERS.forEach(layer => map.on('mousemove', layer, onMarkerMove));
 
       const handleMarkerMouseLeave = ()=>{
-        map.getCanvas().style.cursor = 'pointer';
+        map.getCanvas().style.cursor = 'grab';
         if(listLocked) return;
         const currentPopup = hoverPopup;
         schedulePopupRemoval(currentPopup, 200);
@@ -9584,7 +9584,7 @@ if (!map.__pillHooksInstalled) {
         map.getCanvas().style.cursor='pointer';
       });
       map.on('mouseleave','clusters', ()=>{
-        map.getCanvas().style.cursor='pointer';
+        map.getCanvas().style.cursor='grab';
       });
         postSourceEventsBound = true;
       }


### PR DESCRIPTION
## Summary
- restore the map's default grab cursor instead of forcing a pointer
- reset the canvas cursor to grab when leaving interactive layers so the map remains stable after clicks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a66a65ec8331aa464278815e3498