### PR TITLE
Display map zoom level

### DIFF
--- a/index.html
+++ b/index.html
@@ -2917,6 +2917,27 @@ body.filters-active #filterBtn{
   pointer-events: none;
 }
 
+.map-zoom-indicator{
+  position:absolute;
+  top:calc(var(--safe-top, 0px) + var(--header-h, 0px) + 12px);
+  right:12px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:6px 12px;
+  border-radius:999px;
+  background:rgba(0, 0, 0, 0.7);
+  color:#fff;
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:.3px;
+  line-height:1;
+  pointer-events:none;
+  z-index:5;
+  min-width:72px;
+  text-align:center;
+}
+
 .map-control-row{
   display:flex;
   align-items:center;
@@ -4941,6 +4962,7 @@ if (typeof slugify !== 'function') {
       <div id="geolocate-map" class="geolocate-btn"></div>
       <div id="compass-map" class="compass-btn"></div>
     </div>
+    <div class="map-zoom-indicator" id="mapZoomIndicator" aria-live="polite">Zoom --</div>
     <div id="map"></div>
   </section>
 
@@ -8531,6 +8553,22 @@ function makePosts(){
           bearing: startBearing,
           attributionControl:true
         });
+        const zoomIndicatorEl = document.getElementById('mapZoomIndicator');
+        const updateZoomIndicator = () => {
+          if(!map || !zoomIndicatorEl || typeof map.getZoom !== 'function') return;
+          try{
+            const zoomLevel = map.getZoom();
+            if(Number.isFinite(zoomLevel)){
+              zoomIndicatorEl.textContent = `Zoom ${zoomLevel.toFixed(2)}`;
+            }
+          }catch(err){}
+        };
+        if(zoomIndicatorEl){
+          map.on('zoom', updateZoomIndicator);
+          map.on('zoomend', updateZoomIndicator);
+          map.once('load', updateZoomIndicator);
+          updateZoomIndicator();
+        }
 // === Pill hooks (safe) ===
 try { if (typeof __addOrReplacePill150x40 === 'function') __addOrReplacePill150x40(map); } catch(e){}
 if (!map.__pillHooksInstalled) {


### PR DESCRIPTION
## Summary
- add a zoom indicator element positioned at the top-right of the map
- update the map initialization logic to keep the indicator in sync with the current zoom level

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9afe2c31c833181d396e8815c42a2