### PR TITLE
Limit clustering to zoom 11

### DIFF
--- a/index.html
+++ b/index.html
@@ -5802,9 +5802,9 @@ if (typeof slugify !== 'function') {
           mapStyle = window.mapStyle = 'mapbox://styles/mapbox/standard',
           clusterRadius = parseInt(localStorage.getItem('clusterRadius') || '52', 10),
           clusterMaxZoom = (()=>{
-            let storedValue = parseInt(localStorage.getItem('clusterMaxZoom') || '14', 10);
-            if(Number.isNaN(storedValue)) storedValue = 14;
-            return Math.min(storedValue, 10);
+            let storedValue = parseInt(localStorage.getItem('clusterMaxZoom') || '11', 10);
+            if(Number.isNaN(storedValue)) storedValue = 11;
+            return Math.min(storedValue, 11);
           })(),
           clusterIconType = localStorage.getItem('clusterIconType') || 'circle',
           clusterSvg = localStorage.getItem('clusterSvg') || '',


### PR DESCRIPTION
## Summary
- clamp the stored cluster maximum zoom level to 11 so markers stop clustering once the map zoom exceeds that threshold

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9b4055e2c8331937b94d0f4d43986