### PR TITLE
Ensure mapmarker pill stays fully opaque

### DIFF
--- a/index.html
+++ b/index.html
@@ -9334,6 +9334,7 @@ if (!map.__pillHooksInstalled) {
           pillImg.alt = '';
           pillImg.src = 'assets/icons-30/225x60-pill-99.webp';
           pillImg.className = 'map-card-pill mapmarker-container-pill';
+          pillImg.style.opacity = '1';
           pillImg.draggable = false;
 
           const thumbImg = new Image();


### PR DESCRIPTION
## Summary
- force the dynamically created map marker pill image to use opacity 1 so it renders fully opaque

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b4a260f083318a64135e9680ca90