### PR TITLE
Add solid background behind map marker pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,18 @@
       box-shadow: none;
       z-index: 0;
     }
+    .mapmarker-container::before{
+      content: "";
+      position: absolute;
+      left: -5px;
+      top: -5px;
+      width: 225px;
+      height: 60px;
+      background: #000;
+      border-radius: 999px;
+      pointer-events: none;
+      z-index: 0;
+    }
     .mapmarker-container > .map-card{
       position: absolute;
       left: -25px;
@@ -84,7 +96,7 @@
       pointer-events: auto;
       opacity: 1 !important;
       mix-blend-mode: normal;
-      z-index: 0;
+      z-index: 1;
     }
     .map-card-thumb{
       position: absolute;
@@ -95,7 +107,7 @@
       border-radius: 50%;
       object-fit: cover;
       box-shadow: 0 2px 6px rgba(0,0,0,0.35);
-      z-index: 1;
+      z-index: 2;
     }
     .map-card-text,
     .mapmarker-container-label{
@@ -118,7 +130,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       text-shadow: 0 1px 2px rgba(0,0,0,0.35);
-      z-index: 1;
+      z-index: 2;
       pointer-events: auto;
     }
 


### PR DESCRIPTION
## Summary
- add a pseudo-element background to map markers to block the map bleed-through
- adjust marker pill and content z-index values so thumbnails and labels render above the new background

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9c1fe153483319ba4a21e330bf85d