### PR TITLE
Ensure map control rows remain single line across viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -3002,7 +3002,7 @@ body.filters-active #filterBtn{
   display:flex;
   align-items:center;
   gap:var(--gap);
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
 }
 .map-control-row .geocoder{
   background-color:#ffffff;
@@ -3129,7 +3129,7 @@ body.filters-active #filterBtn{
   max-width:100%;
   margin:0 auto;
   gap:10px;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
 }
 #welcomeBody .map-controls-welcome{
   pointer-events:auto;
@@ -3204,7 +3204,7 @@ body.filters-active #filterBtn{
 
 @media (max-width:600px){
   .map-controls-map{
-    flex-wrap:wrap;
+    flex-wrap:nowrap;
     justify-content:center;
     gap:8px;
   }


### PR DESCRIPTION
## Summary
- prevent all map control rows from wrapping so the controls stay on one line
- keep the map controls centered on narrow screens without introducing wrapping

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d45d2f8c83318d1e4364f204276b