### PR TITLE
Align map overlays and cards with venue coordinates

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,13 +62,18 @@
       background: transparent;
       border-radius: 999px;
       box-shadow: none;
-      z-index: 0;
+      z-index: 5;
     }
     .mapmarker-overlay > .map-card{
       position: absolute;
-      left: -25px;
-      top: -25px;
+      left: 0;
+      top: 0;
+      transform: translate(-25px, -25px);
       pointer-events: auto;
+      z-index: 30;
+    }
+    .mapmarker-overlay.is-card-visible > .mapmarker-container{
+      display: none;
     }
     .map-card img,
     .mapmarker-container img{ display:block; }
@@ -89,23 +94,24 @@
       position: absolute;
       left: 0;
       top: 0;
-      width: 0;
-      height: 0;
+      width: 150px;
+      height: 40px;
+      transform: translate(-50%, -50%);
       pointer-events: none;
     }
     .mapmarker{
       position: absolute;
-      left: -15px;
-      top: -30px;
+      left: 12px;
+      top: 5px;
       width: 30px;
       height: 30px;
       pointer-events: none;
-      z-index: 1;
+      z-index: 2;
     }
     .mapmarker-pill{
       position: absolute;
-      left: -20px;
-      top: -35px;
+      left: 0;
+      top: 0;
       width: 150px;
       height: 40px;
       object-fit: contain;
@@ -123,7 +129,7 @@
       border-radius: 50%;
       object-fit: cover;
       box-shadow: 0 2px 6px rgba(0,0,0,0.35);
-      z-index: 1;
+      z-index: 40;
     }
     .map-card-label,
     .mapmarker-label{
@@ -151,17 +157,17 @@
     }
 
     .mapmarker-label{
-      left: 20px;
-      top: -33px;
-      width: 120px;
+      left: 48px;
+      top: 7px;
+      width: 96px;
       height: auto;
-      padding: 6px 8px 6px 40px;
+      padding: 4px 8px 4px 0;
       pointer-events: none;
       color: #fff;
       gap: 0;
       text-shadow: 0 1px 2px rgba(0,0,0,0.4);
       white-space: normal;
-      z-index: 2;
+      z-index: 3;
     }
 
     .mapmarker-label-line{
@@ -9498,6 +9504,7 @@ if (!map.__pillHooksInstalled) {
 
           cardRoot.append(pillImg, thumbImg, labelEl);
           overlayRoot.append(markerContainer, cardRoot);
+          overlayRoot.classList.add('is-card-visible');
 
           const handleOverlayClick = (ev)=>{
             ev.preventDefault();


### PR DESCRIPTION
## Summary
- center map marker overlays and labels over their associated coordinates
- ensure hover map cards display above marker overlays and hide the underlying overlay when active
- raise the map card thumbnail stacking order so the thumbnail replaces the marker overlay when shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d7cc83e083319789e4dcdf11a432