### PR TITLE
Move map zoom indicator to bottom center

### DIFF
--- a/index.html
+++ b/index.html
@@ -2979,8 +2979,9 @@ body.filters-active #filterBtn{
 
 .map-zoom-indicator{
   position:absolute;
-  top:calc(var(--safe-top, 0px) + var(--header-h, 0px) + 12px);
-  right:12px;
+  bottom:calc(var(--safe-bottom, 0px) + 20px);
+  left:50%;
+  transform:translateX(-50%);
   display:inline-flex;
   align-items:center;
   justify-content:center;


### PR DESCRIPTION
## Summary
- reposition the map zoom indicator so it displays at the bottom center of the map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d86103c88331a501a1cf53adcc71