### PR TITLE
Ensure image modal starts with selected image

### DIFF
--- a/index.html
+++ b/index.html
@@ -12373,6 +12373,15 @@ function renderImageModalImage(container, modal){
   }
 }
 
+function normalizeImageModalSrc(value){
+  if(!value) return '';
+  try {
+    return new URL(value, window.location.href).href;
+  } catch(err){
+    return String(value);
+  }
+}
+
 function resolveImageModalContext(config){
   const result = {images: [], index: 0, gallery: null};
   if(!config) return result;
@@ -12447,6 +12456,14 @@ function resolveImageModalContext(config){
     const found = images.indexOf(src);
     if(found !== -1){
       index = found;
+    } else {
+      const normalizedSrc = normalizeImageModalSrc(src);
+      for(let i=0;i<images.length;i++){
+        if(normalizeImageModalSrc(images[i]) === normalizedSrc){
+          index = i;
+          break;
+        }
+      }
     }
   }
   if(index === null){


### PR DESCRIPTION
## Summary
- normalize modal image source URLs so the clicked image determines the starting slide
- fall back to the normalized source when resolving the modal's initial index

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d9d961136083319b63d512a276362b