### PR TITLE
Prevent hover cards from causing map jitter

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
     .mapmarker-overlay.is-card-visible > .mapmarker-container{
       display: none;
     }
+    .mapmarker-overlay.is-card-visible{
+      pointer-events: auto;
+    }
     .map-card img,
     .mapmarker-container img{ display:block; }
     .map-card-pill{


### PR DESCRIPTION
## Summary
- allow map hover overlays to capture pointer input when a card is visible to prevent repeated map mousemove updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9db07d9888331b888a7108b36b97a