### PR TITLE
Speed up marker cluster zoom transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9394,6 +9394,11 @@ if (!map.__pillHooksInstalled) {
                   const zoomMs = Math.min(600, zoomDelta * 120);
                   const base = 450;
                   computedDuration = Math.max(450, Math.min(2200, base + distanceMs + zoomMs));
+                  if(zoomDelta < 0.35){
+                    const blend = Math.max(0, Math.min(1, zoomDelta / 0.35));
+                    const speedMultiplier = 0.45 + (0.55 * blend);
+                    computedDuration = Math.max(220, Math.min(2200, computedDuration * speedMultiplier));
+                  }
                 }
               }catch(durationErr){
                 console.error(durationErr);


### PR DESCRIPTION
## Summary
- reduce cluster zoom animation duration when zoom delta is minimal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9df7898a883319db584d45059a514