### PR TITLE
Fix pointer events on map card overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -9514,6 +9514,7 @@ if (!map.__pillHooksInstalled) {
           cardRoot.append(pillImg, thumbImg, labelEl);
           overlayRoot.append(markerContainer, cardRoot);
           overlayRoot.classList.add('is-card-visible');
+          overlayRoot.style.pointerEvents = '';
 
           const handleOverlayClick = (ev)=>{
             ev.preventDefault();


### PR DESCRIPTION
## Summary
- clear the inline pointer-events override once the map card overlay becomes visible so stylesheet rules restore interactivity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9f560d03c83319365fa1344e40234