### PR TITLE
Ensure marker label text overlaps with pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -9238,7 +9238,7 @@ if (!map.__pillHooksInstalled) {
             'text-size': markerLabelTextSize,
             'text-line-height': markerLabelTextLineHeight,
             'text-anchor': 'left',
-            'text-allow-overlap': true,
+            'text-allow-overlap': true, // keep marker text aligned with pill collision behaviour
             'text-ignore-placement': true,
             'text-pitch-alignment': 'viewport',
             'text-max-width': markerLabelTextMaxWidth,
@@ -9270,7 +9270,7 @@ if (!map.__pillHooksInstalled) {
       try{ map.setLayoutProperty('marker-label-text','text-size', markerLabelTextSize); }catch(e){}
       try{ map.setLayoutProperty('marker-label-text','text-line-height', markerLabelTextLineHeight); }catch(e){}
       try{ map.setLayoutProperty('marker-label-text','text-anchor','left'); }catch(e){}
-      try{ map.setLayoutProperty('marker-label-text','text-allow-overlap', true); }catch(e){}
+      try{ map.setLayoutProperty('marker-label-text','text-allow-overlap', true); }catch(e){} // keep marker text aligned with pill collision behaviour
       try{ map.setLayoutProperty('marker-label-text','text-ignore-placement', true); }catch(e){}
       try{ map.setLayoutProperty('marker-label-text','text-pitch-alignment','viewport'); }catch(e){}
       try{ map.setLayoutProperty('marker-label-text','text-max-width', markerLabelTextMaxWidth); }catch(e){}


### PR DESCRIPTION
## Summary
- keep the marker-label text layer configured with collision settings that match the pill so both overlap together
- document the intent inline where the layer layout and refresh logic set text overlap properties

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f65187788331ba1390b56d76ff97