### PR TITLE
Ensure map marker overlays stay in front of other markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
       border-radius: 999px;
       box-shadow: none;
       z-index: 5;
+      will-change: transform;
     }
     .mapmarker-overlay > .map-card{
       position: absolute;
@@ -77,6 +78,7 @@
     }
     .mapmarker-overlay.is-card-visible{
       pointer-events: auto;
+      z-index: 20000;
     }
     .map-card img,
     .mapmarker-container img{ display:block; }
@@ -9553,6 +9555,13 @@ if (!map.__pillHooksInstalled) {
           });
 
           const marker = new mapboxgl.Marker({ element: overlayRoot, anchor: 'center' });
+          if(typeof marker.setZIndexOffset === 'function'){
+            try{ marker.setZIndexOffset(20000); }catch(e){}
+          }
+          const markerElement = typeof marker.getElement === 'function' ? marker.getElement() : overlayRoot;
+          if(markerElement && markerElement.style){
+            markerElement.style.zIndex = '20000';
+          }
           if(targetLngLat){ marker.setLngLat(targetLngLat); }
           else if(fixedLngLat){ marker.setLngLat(fixedLngLat); }
           else if(eventLngLat){ marker.setLngLat(eventLngLat); }


### PR DESCRIPTION
## Summary
- elevate the `mapmarker-overlay` z-index when expanded so the entire overlay renders above other markers
- set a high z-index offset on the overlay marker element to keep the full overlay grouped together on top

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9f9a4976083318fb19e774fa58a41