### PR TITLE
Fix Mapbox console warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -5793,6 +5793,8 @@ if (typeof slugify !== 'function') {
     const layers = style && Array.isArray(style.layers) ? style.layers : [];
     if(!layers.length) return;
 
+    const TARGET_SOURCE = 'posts';
+
     function patchExpression(expr){
       if(!Array.isArray(expr)){
         return { expr, changed:false };
@@ -5825,6 +5827,7 @@ if (typeof slugify !== 'function') {
 
     layers.forEach(layer => {
       if(!layer || !layer.id || !layer.filter) return;
+      if(typeof layer.source !== 'string' || layer.source !== TARGET_SOURCE) return;
       try{
         const patched = patchExpression(layer.filter);
         if(!patched.changed) return;
@@ -5833,28 +5836,9 @@ if (typeof slugify !== 'function') {
     });
   }
 
-  function patchTerrainSource(mapInstance, style){
+  function patchTerrainSource(mapInstance){
     if(!mapInstance || typeof mapInstance.setTerrain !== 'function') return;
-    const terrain = style && style.terrain;
-    if(!terrain || !terrain.source) return;
-    const sources = style.sources || {};
-    const originalSource = sources[terrain.source];
-    if(!originalSource) return;
-
-    const dedicatedId = 'terrain-dem-dedicated';
-    if(!mapInstance.getSource?.(dedicatedId)){
-      try {
-        const clone = JSON.parse(JSON.stringify(originalSource));
-        mapInstance.addSource(dedicatedId, clone);
-      } catch(err){}
-    }
-
-    const targetSource = mapInstance.getSource?.(dedicatedId) ? dedicatedId : terrain.source;
-    const nextTerrain = Object.assign({}, terrain, { source: targetSource });
-    if(typeof nextTerrain.cutoff !== 'number' || nextTerrain.cutoff <= 0){
-      nextTerrain.cutoff = 0.01;
-    }
-    try { mapInstance.setTerrain(nextTerrain); } catch(err){}
+    try { mapInstance.setTerrain(null); } catch(err){}
   }
 
   function patchMapboxStyleArtifacts(mapInstance){


### PR DESCRIPTION
## Summary
- limit the filter patching helper to only touch custom `posts` layers so built-in Mapbox featuresets are left unchanged
- disable Mapbox terrain to eliminate repeated DEM and cutoff warnings while keeping buildings intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9fa3f6ef883318fd6d3c237e448bd