### PR TITLE
Align marker sort order across layers

### DIFF
--- a/index.html
+++ b/index.html
@@ -9089,6 +9089,24 @@ if (!map.__pillHooksInstalled) {
         }
         return best;
       }
+      function computeStackOrder(post){
+        const lat = Number(post.lat);
+        const latPart = Number.isFinite(lat) ? Math.round((lat + 90) * 1e6) : 0;
+        const rawId = post.id;
+        let idPart = 0;
+        if(Number.isFinite(rawId)){
+          idPart = Math.trunc(rawId);
+        } else if(rawId !== undefined && rawId !== null){
+          const str = String(rawId);
+          let hash = 0;
+          for(let i = 0; i < str.length; i++){
+            hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
+          }
+          idPart = hash;
+        }
+        const normalizedId = ((idPart % 1e6) + 1e6) % 1e6;
+        return latPart * 1e6 + normalizedId;
+      }
       coordMeta.forEach((meta, key) => {
         let label = findCommonLabel(meta.locVenueCounts, meta.count);
         if(!label){
@@ -9146,7 +9164,8 @@ if (!map.__pillHooksInstalled) {
                 multi:isMultiVenue ? 1 : 0,
                 multiCount: count,
                 multiLabel: String(count),
-                venueKey: venueKey(p.lng, p.lat)
+                venueKey: venueKey(p.lng, p.lat),
+                stackOrder: computeStackOrder(p)
               },
               geometry:{type:'Point', coordinates:[p.lng, p.lat]}
             };
@@ -9187,6 +9206,9 @@ if (!map.__pillHooksInstalled) {
       const visualsChanged = clusterVisualKey !== currentClusterVisualKey || sourceNeedsRebuild;
       ensureMarkerLabelBackground(map);
       const markerLabelFilter = ['all', ['!',['has','point_count']], ['has','title']];
+      const stackSortKey = (offset = 0) => offset === 0
+        ? ['coalesce', ['get','stackOrder'], 0]
+        : ['+', ['coalesce', ['get','stackOrder'], 0], offset];
       const markerLabelTextField = ['let', 'line1',
         ['coalesce', ['get','labelLine1'], ['get','title'], ''],
         ['let', 'line2', ['coalesce', ['get','labelLine2'], ''],
@@ -9295,7 +9317,7 @@ if (!map.__pillHooksInstalled) {
             'icon-anchor': 'center',
             'icon-pitch-alignment': 'viewport',
             'symbol-z-order': 'viewport-y',
-            'symbol-sort-key': 1100
+            'symbol-sort-key': stackSortKey()
           },
           paint:{},
         });
@@ -9307,7 +9329,7 @@ if (!map.__pillHooksInstalled) {
       try{ map.setLayoutProperty('unclustered','icon-anchor', 'center'); }catch(e){}
       try{ map.setLayoutProperty('unclustered','icon-pitch-alignment','viewport'); }catch(e){}
       try{ map.setLayoutProperty('unclustered','symbol-z-order','viewport-y'); }catch(e){}
-      try{ map.setLayoutProperty('unclustered','symbol-sort-key',1100); }catch(e){}
+      try{ map.setLayoutProperty('unclustered','symbol-sort-key', stackSortKey()); }catch(e){}
       if(!map.getLayer('marker-label-bg')){
         map.addLayer({
           id:'marker-label-bg',
@@ -9322,7 +9344,7 @@ if (!map.__pillHooksInstalled) {
             'icon-anchor': 'left',
             'icon-pitch-alignment': 'viewport',
             'symbol-z-order': 'viewport-y',
-            'symbol-sort-key': 1099
+            'symbol-sort-key': stackSortKey(-0.02)
           },
           paint:{
             'icon-translate': [markerLabelBgTranslatePx, 0],
@@ -9348,7 +9370,7 @@ if (!map.__pillHooksInstalled) {
             'text-pitch-alignment': 'viewport',
             'text-max-width': markerLabelTextMaxWidth,
             'symbol-z-order': 'viewport-y',
-            'symbol-sort-key': 1101
+            'symbol-sort-key': stackSortKey(0.02)
           },
           paint:{
             'text-color': '#fff',
@@ -9365,7 +9387,7 @@ if (!map.__pillHooksInstalled) {
       try{ map.setLayoutProperty('marker-label-bg','icon-anchor','left'); }catch(e){}
       try{ map.setLayoutProperty('marker-label-bg','icon-pitch-alignment','viewport'); }catch(e){}
       try{ map.setLayoutProperty('marker-label-bg','symbol-z-order','viewport-y'); }catch(e){}
-      try{ map.setLayoutProperty('marker-label-bg','symbol-sort-key',1099); }catch(e){}
+      try{ map.setLayoutProperty('marker-label-bg','symbol-sort-key', stackSortKey(-0.02)); }catch(e){}
       try{ map.setPaintProperty('marker-label-bg','icon-translate',[markerLabelBgTranslatePx,0]); }catch(e){}
       try{ map.setPaintProperty('marker-label-bg','icon-translate-anchor','viewport'); }catch(e){}
       try{ map.setPaintProperty('marker-label-bg','icon-opacity',1); }catch(e){}
@@ -9380,7 +9402,7 @@ if (!map.__pillHooksInstalled) {
       try{ map.setLayoutProperty('marker-label-text','text-pitch-alignment','viewport'); }catch(e){}
       try{ map.setLayoutProperty('marker-label-text','text-max-width', markerLabelTextMaxWidth); }catch(e){}
       try{ map.setLayoutProperty('marker-label-text','symbol-z-order','viewport-y'); }catch(e){}
-      try{ map.setLayoutProperty('marker-label-text','symbol-sort-key',1101); }catch(e){}
+      try{ map.setLayoutProperty('marker-label-text','symbol-sort-key', stackSortKey(0.02)); }catch(e){}
       try{ map.setPaintProperty('marker-label-text','text-color','#fff'); }catch(e){}
       try{ map.setPaintProperty('marker-label-text','text-translate',[markerLabelTextTranslatePx,0]); }catch(e){}
       try{ map.setPaintProperty('marker-label-text','text-translate-anchor','viewport'); }catch(e){}


### PR DESCRIPTION
## Summary
- add a deterministic `stackOrder` property to GeoJSON features so markers share a common sort key
- drive Mapbox symbol sort expressions from the shared `stackOrder`, keeping background, icon, and text offsets aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9fdad5aa88331b0c4871d89b53e2d