### PR TITLE
Force cluster clicks to zoom to level 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -9508,7 +9508,8 @@ if (!map.__pillHooksInstalled) {
               const coords = feature.geometry && feature.geometry.coordinates;
               if(!coords) { clearSuppress(); return; }
               const maxZoom = typeof map.getMaxZoom === 'function' ? map.getMaxZoom() : undefined;
-              const nextZoom = typeof maxZoom === 'number' ? Math.min(zoom, maxZoom) : zoom;
+              const desiredZoom = 10;
+              const nextZoom = typeof maxZoom === 'number' ? Math.min(desiredZoom, maxZoom) : desiredZoom;
               const animationOpts = { center: coords, zoom: nextZoom, essential: true };
               let computedDuration = 650;
               try{


### PR DESCRIPTION
## Summary
- update the cluster click handler to always target zoom level 10 when expanding clusters
- keep existing easing and duration calculations so they use the new zoom target

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0994c8548331ad8e9ad5d3436738