### PR TITLE
Align open post details with clicked cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -8212,10 +8212,10 @@ function makePosts(){
             pointerTarget = pointerEvt.target;
           }
         }
-        const pointerCard = pointerTarget ? pointerTarget.closest('.post-card') : null;
-        const pointerInsidePostBoard = pointerCard && container.contains(pointerCard);
+        const pointerCard = pointerTarget ? pointerTarget.closest('.post-card, .recents-card') : null;
+        const pointerInsideCardContainer = pointerCard && container.contains(pointerCard);
         const pointerInAdBoard = pointerTarget ? pointerTarget.closest('.ad-board, .ad-panel') : null;
-        const shouldAlignToTop = fromMap || (!!pointerInAdBoard && !pointerInsidePostBoard);
+        const shouldAlignToTop = fromMap || (!!pointerInAdBoard && !pointerInsideCardContainer) || pointerInsideCardContainer;
 
         if(!target){
           target = card(p, fromHistory ? false : true);


### PR DESCRIPTION
## Summary
- ensure pointer detection flags post and recents cards so open details align with their sources
- retain existing map and ad board alignment behavior while reordering target cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da14fa9c9c83319169bd7c5128dd17