### PR TITLE
Adjust openPost alignment behavior for card interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8317,9 +8317,9 @@ function makePosts(){
           }
         }
         const pointerCard = pointerTarget ? pointerTarget.closest('.post-card, .recents-card') : null;
-        const pointerInsideCardContainer = pointerCard && container.contains(pointerCard);
+        const pointerInsideActiveCard = !!(pointerCard && container.contains(pointerCard));
         const pointerInAdBoard = pointerTarget ? pointerTarget.closest('.ad-board, .ad-panel') : null;
-        const shouldAlignToTop = fromMap || (!!pointerInAdBoard && !pointerInsideCardContainer) || pointerInsideCardContainer;
+        const shouldAlignToTop = fromMap || (!!pointerInAdBoard && !pointerInsideActiveCard);
 
         if(!target){
           target = card(p, fromHistory ? false : true);


### PR DESCRIPTION
## Summary
- update the openPost alignment logic so card-origin pointer events inside the active container no longer trigger list reordering
- continue aligning to top for map interactions and ad-board jumps while leaving card replacements in place

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da194742ac8331a9c64a0a0662b830