### PR TITLE
Adjust post alignment when opening cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -8324,8 +8324,8 @@ function makePosts(){
         if(!target){
           target = card(p, fromHistory ? false : true);
           placeOpenPost(target);
-        } else if(shouldAlignToTop && container.contains(target)){
-          const firstCard = container.querySelector('.open-post, .post-card');
+        } else if(shouldAlignToTop && container.contains(target) && !pointerInsideCardContainer){
+          const firstCard = container.querySelector('.open-post, .post-card, .recents-card');
           if(firstCard && firstCard !== target){
             container.insertBefore(target, firstCard);
           } else if(!firstCard){


### PR DESCRIPTION
## Summary
- avoid moving a clicked post or recents card before opening so the detail view aligns with the card position
- include recents cards when relocating posts triggered from external interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da1ac13c888331a9edcfbd603c2832