### PR TITLE
Fix date range input initialization order

### DIFF
--- a/index.html
+++ b/index.html
@@ -7471,8 +7471,9 @@ function makePosts(){
       return parseISODate(iso).toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'}).replace(/,/g,'');
     }
 
+    const dateRangeInput = $('#daterange-textbox');
     $('#keyword-textbox').addEventListener('input', ()=>{ applyFilters(); updateClearButtons(); });
-    $('#daterange-textbox').addEventListener('input', ()=>{ applyFilters(); updateClearButtons(); });
+    dateRangeInput?.addEventListener('input', ()=>{ applyFilters(); updateClearButtons(); });
     if(dateRangeInput){
       dateRangeInput.addEventListener('focus', ()=> openCalendarPopup());
       dateRangeInput.addEventListener('click', ()=> openCalendarPopup());
@@ -7512,7 +7513,6 @@ function makePosts(){
     maxPickerDate.setFullYear(maxPickerDate.getFullYear() + 2);
     const expiredToggle = $('#expiredToggle');
     const calendarScroll = $('#datePickerContainer');
-    const dateRangeInput = $('#daterange-textbox');
     const filterBasics = $('#filterPanel .filter-basics-container');
     const filterPanelBody = $('#filterPanel .panel-body');
     let calendarPopupOpen = false;


### PR DESCRIPTION
## Summary
- query the date range input before attaching listeners to prevent a ReferenceError
- use optional chaining when adding the date range input listener for resilience when absent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da5c2d38808331895fc55006295a17