### PR TITLE
Fix calendar container width to match date range input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1241,7 +1241,7 @@ button[aria-expanded="true"] .results-arrow{
   overflow-y:hidden;
   padding-bottom:var(--scrollbar-h);
   box-sizing:content-box;
-  width:auto;
+  width:340px;
   height:var(--calendar-height);
   max-width:100%;
   border:1px solid var(--border);


### PR DESCRIPTION
## Summary
- set the filter panel calendar container to a fixed 340px width so it aligns under the date range field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6e31951c8331a69e35b513d7c9e2