### PR TITLE
Fix focus handling for date picker popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -7542,6 +7542,7 @@ function makePosts(){
       if(!calendarPopupOpen){
         calendarPopupOpen = true;
         calendarScroll.classList.add('is-visible');
+        calendarScroll.setAttribute('tabindex','0');
         calendarScroll.setAttribute('aria-hidden','false');
         if(dateRangeInput) dateRangeInput.setAttribute('aria-expanded','true');
         document.addEventListener('click', handleCalendarOutsideClick, true);
@@ -7557,6 +7558,13 @@ function makePosts(){
     function closeCalendarPopup(){
       if(!calendarScroll || !calendarPopupOpen) return;
       calendarPopupOpen = false;
+      if(calendarScroll.contains(document.activeElement)){
+        const activeEl = document.activeElement;
+        if(activeEl && typeof activeEl.blur === 'function'){
+          activeEl.blur();
+        }
+      }
+      calendarScroll.setAttribute('tabindex','-1');
       calendarScroll.classList.remove('is-visible');
       calendarScroll.setAttribute('aria-hidden','true');
       if(dateRangeInput) dateRangeInput.setAttribute('aria-expanded','false');


### PR DESCRIPTION
## Summary
- ensure the date picker popup restores its tabindex when opened
- blur any focused calendar element before hiding so aria-hidden is only applied to unfocused content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da70dae5bc8331b6aba555f8426532