### PR TITLE
Handle missing icon-stroke placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -8902,6 +8902,17 @@ if (!map.__pillHooksInstalled) {
   try { map.on('styleimagemissing', (evt) => { if (evt && evt.id === 'marker-label-bg') __addOrReplacePill150x40(map); }); } catch(e){}
   map.__pillHooksInstalled = true;
 }
+        const ensureMissingStyleImage = (evt) => {
+          if(!evt || !evt.id) return;
+          const placeholders = ['mx-federal-5','background','background-stroke','icon','icon-stroke'];
+          if(!placeholders.includes(evt.id)) return;
+          try{
+            if(map.hasImage?.(evt.id)) return;
+            map.addImage(evt.id, createTransparentPlaceholder(4), { pixelRatio: 1 });
+          }catch(err){}
+        };
+        try{ map.on('styleimagemissing', ensureMissingStyleImage); }catch(err){}
+
         const applyStyleAdjustments = () => {
           applyNightSky(map);
           patchMapboxStyleArtifacts(map);


### PR DESCRIPTION
## Summary
- add a styleimagemissing hook to register transparent placeholder sprites for missing map icons
- ensure repeated requests for the same placeholder are ignored once the sprite is registered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8657c63883319f50f311a994a62c