### PR TITLE
Fix marker label composite image handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5847,9 +5847,18 @@ if (typeof slugify !== 'function') {
       }catch(err){
         console.error(err);
       }
+      let imageData = null;
       try{
-        mapInstance.addImage(compositeId, canvas, options);
-        markerLabelCompositeStore.set(compositeId, { image: canvas, options, iconId });
+        imageData = ctx.getImageData(0, 0, baseWidth, baseHeight);
+      }catch(err){
+        console.error(err);
+      }
+      if(!imageData){
+        return null;
+      }
+      try{
+        mapInstance.addImage(compositeId, imageData, options);
+        markerLabelCompositeStore.set(compositeId, { image: imageData, options, iconId });
         return compositeId;
       }catch(err){
         console.error(err);


### PR DESCRIPTION
## Summary
- extract pixel data from the marker label canvas and pass it to `mapInstance.addImage`
- cache the generated `ImageData` so reapplying marker label composites reuses compatible objects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa587151c8331958cf32f32edb97e