### PR TITLE
Compose marker label sprites

### DIFF
--- a/index.html
+++ b/index.html
@@ -5592,8 +5592,6 @@ if (typeof slugify !== 'function') {
   const markerLabelTextSize = 12;
   const markerLabelTextLineHeight = 1.2;
   const markerLabelBgTranslatePx = -(markerIconBaseSizePx * markerIconSize / 2 + markerLabelMarkerInsetPx);
-  const markerLabelTextTranslatePx = markerLabelBgTranslatePx + markerLabelTextPaddingPx;
-  const markerLabelTextMaxWidth = Math.max(3, markerLabelTextAreaWidthPx / markerLabelTextSize);
   const markerLabelEllipsisChar = '\u2026';
   const mapCardTitleWidthPx = 165;
   let markerLabelMeasureContext = null;
@@ -5795,25 +5793,34 @@ if (typeof slugify !== 'function') {
     return markerLabelPillImagePromise;
   }
 
-  async function ensureMarkerLabelComposite(mapInstance, iconId){
-    if(!mapInstance || !iconId){
+  function markerLabelCompositeId(spriteId){
+    return `${MARKER_LABEL_COMPOSITE_PREFIX}${spriteId}`;
+  }
+
+  async function ensureMarkerLabelComposite(mapInstance, labelSpriteId, iconId, labelLine1, labelLine2, isMulti){
+    if(!mapInstance || !labelSpriteId){
       return null;
     }
-    const compositeId = `${MARKER_LABEL_COMPOSITE_PREFIX}${iconId}`;
+    const compositeId = markerLabelCompositeId(labelSpriteId);
+    const meta = markerLabelCompositeStore.get(labelSpriteId) || {};
+    meta.iconId = iconId || meta.iconId || '';
+    meta.labelLine1 = labelLine1 ?? meta.labelLine1 ?? '';
+    meta.labelLine2 = labelLine2 ?? meta.labelLine2 ?? '';
+    meta.isMulti = Boolean(isMulti ?? meta.isMulti);
+    markerLabelCompositeStore.set(labelSpriteId, meta);
     if(mapInstance.hasImage?.(compositeId)){
       return compositeId;
     }
-    const cached = markerLabelCompositeStore.get(compositeId);
-    if(cached && cached.image){
+    if(meta.image){
       try{
-        mapInstance.addImage(compositeId, cached.image, cached.options || {});
+        mapInstance.addImage(compositeId, meta.image, meta.options || {});
         return compositeId;
       }catch(err){
         console.error(err);
       }
     }
-    if(markerLabelCompositePending.has(compositeId)){
-      return markerLabelCompositePending.get(compositeId);
+    if(markerLabelCompositePending.has(labelSpriteId)){
+      return markerLabelCompositePending.get(labelSpriteId);
     }
     const task = (async () => {
       const pillImg = await ensureMarkerLabelPillImage();
@@ -5821,7 +5828,7 @@ if (typeof slugify !== 'function') {
         return null;
       }
       const markerSources = window.subcategoryMarkers || {};
-      const iconUrl = markerSources[iconId];
+      const iconUrl = meta.iconId ? markerSources[meta.iconId] : null;
       let iconImg = null;
       if(iconUrl){
         try{
@@ -5830,26 +5837,66 @@ if (typeof slugify !== 'function') {
           console.error(err);
         }
       }
-      const baseWidth = pillImg.naturalWidth || pillImg.width || markerLabelBackgroundWidthPx;
-      const baseHeight = pillImg.naturalHeight || pillImg.height || markerLabelBackgroundHeightPx;
+      const rawWidth = pillImg.naturalWidth || pillImg.width || markerLabelBackgroundWidthPx;
+      const rawHeight = pillImg.naturalHeight || pillImg.height || markerLabelBackgroundHeightPx;
       const canvas = document.createElement('canvas');
-      canvas.width = baseWidth;
-      canvas.height = baseHeight;
+      canvas.width = Math.max(1, Math.round(Number.isFinite(rawWidth) && rawWidth > 0 ? rawWidth : markerLabelBackgroundWidthPx));
+      canvas.height = Math.max(1, Math.round(Number.isFinite(rawHeight) && rawHeight > 0 ? rawHeight : markerLabelBackgroundHeightPx));
       const ctx = canvas.getContext('2d');
-      ctx.clearRect(0, 0, baseWidth, baseHeight);
-      ctx.drawImage(pillImg, 0, 0, baseWidth, baseHeight);
+      if(!ctx){
+        return null;
+      }
+      const canvasWidth = canvas.width;
+      const canvasHeight = canvas.height;
+      ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+      ctx.drawImage(pillImg, 0, 0, canvasWidth, canvasHeight);
+      const pixelRatio = canvasWidth / markerLabelBackgroundWidthPx;
       if(iconImg){
-        const pixelRatio = baseWidth / markerLabelBackgroundWidthPx;
         const iconSizePx = markerIconBaseSizePx * markerIconSize * pixelRatio;
         const destX = markerLabelMarkerInsetPx * pixelRatio;
-        const destY = (baseHeight - iconSizePx) / 2;
+        const destY = (canvasHeight - iconSizePx) / 2;
         try{
           ctx.drawImage(iconImg, destX, destY, iconSizePx, iconSizePx);
         }catch(err){
           console.error(err);
         }
       }
-      const pixelRatio = baseWidth / markerLabelBackgroundWidthPx;
+      const labelLines = [];
+      const line1 = (meta.labelLine1 || '').trim();
+      const line2 = (meta.labelLine2 || '').trim();
+      if(line1){
+        labelLines.push({ text: line1, color: '#ffffff' });
+      }
+      if(line2){
+        labelLines.push({ text: line2, color: meta.isMulti ? '#d0d0d0' : '#ffffff' });
+      }
+      if(labelLines.length){
+        const fontSizePx = markerLabelTextSize * pixelRatio;
+        const lineGapPx = Math.max(0, (markerLabelTextLineHeight - 1) * markerLabelTextSize * pixelRatio);
+        const totalHeight = labelLines.length * fontSizePx + Math.max(0, labelLines.length - 1) * lineGapPx;
+        let textY = (canvasHeight - totalHeight) / 2;
+        if(!Number.isFinite(textY) || textY < 0){
+          textY = 0;
+        }
+        const textX = markerLabelTextPaddingPx * pixelRatio;
+        ctx.font = `${fontSizePx}px "Open Sans", "Arial Unicode MS Regular", sans-serif`;
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'left';
+        ctx.shadowColor = 'rgba(0,0,0,0.4)';
+        ctx.shadowBlur = 2 * pixelRatio;
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 1 * pixelRatio;
+        labelLines.forEach(line => {
+          ctx.fillStyle = line.color;
+          try{
+            ctx.fillText(line.text, textX, textY);
+          }catch(err){
+            console.error(err);
+          }
+          textY += fontSizePx + lineGapPx;
+        });
+        ctx.shadowColor = 'transparent';
+      }
       const options = { pixelRatio: Number.isFinite(pixelRatio) && pixelRatio > 0 ? pixelRatio : 1 };
       try{
         if(mapInstance.hasImage?.(compositeId)){
@@ -5860,7 +5907,7 @@ if (typeof slugify !== 'function') {
       }
       let imageData = null;
       try{
-        imageData = ctx.getImageData(0, 0, baseWidth, baseHeight);
+        imageData = ctx.getImageData(0, 0, canvasWidth, canvasHeight);
       }catch(err){
         console.error(err);
       }
@@ -5869,16 +5916,16 @@ if (typeof slugify !== 'function') {
       }
       try{
         mapInstance.addImage(compositeId, imageData, options);
-        markerLabelCompositeStore.set(compositeId, { image: imageData, options, iconId });
+        markerLabelCompositeStore.set(labelSpriteId, Object.assign(meta, { image: imageData, options }));
         return compositeId;
       }catch(err){
         console.error(err);
         return null;
       }
     })().finally(() => {
-      markerLabelCompositePending.delete(compositeId);
+      markerLabelCompositePending.delete(labelSpriteId);
     });
-    markerLabelCompositePending.set(compositeId, task);
+    markerLabelCompositePending.set(labelSpriteId, task);
     return task;
   }
 
@@ -5886,15 +5933,16 @@ if (typeof slugify !== 'function') {
     if(!mapInstance){
       return;
     }
-    markerLabelCompositeStore.forEach((entry, id) => {
+    markerLabelCompositeStore.forEach((entry, spriteId) => {
       if(!entry || !entry.image){
         return;
       }
+      const compositeId = markerLabelCompositeId(spriteId);
       try{
-        if(mapInstance.hasImage?.(id)){
+        if(mapInstance.hasImage?.(compositeId)){
           return;
         }
-        mapInstance.addImage(id, entry.image, entry.options || {});
+        mapInstance.addImage(compositeId, entry.image, entry.options || {});
       }catch(err){
         console.error(err);
       }
@@ -6680,7 +6728,9 @@ function buildClusterListHTML(items){
           return;
         }
         if(e.id.startsWith(MARKER_LABEL_COMPOSITE_PREFIX)){
-          ensureMarkerLabelComposite(mapInstance, e.id.slice(MARKER_LABEL_COMPOSITE_PREFIX.length));
+          const spriteId = e.id.slice(MARKER_LABEL_COMPOSITE_PREFIX.length);
+          const meta = markerLabelCompositeStore.get(spriteId) || {};
+          ensureMarkerLabelComposite(mapInstance, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti);
           return;
         }
         addIcon(e.id);
@@ -9834,6 +9884,8 @@ if (!map.__pillHooksInstalled) {
             line1: labelTitle,
             line2: venueLine
           });
+          const spriteSource = [MULTI_VENUE_MARKER_ID, labelTitle || '', venueLine || ''].join('|');
+          const labelSpriteId = hashString(spriteSource);
           features.push({
             type:'Feature',
             properties:{
@@ -9842,6 +9894,7 @@ if (!map.__pillHooksInstalled) {
               label: combinedLabel,
               labelLine1: labelTitle,
               labelLine2: venueLine,
+              labelSpriteId,
               venueName: canonicalVenue,
               city: sample.city,
               cat: sample.category,
@@ -9859,6 +9912,8 @@ if (!map.__pillHooksInstalled) {
         const p = group[0];
         const labelLines = getMarkerLabelLines(p);
         const combinedLabel = buildMarkerLabelText(p, labelLines);
+        const spriteSource = [baseSub || '', labelLines.line1 || '', labelLines.line2 || ''].join('|');
+        const labelSpriteId = hashString(spriteSource);
         features.push({
           type:'Feature',
           properties:{
@@ -9867,6 +9922,7 @@ if (!map.__pillHooksInstalled) {
             label: combinedLabel,
             labelLine1: labelLines.line1,
             labelLine2: labelLines.line2,
+            labelSpriteId,
             venueName: primaryVenue,
             city:p.city,
             cat:p.category,
@@ -9909,7 +9965,22 @@ if (!map.__pillHooksInstalled) {
         await Promise.all(iconIds.map(id => ensureMapIcon(id).catch(()=>{})));
       }
       if(typeof ensureMarkerLabelComposite === 'function'){
-        await Promise.all(iconIds.map(id => ensureMarkerLabelComposite(map, id).catch(()=>{})));
+        const spriteMeta = new Map();
+        geojson.features.forEach(feature => {
+          if(!feature || !feature.properties) return;
+          const props = feature.properties;
+          const spriteId = props.labelSpriteId;
+          if(!spriteId || spriteMeta.has(spriteId)) return;
+          spriteMeta.set(spriteId, {
+            sub: props.sub || props.baseSub || '',
+            line1: props.labelLine1 || '',
+            line2: props.labelLine2 || '',
+            isMulti: props.multi === 1
+          });
+        });
+        await Promise.all(Array.from(spriteMeta.entries()).map(([spriteId, meta]) =>
+          ensureMarkerLabelComposite(map, spriteId, meta.sub, meta.line1, meta.line2, meta.isMulti).catch(()=>{})
+        ));
       }
       if(!map.getLayer('posts-heat')){
         map.addLayer({ id:'posts-heat', type:'heatmap', source:'posts', maxzoom:4, paint:{
@@ -9923,26 +9994,6 @@ if (!map.__pillHooksInstalled) {
       const visualsChanged = clusterVisualKey !== currentClusterVisualKey || sourceNeedsRebuild;
       ensureMarkerLabelBackground(map);
       const markerLabelFilter = ['all', ['!',['has','point_count']], ['has','title']];
-      const markerLabelTextField = ['let', 'line1',
-        ['coalesce', ['get','labelLine1'], ['get','title'], ''],
-        ['let', 'line2', ['coalesce', ['get','labelLine2'], ''],
-          ['let', 'isMulti', ['==', ['get','multi'], 1],
-            ['case',
-              ['all', ['var','isMulti'], ['!=', ['var','line2'], '']],
-              ['format',
-                ['var','line1'], { 'font-scale': 1, 'text-color': '#ffffff' },
-                '\n', {},
-                ['var','line2'], { 'font-scale': 1, 'text-color': '#d0d0d0' }
-              ],
-              ['case',
-                ['!=', ['var','line2'], ''],
-                ['concat', ['var','line1'], '\n', ['var','line2']],
-                ['var','line1']
-              ]
-            ]
-          ]
-        ]
-      ];
 
       if(shouldCluster){
         if(usingSvgClusters){
@@ -10025,11 +10076,11 @@ if (!map.__pillHooksInstalled) {
         lastClusterSvgHash = '';
       }
 
-      const markerLabelIconImage = ['let', 'subId', ['coalesce', ['get','sub'], ''],
+      const markerLabelIconImage = ['let', 'spriteId', ['coalesce', ['get','labelSpriteId'], ''],
         ['case',
-          ['==', ['var','subId'], ''],
+          ['==', ['var','spriteId'], ''],
           MARKER_LABEL_BG_ID,
-          ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','subId']]
+          ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','spriteId']]
         ]
       ];
 
@@ -10046,26 +10097,13 @@ if (!map.__pillHooksInstalled) {
             'icon-ignore-placement': true,
             'icon-anchor': 'left',
             'icon-pitch-alignment': 'viewport',
-            'text-field': markerLabelTextField,
-            'text-font': ['Open Sans Regular','Arial Unicode MS Regular'],
-            'text-size': markerLabelTextSize,
-            'text-line-height': markerLabelTextLineHeight,
-            'text-anchor': 'left',
-            'text-allow-overlap': true,
-            'text-ignore-placement': true,
-            'text-pitch-alignment': 'viewport',
-            'text-max-width': markerLabelTextMaxWidth,
-            'text-optional': true,
             'symbol-z-order': 'viewport-y',
             'symbol-sort-key': 1100
           },
           paint:{
             'icon-translate': [markerLabelBgTranslatePx, 0],
             'icon-translate-anchor': 'viewport',
-            'icon-opacity': 1,
-            'text-color': '#fff',
-            'text-translate': [markerLabelTextTranslatePx, 0],
-            'text-translate-anchor': 'viewport'
+            'icon-opacity': 1
           }
         });
       }
@@ -10076,24 +10114,11 @@ if (!map.__pillHooksInstalled) {
       try{ map.setLayoutProperty('marker-label','icon-ignore-placement', true); }catch(e){}
       try{ map.setLayoutProperty('marker-label','icon-anchor','left'); }catch(e){}
       try{ map.setLayoutProperty('marker-label','icon-pitch-alignment','viewport'); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-field', markerLabelTextField); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-font',['Open Sans Regular','Arial Unicode MS Regular']); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-size', markerLabelTextSize); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-line-height', markerLabelTextLineHeight); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-anchor','left'); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-allow-overlap', true); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-ignore-placement', true); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-pitch-alignment','viewport'); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-max-width', markerLabelTextMaxWidth); }catch(e){}
-      try{ map.setLayoutProperty('marker-label','text-optional', true); }catch(e){}
       try{ map.setLayoutProperty('marker-label','symbol-z-order','viewport-y'); }catch(e){}
       try{ map.setLayoutProperty('marker-label','symbol-sort-key', 1100); }catch(e){}
       try{ map.setPaintProperty('marker-label','icon-translate',[markerLabelBgTranslatePx,0]); }catch(e){}
       try{ map.setPaintProperty('marker-label','icon-translate-anchor','viewport'); }catch(e){}
       try{ map.setPaintProperty('marker-label','icon-opacity',1); }catch(e){}
-      try{ map.setPaintProperty('marker-label','text-color','#fff'); }catch(e){}
-      try{ map.setPaintProperty('marker-label','text-translate',[markerLabelTextTranslatePx,0]); }catch(e){}
-      try{ map.setPaintProperty('marker-label','text-translate-anchor','viewport'); }catch(e){}
       ['hover-fill','clusters','cluster-count','marker-label'].forEach(id=>{
         if(map.getLayer(id)){
           try{ map.moveLayer(id); }catch(e){}
@@ -10103,8 +10128,7 @@ if (!map.__pillHooksInstalled) {
         ['clusters','circle-opacity-transition'],
         ['clusters','icon-opacity-transition'],
         ['cluster-count','text-opacity-transition'],
-        ['marker-label','icon-opacity-transition'],
-        ['marker-label','text-opacity-transition']
+        ['marker-label','icon-opacity-transition']
       ].forEach(([layer, prop])=>{
         if(map.getLayer(layer)){
           try{ map.setPaintProperty(layer, prop, {duration:0}); }catch(e){}


### PR DESCRIPTION
## Summary
- generate per-feature `labelSpriteId` values so marker sprites can be reused across features
- render pill, icon, and label lines into cached composite sprites keyed by the new id
- update the marker label layer to rely solely on the composite sprite for icon and text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab405ad8883319a2113989cad7961