### PR TITLE
Simplify board transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8776,12 +8776,6 @@ function makePosts(){
         boardsContainer.style.justifyContent = 'flex-start';
         const skipAnimation = !boardsInitialized;
         toggleBoard(recentsBoard, isPostsMode && historyActive, skipAnimation);
-        if(postBoard){
-          const desiredSide = historyActive ? 'right' : 'left';
-          if(postBoard.dataset.side !== desiredSide){
-            postBoard.dataset.side = desiredSide;
-          }
-        }
         toggleBoard(postBoard, isPostsMode && !historyActive, skipAnimation);
         document.body.classList.toggle('detail-open', !!anyOpenPost);
         if(adBoard){
@@ -9204,7 +9198,7 @@ function makePosts(){
                 requestAnimationFrame(() => {
                   try{
                     stopSpin();
-                    fn(id);
+                    fn(id, false, false, cardEl);
                   }catch(err){ console.error(err); }
                 });
               });


### PR DESCRIPTION
## Summary
- let post and ad boards rely on the standard slide transitions when toggled
- reuse the recent-card opening path for post cards by passing the clicked element into `openPost`

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dace599be0833186175d76b6a3159b