### PR TITLE
Allow ad board transition in map mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2689,10 +2689,6 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   min-height:var(--panel-area-height, calc((var(--vh, 1vh) * 100) - var(--header-h) - var(--safe-top) - var(--footer-h)));
 }
 
-body.mode-map .ad-board{
-  display:none !important;
-}
-
 body.hide-ads .ad-board{
   pointer-events:none;
 }


### PR DESCRIPTION
## Summary
- remove the map mode display override so the ad board uses the shared slide animation logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dadcb4f1048331878109b332510f1a