### PR TITLE
Remove redundant post board positioning overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -3363,14 +3363,7 @@ body.filters-active #filterBtn{
 }
 
 .mode-posts .post-board{
-  left:0;
   z-index:1;
-  pointer-events:auto;
-}
-
-.mode-map .post-board{
-  left:calc(-100vw - var(--filter-panel-offset));
-  pointer-events:none;
 }
 .map-area{
   position: fixed;


### PR DESCRIPTION
## Summary
- remove the mode-specific left and pointer-events overrides from the post board so it relies on the shared panel-visible transforms
- keep the z-index adjustment for posts mode while allowing the standard slide transition to manage positioning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dadda0ec74833182dd74ea6aabdaa7