### PR TITLE
Fix openPost to ignore detached origin elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -8968,6 +8968,9 @@ function makePosts(){
           return;
         }
 
+        if(originEl && !container.contains(originEl)){
+          originEl = null;
+        }
         let target = originEl || container.querySelector(`[data-id="${id}"]`);
 
         (function(){
@@ -9006,6 +9009,9 @@ function makePosts(){
           }
         })();
 
+        if(originEl && !container.contains(originEl)){
+          originEl = null;
+        }
         target = originEl || container.querySelector(`[data-id="${id}"]`);
 
         const pointerEvt = window.__lastPointerDown;


### PR DESCRIPTION
## Summary
- ensure `openPost` verifies that the provided `originEl` is still attached to the container
- fall back to querying the DOM when the origin element has been removed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae430a2f08331b01ea76aea58afbf