### PR TITLE
Remove redundant post board positioning overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -3362,7 +3362,8 @@ body.filters-active #filterBtn{
   margin:0;
 }
 
-.mode-posts .post-board{
+body.mode-posts .post-board,
+body.mode-map .post-board{
   z-index:1;
 }
 .map-area{


### PR DESCRIPTION
## Summary
- ensure the post board shares the same z-index styling in both posts and map modes so panel transforms govern its position

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daea966b2c8331b92f6b4c87dc1223