### PR TITLE
Allow ad board to slide closed in map mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2683,7 +2683,6 @@ body.hide-ads .post-mode-boards{padding-right:0;}
   transition:transform var(--panel-transition-duration, 0.3s) ease,
              opacity var(--panel-transition-duration, 0.3s) ease;
   will-change:transform, opacity;
-  display:none;
   height:var(--panel-area-height, calc((var(--vh, 1vh) * 100) - var(--header-h) - var(--safe-top) - var(--footer-h)));
   max-height:var(--panel-area-height, calc((var(--vh, 1vh) * 100) - var(--header-h) - var(--safe-top) - var(--footer-h)));
   min-height:var(--panel-area-height, calc((var(--vh, 1vh) * 100) - var(--header-h) - var(--safe-top) - var(--footer-h)));


### PR DESCRIPTION
## Summary
- remove the CSS display override so the ad board can animate when map mode is toggled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daef233cb88331afd8b23481bdfe73