### PR TITLE
Remove extra gap above compressed post descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4323,6 +4323,9 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   .post-details-description-container .desc-wrap{
     margin:10px 0 0;
   }
+  .open-post:not(.desc-expanded) .post-details-description-container .desc-wrap{
+    margin-top:0;
+  }
   .post-details-description-container .desc{
     margin:0;
   }


### PR DESCRIPTION
## Summary
- prevent extra spacing between a compressed post header and its description

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb8eb9c3c8331ad37f4caf0d0ab16