### PR TITLE
Scope button styles away from Mapbox controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -683,8 +683,8 @@ textarea,
   user-select: text;
 }
 
-button:not([class*="mapboxgl-ctrl"]),
-[role="button"]{
+button:not([class*="mapboxgl-"]),
+[role="button"]:not([class*="mapboxgl-"]){
   background: var(--btn);
   border: 1px solid var(--btn);
   color: var(--button-text);
@@ -701,60 +701,60 @@ button:not([class*="mapboxgl-ctrl"]),
   transition: background .2s,border-color .2s,color .2s,transform .05s;
 }
 
-button:hover,
-[role="button"]:hover{
+button:not([class*="mapboxgl-"]):hover,
+[role="button"]:not([class*="mapboxgl-"]):hover{
   background: var(--btn-hover);
   border-color: var(--btn-hover);
   color: var(--button-hover-text);
 }
 
-button:active,
-[role="button"]:active{
+button:not([class*="mapboxgl-"]):active,
+[role="button"]:not([class*="mapboxgl-"]):active{
   background: var(--btn-active);
   border-color: var(--btn-active);
   color: var(--button-active-text);
 }
 
-button[aria-pressed="true"],
-[role="button"][aria-pressed="true"],
-button[aria-current="page"],
-[role="button"][aria-current="page"],
-button[aria-selected="true"],
-[role="button"][aria-selected="true"],
-button.selected,
-[role="button"].selected,
-button.on,
-[role="button"].on{
+button:not([class*="mapboxgl-"])[aria-pressed="true"],
+[role="button"]:not([class*="mapboxgl-"])[aria-pressed="true"],
+button:not([class*="mapboxgl-"])[aria-current="page"],
+[role="button"]:not([class*="mapboxgl-"])[aria-current="page"],
+button:not([class*="mapboxgl-"])[aria-selected="true"],
+[role="button"]:not([class*="mapboxgl-"])[aria-selected="true"],
+button:not([class*="mapboxgl-"]).selected,
+[role="button"]:not([class*="mapboxgl-"]).selected,
+button:not([class*="mapboxgl-"]).on,
+[role="button"]:not([class*="mapboxgl-"]).on{
   background: var(--button-selected-bg, var(--btn-selected));
   border-color: var(--button-selected-border, var(--button-selected-bg, var(--btn-selected))) !important;
   color: var(--button-selected-text, var(--button-active-text)) !important;
 }
 
-button[aria-pressed="true"]:hover,
-[role="button"][aria-pressed="true"]:hover,
-button[aria-current="page"]:hover,
-[role="button"][aria-current="page"]:hover,
-button[aria-selected="true"]:hover,
-[role="button"][aria-selected="true"]:hover,
-button.selected:hover,
-[role="button"].selected:hover,
-button.on:hover,
-[role="button"].on:hover{
+button:not([class*="mapboxgl-"])[aria-pressed="true"]:hover,
+[role="button"]:not([class*="mapboxgl-"])[aria-pressed="true"]:hover,
+button:not([class*="mapboxgl-"])[aria-current="page"]:hover,
+[role="button"]:not([class*="mapboxgl-"])[aria-current="page"]:hover,
+button:not([class*="mapboxgl-"])[aria-selected="true"]:hover,
+[role="button"]:not([class*="mapboxgl-"])[aria-selected="true"]:hover,
+button:not([class*="mapboxgl-"]).selected:hover,
+[role="button"]:not([class*="mapboxgl-"]).selected:hover,
+button:not([class*="mapboxgl-"]).on:hover,
+[role="button"]:not([class*="mapboxgl-"]).on:hover{
   background: var(--button-selected-hover, var(--btn-selected-hover));
   border-color: var(--button-selected-hover-border, var(--button-selected-hover, var(--btn-selected-hover))) !important;
   color: var(--button-selected-hover-text, var(--button-selected-text, var(--button-active-text))) !important;
 }
 
-button[aria-pressed="true"]:active,
-[role="button"][aria-pressed="true"]:active,
-button[aria-current="page"]:active,
-[role="button"][aria-current="page"]:active,
-button[aria-selected="true"]:active,
-[role="button"][aria-selected="true"]:active,
-button.selected:active,
-[role="button"].selected:active,
-button.on:active,
-[role="button"].on:active{
+button:not([class*="mapboxgl-"])[aria-pressed="true"]:active,
+[role="button"]:not([class*="mapboxgl-"])[aria-pressed="true"]:active,
+button:not([class*="mapboxgl-"])[aria-current="page"]:active,
+[role="button"]:not([class*="mapboxgl-"])[aria-current="page"]:active,
+button:not([class*="mapboxgl-"])[aria-selected="true"]:active,
+[role="button"]:not([class*="mapboxgl-"])[aria-selected="true"]:active,
+button:not([class*="mapboxgl-"]).selected:active,
+[role="button"]:not([class*="mapboxgl-"]).selected:active,
+button:not([class*="mapboxgl-"]).on:active,
+[role="button"]:not([class*="mapboxgl-"]).on:active{
   background: var(--button-selected-active, var(--btn-selected-active));
   border-color: var(--button-selected-active-border, var(--button-selected-active, var(--btn-selected-active))) !important;
   color: var(--button-selected-active-text, var(--button-selected-text, var(--button-active-text))) !important;
@@ -771,20 +771,20 @@ a:hover{
 a:active{
   color: var(--active);
 }
-button:active,
-[role="button"]:active{
+button:not([class*="mapboxgl-"]):active,
+[role="button"]:not([class*="mapboxgl-"]):active{
   transform: scale(0.97);
 }
-button:focus-visible,
-[role="button"]:focus-visible{
+button:not([class*="mapboxgl-"]):focus-visible,
+[role="button"]:not([class*="mapboxgl-"]):focus-visible{
   outline:2px solid #ffffff;
   outline-offset:2px;
 }
 
-button:disabled,
-[role="button"][aria-disabled="true"],
-button.disabled,
-[role="button"].disabled{
+button:not([class*="mapboxgl-"]):disabled,
+[role="button"]:not([class*="mapboxgl-"])[aria-disabled="true"],
+button:not([class*="mapboxgl-"]).disabled,
+[role="button"]:not([class*="mapboxgl-"]).disabled{
   background: var(--btn-disabled);
   border-color: var(--btn-disabled);
   color: var(--button-disabled-text);
@@ -792,10 +792,10 @@ button.disabled,
   opacity: 0.6;
 }
 
-button:disabled:hover,
-[role="button"][aria-disabled="true"]:hover,
-button.disabled:hover,
-[role="button"].disabled:hover{
+button:not([class*="mapboxgl-"]):disabled:hover,
+[role="button"]:not([class*="mapboxgl-"])[aria-disabled="true"]:hover,
+button:not([class*="mapboxgl-"]).disabled:hover,
+[role="button"]:not([class*="mapboxgl-"]).disabled:hover{
   background: var(--btn-disabled);
   border-color: var(--btn-disabled);
   color: var(--button-disabled-text);


### PR DESCRIPTION
## Summary
- scope all button and role="button" rules to ignore Mapbox-provided controls
- extend the exclusion to all attribute-based button state selectors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd1e3c75c83318c9e50c303111b1d