### PR TITLE
Fix session calendar alignment in session menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -4010,7 +4010,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   flex:1 1 auto;
   max-width:100%;
   margin-bottom:0;
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable;
 }
 .open-post .post-calendar .calendar,
 .second-post-column .post-calendar .calendar,


### PR DESCRIPTION
## Summary
- adjust the calendar scroll container to reserve scrollbar space only on the trailing edge so the months align properly

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbfa91dfa88331a2972d89a6bc1e85