### PR TITLE
Replace seed heatmap with balloon icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -6380,12 +6380,7 @@ if (typeof slugify !== 'function') {
 
         function setupSeedLayers(mapInstance){
           if(!mapInstance) return;
-          ensureHeatmapIconImage(mapInstance).then((iconMeta = {})=>{
-            const gradient = Array.isArray(iconMeta.heatmapColors) && iconMeta.heatmapColors.length >= 4
-              ? iconMeta.heatmapColors.slice(0, 4)
-              : DEFAULT_HEATMAP_COLORS.slice();
-            const [colorA, colorB, colorC, colorD] = gradient;
-
+          ensureHeatmapIconImage(mapInstance).then(()=>{
             try{
               if(mapInstance.getLayer(HEATMAP_LAYER_ID)) mapInstance.removeLayer(HEATMAP_LAYER_ID);
             }catch(err){ console.error(err); }
@@ -6408,16 +6403,21 @@ if (typeof slugify !== 'function') {
             try{
               mapInstance.addLayer({
                 id: HEATMAP_LAYER_ID,
-                type: 'heatmap',
+                type: 'symbol',
                 source: HEATMAP_SOURCE_ID,
                 minzoom: HEATMAP_MIN_ZOOM,
                 maxzoom: HEATMAP_MAX_ZOOM,
+                layout: {
+                  'icon-image': HEATMAP_IMAGE_ID,
+                  'icon-size': ['interpolate', ['linear'], ['zoom'], 0, 0.35, 2.5, 0.55],
+                  'icon-allow-overlap': true,
+                  'icon-ignore-placement': true,
+                  'icon-anchor': 'bottom',
+                  'symbol-z-order': 'viewport-y',
+                  'symbol-sort-key': 1000
+                },
                 paint: {
-                  'heatmap-weight': ['interpolate', ['linear'], ['zoom'], 0, 0.6, 2.5, 1.1],
-                  'heatmap-intensity': ['interpolate', ['linear'], ['zoom'], 0, 0.6, 2.5, 1.2],
-                  'heatmap-radius': ['interpolate', ['linear'], ['zoom'], 0, 14, 1, 22, 2.5, 32],
-                  'heatmap-color': ['interpolate', ['linear'], ['heatmap-density'], 0, 'rgba(0,0,0,0)', 0.3, colorA, 0.6, colorB, 0.8, colorC, 1, colorD],
-                  'heatmap-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.8, 2.8, 0.45, 3, 0]
+                  'icon-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.9, 2.8, 0.6, 3, 0]
                 }
               });
             }catch(err){ console.error(err); }


### PR DESCRIPTION
## Summary
- replace the seed heatmap layer with a symbol layer that uses the balloon icon image
- configure icon sizing, opacity, and overlap behavior to preserve low-zoom visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1274400c83319631cd4a8de953b4