### PR TITLE
Replace clusters with interactive balloon markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -6107,7 +6107,7 @@ if (typeof slugify !== 'function') {
 
   // Attach pointer cursor only after style is ready, and re-attach if style changes later.
   function armPointerOnSymbolLayers(map){
-    const POINTER_READY_IDS = new Set(['marker-label','post-clusters','post-cluster-count']);
+    const POINTER_READY_IDS = new Set(['marker-label','multi-marker-label','post-balloons']);
 
     function shouldAttachPointer(layer){
       if (!layer || layer.type !== 'symbol') return false;
@@ -6261,281 +6261,241 @@ if (typeof slugify !== 'function') {
           spinLogoClick = localStorage.getItem('spinLogoClick') === 'false' ? false : true,
           spinSpeed = parseFloat(localStorage.getItem('spinSpeed') || String(DEFAULT_SPIN_SPEED)),
           spinEnabled = spinLoadStart && (spinLoadType === 'all' || (spinLoadType === 'new' && firstVisit)),
-          mapStyle = window.mapStyle = 'mapbox://styles/mapbox/standard',
-          clusterRadius = (()=>{
-            const DEFAULT_RADIUS = 52;
-            let stored = parseInt(localStorage.getItem('clusterRadius') || String(DEFAULT_RADIUS), 10);
-            if(!Number.isFinite(stored) || Number.isNaN(stored)) stored = DEFAULT_RADIUS;
-            return Math.max(0, Math.min(stored, 512));
-          })(),
-          clusterMaxZoom = (()=>{
-            let storedValue = parseInt(localStorage.getItem('clusterMaxZoom') || '9', 10);
-            if(Number.isNaN(storedValue)) storedValue = 9;
-            return Math.max(0, Math.min(storedValue, 9));
-          })(),
-          clusterIconType = localStorage.getItem('clusterIconType') || 'circle',
-          clusterSvg = localStorage.getItem('clusterSvg') || '';
-        const CLUSTER_SOURCE_ID = 'post-cluster-source';
-        const CLUSTER_LAYER_ID = 'post-clusters';
-        const CLUSTER_COUNT_LAYER_ID = 'post-cluster-count';
-        const CLUSTER_MIN_ZOOM = 3;
-        const CLUSTER_MAX_ZOOM = 7;
-        const HEATMAP_SOURCE_ID = 'post-seed-heatmap-source';
-        const HEATMAP_LAYER_ID = 'post-seed-heatmap-layer';
-        const HEATMAP_IMAGE_ID = 'seed-balloon-icon';
-        const HEATMAP_IMAGE_URL = 'assets/balloons/balloons-icon-16185.webp';
-        const HEATMAP_MIN_ZOOM = 0;
-        const HEATMAP_MAX_ZOOM = CLUSTER_MIN_ZOOM;
-        const DEFAULT_HEATMAP_COLORS = [
-          'rgba(36, 198, 220, 0.55)',
-          'rgba(81, 74, 157, 0.65)',
-          'rgba(247, 121, 125, 0.75)',
-          'rgba(251, 215, 134, 0.85)'
-        ];
+          mapStyle = window.mapStyle = 'mapbox://styles/mapbox/standard';
+        const BALLOON_SOURCE_ID = 'post-balloon-source';
+        const BALLOON_LAYER_ID = 'post-balloons';
+        const BALLOON_LAYER_IDS = [BALLOON_LAYER_ID];
+        const BALLOON_IMAGE_ID = 'seed-balloon-icon';
+        const BALLOON_IMAGE_URL = 'assets/balloons/balloons-icon-16185.webp';
+        const BALLOON_MIN_ZOOM = 0;
+        const BALLOON_MAX_ZOOM = 8;
+        let balloonLayersVisible = true;
 
-        function ensureHeatmapIconImage(mapInstance){
+        function ensureBalloonIconImage(mapInstance){
           return new Promise(resolve => {
             if(!mapInstance || typeof mapInstance.hasImage !== 'function'){
-              resolve({ heatmapColors: DEFAULT_HEATMAP_COLORS.slice() });
+              resolve();
               return;
             }
-            const cachedColors = mapInstance.__heatmapIconColors;
-            if(mapInstance.hasImage(HEATMAP_IMAGE_ID) && Array.isArray(cachedColors) && cachedColors.length){
-              resolve({ heatmapColors: cachedColors });
+            if(mapInstance.hasImage(BALLOON_IMAGE_ID)){
+              resolve();
               return;
             }
-            const finalize = (colors)=>{
-              const gradient = Array.isArray(colors) && colors.length ? colors : DEFAULT_HEATMAP_COLORS.slice();
-              mapInstance.__heatmapIconColors = gradient;
-              resolve({ heatmapColors: gradient });
-            };
             const handleImage = (image)=>{
               if(!image){
-                finalize();
+                resolve();
                 return;
               }
               try{
-                if(!mapInstance.hasImage(HEATMAP_IMAGE_ID)){
-                  const data = image && image.data ? image.data : image;
-                  mapInstance.addImage(HEATMAP_IMAGE_ID, data);
+                if(!mapInstance.hasImage(BALLOON_IMAGE_ID) && image.width > 0 && image.height > 0){
+                  const pixelRatio = image.width >= 256 ? 2 : 1;
+                  mapInstance.addImage(BALLOON_IMAGE_ID, image, { pixelRatio });
                 }
               }catch(err){ console.error(err); }
-              try{
-                if(typeof document !== 'undefined'){
-                  const canvas = document.createElement('canvas');
-                  const size = Math.max(1, Math.min(128, image.width || image.height || 64));
-                  canvas.width = size;
-                  canvas.height = size;
-                  const ctx = canvas.getContext && canvas.getContext('2d');
-                  if(ctx){
-                    ctx.drawImage(image, 0, 0, size, size);
-                    const samplePoints = [
-                      [Math.floor(size * 0.25), Math.floor(size * 0.25)],
-                      [Math.floor(size * 0.55), Math.floor(size * 0.45)],
-                      [Math.floor(size * 0.7), Math.floor(size * 0.7)],
-                      [Math.floor(size * 0.4), Math.floor(size * 0.8)]
-                    ];
-                    const rgba = (data)=>`rgba(${data[0]}, ${data[1]}, ${data[2]}, ${Math.round((data[3] / 255) * 100) / 100})`;
-                    const colors = samplePoints.map(([x, y])=>{
-                      try{
-                        const pixel = ctx.getImageData(x, y, 1, 1).data;
-                        return rgba(pixel);
-                      }catch(sampleErr){
-                        console.error(sampleErr);
-                        return null;
-                      }
-                    }).filter(Boolean);
-                    finalize(colors);
-                    return;
-                  }
-                }
-              }catch(colorErr){ console.error(colorErr); }
-              finalize();
+              resolve();
             };
             try{
               if(typeof mapInstance.loadImage === 'function'){
-                const result = mapInstance.loadImage(HEATMAP_IMAGE_URL);
-                if(result && typeof result.then === 'function'){
-                  result.then(res => handleImage(res && (res.data || res)))
-                    .catch(err => { console.error(err); finalize(); });
-                  return;
-                }
-                mapInstance.loadImage(HEATMAP_IMAGE_URL, (err, image)=>{
-                  if(err){ console.error(err); finalize(); return; }
+                mapInstance.loadImage(BALLOON_IMAGE_URL, (err, image)=>{
+                  if(err){ console.error(err); resolve(); return; }
                   handleImage(image);
                 });
                 return;
               }
-            }catch(err){ console.error(err); finalize(); return; }
+            }catch(err){ console.error(err); resolve(); return; }
             if(typeof Image !== 'undefined'){
               const img = new Image();
               img.crossOrigin = 'anonymous';
               img.onload = ()=>handleImage(img);
-              img.onerror = ()=>finalize();
-              img.src = HEATMAP_IMAGE_URL;
+              img.onerror = ()=>resolve();
+              img.src = BALLOON_IMAGE_URL;
               return;
             }
-            finalize();
+            resolve();
           });
+        }
+
+        function formatBalloonCount(count){
+          if(!Number.isFinite(count) || count <= 0){
+            return '0';
+          }
+          if(count >= 1000000){
+            const value = count / 1000000;
+            const formatted = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
+            return `${formatted}m`;
+          }
+          if(count >= 1000){
+            const value = count / 1000;
+            const formatted = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
+            return `${formatted}k`;
+          }
+          return String(count);
+        }
+
+        function getBalloonGridSize(zoom){
+          const z = Number.isFinite(zoom) ? zoom : 0;
+          if(z >= 7.5) return 0.5;
+          if(z >= 6) return 1;
+          if(z >= 4) return 2.5;
+          if(z >= 2) return 5;
+          return 10;
+        }
+
+        function buildBalloonFeatureCollection(zoom){
+          const postsSource = Array.isArray(ALL_POSTS_CACHE) ? ALL_POSTS_CACHE : [];
+          const gridSizeRaw = getBalloonGridSize(zoom);
+          const gridSize = gridSizeRaw > 0 ? gridSizeRaw : 5;
+          const groups = new Map();
+          postsSource.forEach(post => {
+            if(!post || !Number.isFinite(post.lng) || !Number.isFinite(post.lat)) return;
+            const lng = post.lng;
+            const lat = Math.max(-85, Math.min(85, post.lat));
+            const col = Math.floor((lng + 180) / gridSize);
+            const row = Math.floor((lat + 90) / gridSize);
+            const key = `${col}|${row}`;
+            let bucket = groups.get(key);
+            if(!bucket){
+              bucket = { count:0, sumLng:0, sumLat:0 };
+              groups.set(key, bucket);
+            }
+            bucket.count += 1;
+            bucket.sumLng += lng;
+            bucket.sumLat += lat;
+          });
+          const features = [];
+          groups.forEach((bucket, key) => {
+            if(bucket.count <= 0) return;
+            const avgLng = bucket.sumLng / bucket.count;
+            const avgLat = bucket.sumLat / bucket.count;
+            features.push({
+              type:'Feature',
+              properties:{
+                count: bucket.count,
+                label: formatBalloonCount(bucket.count),
+                bucket: key
+              },
+              geometry:{ type:'Point', coordinates:[avgLng, avgLat] }
+            });
+          });
+          return { type:'FeatureCollection', features };
+        }
+
+        let lastBalloonBucketKey = null;
+
+        function getBalloonBucketKey(zoom){
+          const size = getBalloonGridSize(zoom);
+          return Number.isFinite(size) ? size.toFixed(2) : 'default';
+        }
+
+        function updateBalloonSourceForZoom(zoom){
+          if(!map) return;
+          const source = map.getSource && map.getSource(BALLOON_SOURCE_ID);
+          if(!source || typeof source.setData !== 'function') return;
+          const zoomValue = Number.isFinite(zoom) ? zoom : (typeof map.getZoom === 'function' ? map.getZoom() : 0);
+          const bucketKey = getBalloonBucketKey(zoomValue);
+          if(lastBalloonBucketKey === bucketKey) return;
+          try{
+            const data = buildBalloonFeatureCollection(zoomValue);
+            source.setData(data);
+            lastBalloonBucketKey = bucketKey;
+          }catch(err){ console.error(err); }
+        }
+
+        function resetBalloonSourceState(){
+          lastBalloonBucketKey = null;
         }
 
         function setupSeedLayers(mapInstance){
           if(!mapInstance) return;
-          ensureHeatmapIconImage(mapInstance).then(()=>{
+          ensureBalloonIconImage(mapInstance).then(()=>{
             try{
-              if(mapInstance.getLayer(HEATMAP_LAYER_ID)) mapInstance.removeLayer(HEATMAP_LAYER_ID);
+              if(mapInstance.getLayer(BALLOON_LAYER_ID)) mapInstance.removeLayer(BALLOON_LAYER_ID);
             }catch(err){ console.error(err); }
 
-            let heatmapSource = null;
+            let balloonSource = null;
             try{
-              heatmapSource = mapInstance.getSource && mapInstance.getSource(HEATMAP_SOURCE_ID);
-            }catch(err){ heatmapSource = null; }
+              balloonSource = mapInstance.getSource && mapInstance.getSource(BALLOON_SOURCE_ID);
+            }catch(err){ balloonSource = null; }
+            const emptyData = (typeof EMPTY_FEATURE_COLLECTION !== 'undefined') ? EMPTY_FEATURE_COLLECTION : { type:'FeatureCollection', features: [] };
             try{
-              if(heatmapSource && typeof heatmapSource.setData === 'function'){
-                heatmapSource.setData(POST_SEED_GEOJSON);
+              if(balloonSource && typeof balloonSource.setData === 'function'){
+                balloonSource.setData(emptyData);
               } else {
-                if(heatmapSource){
-                  try{ mapInstance.removeSource(HEATMAP_SOURCE_ID); }catch(removeErr){ console.error(removeErr); }
+                if(balloonSource){
+                  try{ mapInstance.removeSource(BALLOON_SOURCE_ID); }catch(removeErr){ console.error(removeErr); }
                 }
-                mapInstance.addSource(HEATMAP_SOURCE_ID, { type:'geojson', data: POST_SEED_GEOJSON });
+                mapInstance.addSource(BALLOON_SOURCE_ID, { type:'geojson', data: emptyData });
               }
             }catch(err){ console.error(err); }
 
             try{
               mapInstance.addLayer({
-                id: HEATMAP_LAYER_ID,
+                id: BALLOON_LAYER_ID,
                 type: 'symbol',
-                source: HEATMAP_SOURCE_ID,
-                minzoom: HEATMAP_MIN_ZOOM,
-                maxzoom: HEATMAP_MAX_ZOOM,
+                source: BALLOON_SOURCE_ID,
+                minzoom: BALLOON_MIN_ZOOM,
+                maxzoom: BALLOON_MAX_ZOOM,
                 layout: {
-                  'icon-image': HEATMAP_IMAGE_ID,
-                  'icon-size': ['interpolate', ['linear'], ['zoom'], 0, 0.35, 2.5, 0.55],
+                  'icon-image': BALLOON_IMAGE_ID,
+                  'icon-size': ['interpolate', ['linear'], ['zoom'], 0, 0.4, 7.5, 1],
                   'icon-allow-overlap': true,
                   'icon-ignore-placement': true,
                   'icon-anchor': 'bottom',
+                  'text-field': ['to-string', ['coalesce', ['get','label'], ['get','count']]],
+                  'text-size': 12,
+                  'text-offset': [0, -1.35],
+                  'text-font': ['Open Sans Bold','Arial Unicode MS Bold'],
+                  'text-allow-overlap': true,
+                  'text-ignore-placement': true,
                   'symbol-z-order': 'viewport-y',
-                  'symbol-sort-key': 1000
+                  'symbol-sort-key': 900
                 },
                 paint: {
-                  'icon-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.9, 2.8, 0.6, 3, 0]
-                }
+                  'text-color': '#ffffff',
+                  'text-halo-color': 'rgba(0,0,0,0.45)',
+                  'text-halo-width': 1.2,
+                  'icon-opacity': 0.95
+                },
+                metadata:{ cursor:'pointer' }
               });
             }catch(err){ console.error(err); }
+
+            resetBalloonSourceState();
+            const currentZoomValue = mapInstance.getZoom ? mapInstance.getZoom() : BALLOON_MIN_ZOOM;
+            updateBalloonSourceForZoom(currentZoomValue);
+            const shouldShow = Number.isFinite(currentZoomValue) ? currentZoomValue < BALLOON_MAX_ZOOM : true;
+            try{
+              mapInstance.setLayoutProperty(BALLOON_LAYER_ID, 'visibility', shouldShow ? 'visible' : 'none');
+            }catch(err){}
+            balloonLayersVisible = shouldShow;
           });
-          try{
-            if(mapInstance.getLayer(CLUSTER_LAYER_ID)) mapInstance.removeLayer(CLUSTER_LAYER_ID);
-            if(mapInstance.getLayer(CLUSTER_COUNT_LAYER_ID)) mapInstance.removeLayer(CLUSTER_COUNT_LAYER_ID);
-            if(mapInstance.getSource(CLUSTER_SOURCE_ID)) mapInstance.removeSource(CLUSTER_SOURCE_ID);
-          }catch(err){ console.error(err); }
 
-          const normalizedClusterMaxZoom = Number.isFinite(clusterMaxZoom) ? Math.floor(clusterMaxZoom) : CLUSTER_MIN_ZOOM;
-          const effectiveClusterMaxZoom = Math.max(
-            CLUSTER_MIN_ZOOM,
-            Math.min(normalizedClusterMaxZoom, CLUSTER_MAX_ZOOM)
-          );
-          const effectiveRadius = clusterRadius > 0 ? clusterRadius : 60;
-          try{
-            mapInstance.addSource(CLUSTER_SOURCE_ID, {
-              type:'geojson',
-              data: POST_SEED_GEOJSON,
-              cluster: true,
-              clusterRadius: effectiveRadius,
-              clusterMaxZoom: effectiveClusterMaxZoom
-            });
-          }catch(err){ console.error(err); }
-
-          try{
-            mapInstance.addLayer({
-              id: CLUSTER_LAYER_ID,
-              type:'circle',
-              source: CLUSTER_SOURCE_ID,
-              filter:['has','point_count'],
-              minzoom: CLUSTER_MIN_ZOOM,
-              maxzoom: effectiveClusterMaxZoom,
-              paint:{
-                'circle-color': ['step',['get','point_count'], '#24c6dc', 20, '#514a9d', 50, '#f7797d', 100, '#fbd786'],
-                'circle-radius': ['step',['get','point_count'], 16, 20, 22, 50, 28, 100, 34],
-                'circle-opacity': 0.85,
-                'circle-stroke-color':'#0b1623',
-                'circle-stroke-width':1
-              }
-            });
-          }catch(err){ console.error(err); }
-
-          try{
-            mapInstance.addLayer({
-              id: CLUSTER_COUNT_LAYER_ID,
-              type:'symbol',
-              source: CLUSTER_SOURCE_ID,
-              filter:['has','point_count'],
-              minzoom: CLUSTER_MIN_ZOOM,
-              maxzoom: effectiveClusterMaxZoom,
-              layout:{
-                'text-field':['to-string', ['coalesce', ['get','total_posts'], ['get','point_count_abbreviated']]],
-                'text-size':12,
-                'text-allow-overlap': true,
-                'text-ignore-placement': true,
-                'symbol-z-order': 'viewport-y',
-                'symbol-sort-key': 1001
-              },
-              paint:{'text-color':'#fff'}
-            });
-          }catch(err){ console.error(err); }
-
-          if(!mapInstance.__seedClusterEventsBound){
-            const clusterLayers = [CLUSTER_LAYER_ID, CLUSTER_COUNT_LAYER_ID];
-            const handleClusterZoom = (e)=>{
+          if(!mapInstance.__seedBalloonEventsBound){
+            const handleBalloonClick = (e)=>{
               if(e && typeof e.preventDefault === 'function') e.preventDefault();
-              const features = mapInstance.queryRenderedFeatures(e.point, { layers: clusterLayers.filter(id => mapInstance.getLayer(id)) });
-              if(!features.length) return;
-              const feature = features[0];
-              const props = feature && feature.properties;
-              const clusterId = props && typeof props.cluster_id === 'number' ? props.cluster_id : null;
-              if(clusterId === null) return;
-              const source = mapInstance.getSource(CLUSTER_SOURCE_ID);
-              if(!source || typeof source.getClusterExpansionZoom !== 'function') return;
-              source.getClusterExpansionZoom(clusterId, (err, expansionZoom)=>{
-                if(err) return;
-                const coords = feature.geometry && feature.geometry.coordinates;
-                if(!Array.isArray(coords) || coords.length < 2) return;
-                const maxZoom = typeof mapInstance.getMaxZoom === 'function' ? mapInstance.getMaxZoom() : undefined;
-                const currentZoom = typeof mapInstance.getZoom === 'function' ? mapInstance.getZoom() : undefined;
-                const targetZoom = typeof expansionZoom === 'number' ? expansionZoom : currentZoom;
-                if(typeof targetZoom !== 'number') return;
-                const nextZoom = typeof maxZoom === 'number' ? Math.min(targetZoom, maxZoom) : targetZoom;
-                const animationOpts = { center: coords, zoom: nextZoom, essential: true };
-                let computedDuration = 650;
-                try{
-                  const currentCenter = typeof mapInstance.getCenter === 'function' ? mapInstance.getCenter() : null;
-                  const targetLngLat = (typeof mapboxgl !== 'undefined' && mapboxgl && typeof mapboxgl.LngLat === 'function')
-                    ? new mapboxgl.LngLat(coords[0], coords[1])
-                    : null;
-                  const zoomNow = typeof currentZoom === 'number' ? currentZoom : (typeof mapInstance.getZoom === 'function' ? mapInstance.getZoom() : null);
-                  if(currentCenter && targetLngLat && typeof currentCenter.distanceTo === 'function'){
-                    const distanceMeters = currentCenter.distanceTo(targetLngLat);
-                    const distanceMs = Math.min(1200, Math.log(distanceMeters / 1000 + 1) * 600);
-                    const zoomDelta = typeof zoomNow === 'number' ? Math.abs(nextZoom - zoomNow) : 0;
-                    const zoomMs = Math.min(600, zoomDelta * 120);
-                    const base = 450;
-                    computedDuration = Math.max(450, Math.min(2200, base + distanceMs + zoomMs));
-                    if(zoomDelta < 0.35){
-                      const blend = Math.max(0, Math.min(1, zoomDelta / 0.35));
-                      const speedMultiplier = 0.45 + (0.55 * blend);
-                      computedDuration = Math.max(220, Math.min(2200, computedDuration * speedMultiplier));
-                    }
-                  }
-                }catch(durationErr){ console.error(durationErr); }
-                animationOpts.duration = Math.round(computedDuration);
-                try{ mapInstance.easeTo(animationOpts); }catch(err){ console.error(err); }
-              });
+              const feature = e && e.features && e.features[0];
+              if(!feature) return;
+              const coords = feature.geometry && feature.geometry.coordinates;
+              if(!Array.isArray(coords) || coords.length < 2) return;
+              const currentZoom = typeof mapInstance.getZoom === 'function' ? mapInstance.getZoom() : 0;
+              const maxZoom = typeof mapInstance.getMaxZoom === 'function' ? mapInstance.getMaxZoom() : 22;
+              let targetZoom = currentZoom + 1;
+              if(currentZoom >= 7.5){
+                targetZoom = Math.max(BALLOON_MAX_ZOOM, currentZoom);
+              } else {
+                targetZoom = Math.min(targetZoom, BALLOON_MAX_ZOOM);
+              }
+              if(Number.isFinite(maxZoom)){
+                targetZoom = Math.min(targetZoom, maxZoom);
+              }
+              try{
+                mapInstance.easeTo({ center: coords, zoom: targetZoom, duration: 450, essential: true });
+              }catch(err){ console.error(err); }
             };
-            clusterLayers.forEach(id => {
-              mapInstance.on('click', id, handleClusterZoom);
-              mapInstance.on('mouseenter', id, ()=>{ mapInstance.getCanvas().style.cursor = 'pointer'; });
-              mapInstance.on('mouseleave', id, ()=>{ mapInstance.getCanvas().style.cursor = 'grab'; });
-            });
-            mapInstance.__seedClusterEventsBound = true;
+            mapInstance.on('click', BALLOON_LAYER_ID, handleBalloonClick);
+            mapInstance.on('mouseenter', BALLOON_LAYER_ID, ()=>{ mapInstance.getCanvas().style.cursor = 'pointer'; });
+            mapInstance.on('mouseleave', BALLOON_LAYER_ID, ()=>{ mapInstance.getCanvas().style.cursor = 'grab'; });
+            mapInstance.__seedBalloonEventsBound = true;
           }
           if(mapInstance === map){
             updateLayerVisibility(lastKnownZoom);
@@ -6737,8 +6697,6 @@ if (typeof slugify !== 'function') {
       try{ map.doubleClickZoom[fn](); }catch(e){}
       try{ map.touchZoomRotate[fn](); }catch(e){}
     }
-    const MAX_CLUSTER_BOUNDS_LEAVES = 500;
-
     const MARKER_INTERACTIVE_LAYERS = ['marker-label','multi-marker-label'];
     window.__overCard = window.__overCard || false;
 
@@ -8619,9 +8577,7 @@ function makePosts(){
     const MARKER_ZOOM_THRESHOLD = 8;
     const MULTI_CARD_MIN_ZOOM = 8;
     const MARKER_LAYER_IDS = ['hover-fill','marker-label','multi-marker-label'];
-    const CLUSTER_LAYER_IDS = [CLUSTER_LAYER_ID, CLUSTER_COUNT_LAYER_ID];
     let markerLayersVisible = false;
-    let clusterLayersVisible = true;
     let pendingZoomCheckToken = null;
     let pendingZoomEvent = null;
 
@@ -8658,16 +8614,18 @@ function makePosts(){
     function updateLayerVisibility(zoom){
       const zoomValue = Number.isFinite(zoom) ? zoom : getZoomFromEvent();
       const withinMarkerRange = Number.isFinite(zoomValue) && zoomValue >= MARKER_ZOOM_THRESHOLD;
-      const postsReady = postsLoaded && withinMarkerRange;
       const shouldShowMarkers = withinMarkerRange;
-      const shouldShowClusters = !withinMarkerRange || !postsReady;
+      const shouldShowBalloons = !withinMarkerRange;
       if(markerLayersVisible !== shouldShowMarkers){
         MARKER_LAYER_IDS.forEach(id => setLayerVisibility(id, shouldShowMarkers));
         markerLayersVisible = shouldShowMarkers;
       }
-      if(clusterLayersVisible !== shouldShowClusters){
-        CLUSTER_LAYER_IDS.forEach(id => setLayerVisibility(id, shouldShowClusters));
-        clusterLayersVisible = shouldShowClusters;
+      if(balloonLayersVisible !== shouldShowBalloons){
+        BALLOON_LAYER_IDS.forEach(id => setLayerVisibility(id, shouldShowBalloons));
+        balloonLayersVisible = shouldShowBalloons;
+      }
+      if(shouldShowBalloons){
+        updateBalloonSourceForZoom(zoomValue);
       }
     }
 
@@ -8682,6 +8640,7 @@ function makePosts(){
       }
       updatePostsButtonState(lastKnownZoom);
       updateLayerVisibility(lastKnownZoom);
+      updateBalloonSourceForZoom(lastKnownZoom);
     }
 
     function scheduleCheckLoadPosts(event){
@@ -10883,6 +10842,7 @@ if (!map.__pillHooksInstalled) {
           const zoom = map.getZoom();
           const pitch = map.getPitch();
           const bearing = map.getBearing();
+          updateBalloonSourceForZoom(zoom);
           localStorage.setItem('mapView', JSON.stringify({center, zoom, pitch, bearing}));
         };
         ['moveend','zoomend','rotateend','pitchend'].forEach(ev => map.on(ev, refreshMapView));
@@ -11602,7 +11562,7 @@ if (!map.__pillHooksInstalled) {
       };
       MARKER_INTERACTIVE_LAYERS.forEach(layer => map.on('mouseleave', layer, handleMarkerMouseLeave));
 
-      // Maintain pointer cursor for clusters and surface multi-venue cards when applicable
+      // Maintain pointer cursor for balloons and surface multi-venue cards when applicable
         postSourceEventsBound = true;
       }
       } catch (err) {


### PR DESCRIPTION
## Summary
- remove Mapbox cluster and heatmap setup and introduce a balloon GeoJSON source with reusable icon loading
- aggregate post seeds into zoom-aware balloon markers, update layer visibility handling, and zoom-to-next-level click behavior
- refresh supporting helpers to keep balloon data in sync with map zoom and pointer affordances

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc20f631ac83318631b4182bae9ddb