### PR TITLE
Delay post data loading until map zoom threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -6333,7 +6333,14 @@ if (typeof slugify !== 'function') {
         let lastBalloonGroupingDetails = { key: null, zoom: null, groups: new Map() };
 
         function buildBalloonFeatureCollection(zoom){
-          const postsSource = Array.isArray(ALL_POSTS_CACHE) ? ALL_POSTS_CACHE : [];
+          const allowInitialize = Number.isFinite(zoom) && zoom >= MARKER_ZOOM_THRESHOLD;
+          const postsSource = getAllPostsCache({ allowInitialize });
+          if(!Array.isArray(postsSource) || postsSource.length === 0){
+            const emptyGroups = new Map();
+            const groupingKey = getBalloonBucketKey(zoom);
+            lastBalloonGroupingDetails = { key: groupingKey, zoom, groups: emptyGroups };
+            return { type:'FeatureCollection', features: [] };
+          }
           const { groups } = groupPostsForBalloonZoom(postsSource, zoom);
           const features = [];
           groups.forEach((bucket, key) => {
@@ -8561,15 +8568,18 @@ function makePosts(){
   return out;
 }
 
-    const ALL_POSTS_CACHE = makePosts();
-    const POST_POINT_FEATURES = ALL_POSTS_CACHE
-      .filter(p => Number.isFinite(p.lng) && Number.isFinite(p.lat))
-      .map(p => ({
-        type:'Feature',
-        properties:{ id: p.id },
-        geometry:{ type:'Point', coordinates:[p.lng, p.lat] }
-      }));
-    const POST_SEED_GEOJSON = { type:'FeatureCollection', features: POST_POINT_FEATURES };
+    let ALL_POSTS_CACHE = null;
+    function getAllPostsCache(options = {}){
+      const { allowInitialize = true } = options;
+      if(Array.isArray(ALL_POSTS_CACHE)){
+        return ALL_POSTS_CACHE;
+      }
+      if(!allowInitialize){
+        return null;
+      }
+      ALL_POSTS_CACHE = makePosts();
+      return ALL_POSTS_CACHE;
+    }
     const EMPTY_FEATURE_COLLECTION = { type:'FeatureCollection', features: [] };
 
     const markerDataCache = {
@@ -8785,7 +8795,10 @@ function makePosts(){
         applyFilters();
         return;
       }
-      const nextPosts = ALL_POSTS_CACHE.filter(p => pointWithinBounds(p.lng, p.lat, normalized));
+      const cache = getAllPostsCache();
+      const nextPosts = Array.isArray(cache)
+        ? cache.filter(p => pointWithinBounds(p.lng, p.lat, normalized))
+        : [];
       posts = nextPosts;
       postsLoaded = true;
       window.postsLoaded = postsLoaded;


### PR DESCRIPTION
## Summary
- lazily initialize the post cache so that post data is not created before the zoom threshold
- gate balloon feature generation behind the zoom requirement and reuse any already-loaded data
- filter posts by the current map bounds whenever loading data after the threshold is met

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcdd204b4c8331b5a1e1b979070df4