### PR TITLE
Adjust balloon zoom fallback behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -6532,7 +6532,7 @@ if (typeof slugify !== 'function') {
               const zoomFromChild = hasChildTarget && Number.isFinite(childTarget.zoom)
                 ? Math.max(childTarget.zoom, safeCurrentZoom)
                 : null;
-              const fallbackZoom = Math.min(maxAllowedZoom, Math.max(safeCurrentZoom + 1, safeCurrentZoom));
+              const fallbackTargetZoom = Math.min(8, maxAllowedZoom);
               let finalZoom;
               if(zoomFromChild !== null){
                 const cappedChildZoom = Math.min(zoomFromChild, maxAllowedZoom);
@@ -6543,7 +6543,7 @@ if (typeof slugify !== 'function') {
                   finalZoom = cappedChildZoom;
                 }
               } else {
-                finalZoom = Math.min(8, maxAllowedZoom, Math.max(fallbackZoom, safeCurrentZoom));
+                finalZoom = safeCurrentZoom < fallbackTargetZoom ? fallbackTargetZoom : safeCurrentZoom;
               }
               try{
                 const flight = { center: targetCenter, zoom: finalZoom, essential: true };


### PR DESCRIPTION
## Summary
- ensure balloon clicks without child targets jump directly to zoom level 8 rather than incrementing zoom

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd10b70a408331a72a4eff6964dd09