### PR TITLE
Ensure markers load immediately at zoom threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -8378,14 +8378,20 @@ function makePosts(){
       if(!map) return;
       const zoomCandidate = getZoomFromEvent(event);
       updateZoomState(zoomCandidate);
-      if(waitForInitialZoom){
-        postLoadRequested = true;
-        hideResultIndicators();
-        return;
-      }
       let zoomLevel = Number.isFinite(zoomCandidate) ? zoomCandidate : lastKnownZoom;
       if(!Number.isFinite(zoomLevel)){
         zoomLevel = getZoomFromEvent();
+      }
+      if(waitForInitialZoom){
+        if(Number.isFinite(zoomLevel) && zoomLevel >= MARKER_ZOOM_THRESHOLD){
+          waitForInitialZoom = false;
+          window.waitForInitialZoom = waitForInitialZoom;
+          initialZoomStarted = false;
+        } else {
+          postLoadRequested = true;
+          hideResultIndicators();
+          return;
+        }
       }
       if(!Number.isFinite(zoomLevel)){
         postLoadRequested = true;


### PR DESCRIPTION
## Summary
- allow the initial post-loading gate to clear automatically when the map zoom meets the marker threshold
- prevent extra interaction requirements so markers appear as soon as zoom level 8 is displayed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd138dddec83319b538c2d19379450