### PR TITLE
Style map pills for new colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
       pointer-events: auto;
       isolation: isolate;
       touch-action: none;
+      border-radius: 999px;
     }
     .mapmarker-overlay{
       position: relative;
@@ -90,8 +91,9 @@
       width: 225px;
       height: 60px;
       object-fit: contain;
-      pointer-events: auto;
-      opacity: 0.9 !important;
+      pointer-events: none;
+      opacity: 0 !important;
+      visibility: hidden;
       mix-blend-mode: normal;
       z-index: 0;
     }
@@ -103,6 +105,8 @@
       height: 40px;
       transform: translate(-50%, -50%);
       pointer-events: none;
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.7);
     }
     .mapmarker{
       position: absolute;
@@ -121,9 +125,13 @@
       height: 40px;
       object-fit: contain;
       pointer-events: none;
-      opacity: 0.9 !important;
+      opacity: 0 !important;
+      visibility: hidden;
       mix-blend-mode: normal;
       z-index: 0;
+    }
+    .map-card--popup{
+      background-color: #2e3a72;
     }
     .map-card-thumb{
       position: absolute;


### PR DESCRIPTION
## Summary
- replace the marker pill image with a rounded container background so it renders black at 70% opacity
- hide the popup card pill image and style the popup card background with the requested #2e3a72 color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd1c06abd883319358c5e9e68f0a30