### PR TITLE
Add automatic pitch transition beyond zoom level 17

### DIFF
--- a/index.html
+++ b/index.html
@@ -6129,6 +6129,13 @@ if (typeof slugify !== 'function') {
   window.callWhenDefined = window.callWhenDefined || callWhenDefined;
 
   let startPitch, startBearing, logoEls = [], geocoder;
+  const AUTO_PITCH_START_ZOOM = 17;
+  const AUTO_PITCH_END_ZOOM = 22;
+  const AUTO_PITCH_START_DEG = 90;
+  const AUTO_PITCH_END_DEG = 0;
+  const AUTO_PITCH_TOLERANCE = 7;
+  let autoPitchEnabled = true;
+  let applyingAutoPitch = false;
   const geocoders = [];
   let lastGeocoderProximity = null;
 
@@ -6228,7 +6235,23 @@ if (typeof slugify !== 'function') {
     const startCenter = savedView?.center || defaultCenter;
     const startZoom = savedView?.zoom || 1.5;
     let lastKnownZoom = startZoom;
-    startPitch = window.startPitch = savedView?.pitch || 0;
+    const hasSavedPitch = typeof savedView?.pitch === 'number';
+    let initialPitch = AUTO_PITCH_START_DEG;
+    if(hasSavedPitch){
+      initialPitch = savedView.pitch;
+      let expectedPitch = getAutoPitchForZoom(startZoom);
+      if(!Number.isFinite(expectedPitch) && Number.isFinite(startZoom) && startZoom <= AUTO_PITCH_START_ZOOM){
+        expectedPitch = AUTO_PITCH_START_DEG;
+      }
+      if(Number.isFinite(expectedPitch) && Number.isFinite(savedView.pitch)){
+        autoPitchEnabled = Math.abs(expectedPitch - savedView.pitch) <= AUTO_PITCH_TOLERANCE;
+      }else{
+        autoPitchEnabled = false;
+      }
+    }else{
+      autoPitchEnabled = true;
+    }
+    startPitch = window.startPitch = initialPitch;
     startBearing = window.startBearing = savedView?.bearing || 0;
 
       let map, spinning = false, historyWasActive = localStorage.getItem('historyActive') === 'true', expiredWasOn = false, dateStart = null, dateEnd = null,
@@ -8360,6 +8383,54 @@ function makePosts(){
       }
     }
 
+    function getAutoPitchForZoom(zoom){
+      if(!Number.isFinite(zoom) || zoom <= AUTO_PITCH_START_ZOOM){
+        return NaN;
+      }
+      if(zoom >= AUTO_PITCH_END_ZOOM){
+        return AUTO_PITCH_END_DEG;
+      }
+      const progress = (zoom - AUTO_PITCH_START_ZOOM) / (AUTO_PITCH_END_ZOOM - AUTO_PITCH_START_ZOOM);
+      return AUTO_PITCH_START_DEG + (AUTO_PITCH_END_DEG - AUTO_PITCH_START_DEG) * progress;
+    }
+
+    function applyAutoPitch(targetPitch){
+      if(!autoPitchEnabled || !map || typeof map.getPitch !== 'function' || typeof map.easeTo !== 'function') return;
+      let currentPitch;
+      try{ currentPitch = map.getPitch(); }catch(err){ currentPitch = NaN; }
+      if(!Number.isFinite(currentPitch) || !Number.isFinite(targetPitch)) return;
+      let minPitch = AUTO_PITCH_END_DEG;
+      let maxPitch = AUTO_PITCH_START_DEG;
+      if(typeof map.getMinPitch === 'function'){
+        try{ const candidate = map.getMinPitch(); if(Number.isFinite(candidate)) minPitch = Math.max(minPitch, candidate); }catch(err){}
+      }
+      if(typeof map.getMaxPitch === 'function'){
+        try{ const candidate = map.getMaxPitch(); if(Number.isFinite(candidate)) maxPitch = Math.min(maxPitch, candidate); }catch(err){}
+      }
+      const clampedTarget = Math.max(minPitch, Math.min(maxPitch, targetPitch));
+      if(Math.abs(currentPitch - clampedTarget) < 0.5) return;
+      applyingAutoPitch = true;
+      try{
+        map.easeTo({ pitch: clampedTarget, duration: 0, easing: t => t, essential: true });
+      }catch(err){
+        applyingAutoPitch = false;
+        return;
+      }
+      const release = () => { applyingAutoPitch = false; };
+      if(typeof requestAnimationFrame === 'function'){
+        requestAnimationFrame(release);
+      } else {
+        setTimeout(release, 0);
+      }
+    }
+
+    function updateAutoPitchForZoom(zoom){
+      if(!autoPitchEnabled) return;
+      const desiredPitch = getAutoPitchForZoom(zoom);
+      if(!Number.isFinite(desiredPitch)) return;
+      applyAutoPitch(desiredPitch);
+    }
+
     function updateZoomState(zoom){
       if(Number.isFinite(zoom)){
         lastKnownZoom = zoom;
@@ -8372,6 +8443,7 @@ function makePosts(){
       updatePostsButtonState(lastKnownZoom);
       updateLayerVisibility(lastKnownZoom);
       updateBalloonSourceForZoom(lastKnownZoom);
+      updateAutoPitchForZoom(lastKnownZoom);
       if(!Number.isFinite(lastKnownZoom) || lastKnownZoom < MULTI_CARD_MIN_ZOOM){
         destroyMultiPostCardContainer();
       }
@@ -10572,6 +10644,10 @@ if (!map.__pillHooksInstalled) {
       });
 
         ['mousedown','wheel','touchstart','dragstart','pitchstart','rotatestart','zoomstart'].forEach(ev=> map.on(ev, haltSpin));
+        map.on('pitchstart', () => {
+          if(applyingAutoPitch) return;
+          autoPitchEnabled = false;
+        });
         map.on('pitch', () => {
           const pIn = document.getElementById('mapPitch');
           const pVal = document.getElementById('pitchVal');


### PR DESCRIPTION
## Summary
- set the default map pitch to the high-angle planet view when no manual pitch preference is saved
- add automatic pitch easing that gradually levels the map from zoom 17 through zoom 22
- stop the automatic easing once a manual pitch interaction is detected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1f59deb48331ba33cd2621aae291