### PR TITLE
Ensure auto pitch stays at start angle for low zoom levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -8385,7 +8385,7 @@ function makePosts(){
 
     function getAutoPitchForZoom(zoom){
       if(!Number.isFinite(zoom) || zoom <= AUTO_PITCH_START_ZOOM){
-        return NaN;
+        return AUTO_PITCH_START_DEG;
       }
       if(zoom >= AUTO_PITCH_END_ZOOM){
         return AUTO_PITCH_END_DEG;


### PR DESCRIPTION
## Summary
- ensure getAutoPitchForZoom returns the starting auto pitch angle for invalid or low zoom levels so the map holds the straight-down view until auto easing begins

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd288c396c83318f4ad92b6320d9d8