### PR TITLE
Fix auto pitch fallback for low zoom levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -8382,13 +8382,14 @@ function makePosts(){
     }
 
     function getAutoPitchForZoom(zoom){
-      if(!Number.isFinite(zoom) || zoom <= AUTO_PITCH_START_ZOOM){
+      const numericZoom = Number.isFinite(zoom) ? zoom : Number(zoom);
+      if(!Number.isFinite(numericZoom) || numericZoom <= AUTO_PITCH_START_ZOOM){
         return AUTO_PITCH_START_DEG;
       }
-      if(zoom >= AUTO_PITCH_END_ZOOM){
+      if(numericZoom >= AUTO_PITCH_END_ZOOM){
         return AUTO_PITCH_END_DEG;
       }
-      const progress = (zoom - AUTO_PITCH_START_ZOOM) / (AUTO_PITCH_END_ZOOM - AUTO_PITCH_START_ZOOM);
+      const progress = (numericZoom - AUTO_PITCH_START_ZOOM) / (AUTO_PITCH_END_ZOOM - AUTO_PITCH_START_ZOOM);
       return AUTO_PITCH_START_DEG + (AUTO_PITCH_END_DEG - AUTO_PITCH_START_DEG) * progress;
     }
 


### PR DESCRIPTION
## Summary
- sanitize the auto pitch helper to fall back to the start pitch when the zoom value is non-finite or below the easing range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2ecf1ab08331aa273459dd372260