### PR TITLE
Adjust balloon max zoom threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -6267,7 +6267,7 @@ if (typeof slugify !== 'function') {
         const BALLOON_IMAGE_ID = 'seed-balloon-icon';
         const BALLOON_IMAGE_URL = 'assets/balloons/balloons-icon-16185.webp';
         const BALLOON_MIN_ZOOM = 0;
-        const BALLOON_MAX_ZOOM = 8;
+        const BALLOON_MAX_ZOOM = 7.99;
         let balloonLayersVisible = true;
 
         function ensureBalloonIconImage(mapInstance){


### PR DESCRIPTION
## Summary
- limit balloon layer visibility to zoom levels below 8 so markers own zoom threshold remains exclusive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd307d93808331a350909aff1d1995