### PR TITLE
Manage marker label composites by viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -5730,7 +5730,81 @@ if (typeof slugify !== 'function') {
   const MARKER_LABEL_COMPOSITE_PREFIX = 'marker-label-composite-';
   const markerLabelCompositeStore = new Map();
   const markerLabelCompositePending = new Map();
+  const MARKER_LABEL_COMPOSITE_LIMIT = 900;
   let markerLabelPillImagePromise = null;
+
+  function nowTimestamp(){
+    try{
+      if(typeof performance !== 'undefined' && typeof performance.now === 'function'){
+        return performance.now();
+      }
+    }catch(err){}
+    return Date.now();
+  }
+
+  function collectActiveCompositeEntries(mapInstance){
+    const entries = [];
+    if(!mapInstance) return entries;
+    markerLabelCompositeStore.forEach((meta, spriteId) => {
+      if(!meta || !meta.image) return;
+      const compositeId = markerLabelCompositeId(spriteId);
+      let present = false;
+      if(typeof mapInstance.hasImage === 'function'){
+        try{ present = !!mapInstance.hasImage(compositeId); }
+        catch(err){ present = false; }
+      }
+      if(!present) return;
+      entries.push({
+        spriteId,
+        compositeId,
+        priority: Boolean(meta.priority),
+        lastUsed: Number.isFinite(meta.lastUsed) ? meta.lastUsed : 0
+      });
+    });
+    return entries;
+  }
+
+  function enforceMarkerLabelCompositeBudget(mapInstance, options = {}){
+    if(!mapInstance || !MARKER_LABEL_COMPOSITE_LIMIT || MARKER_LABEL_COMPOSITE_LIMIT <= 0){
+      return;
+    }
+    if(typeof mapInstance.removeImage !== 'function'){
+      return;
+    }
+    const { keep = [], reserve = 0 } = options || {};
+    const keepList = Array.isArray(keep) ? keep : [keep];
+    const keepSet = new Set(keepList.filter(Boolean));
+    const entries = collectActiveCompositeEntries(mapInstance);
+    if(!entries.length){
+      return;
+    }
+    const effectiveLimit = Math.max(0, MARKER_LABEL_COMPOSITE_LIMIT - Math.max(0, reserve));
+    if(entries.length <= effectiveLimit){
+      return;
+    }
+    entries.forEach(entry => {
+      entry.keep = keepSet.has(entry.spriteId);
+    });
+    entries.sort((a, b) => {
+      if(a.keep !== b.keep){
+        return a.keep ? -1 : 1;
+      }
+      if(a.priority !== b.priority){
+        return a.priority ? -1 : 1;
+      }
+      return (b.lastUsed || 0) - (a.lastUsed || 0);
+    });
+    entries.slice(effectiveLimit).forEach(entry => {
+      if(keepSet.has(entry.spriteId)) return;
+      markerLabelCompositeStore.delete(entry.spriteId);
+      markerLabelCompositePending.delete(entry.spriteId);
+      try{
+        if(typeof mapInstance.hasImage === 'function' && mapInstance.hasImage(entry.compositeId)){
+          mapInstance.removeImage(entry.compositeId);
+        }
+      }catch(err){}
+    });
+  }
 
   function loadMarkerLabelImage(url){
     return new Promise((resolve, reject) => {
@@ -5771,23 +5845,28 @@ if (typeof slugify !== 'function') {
     return `${MARKER_LABEL_COMPOSITE_PREFIX}${spriteId}`;
   }
 
-  async function ensureMarkerLabelComposite(mapInstance, labelSpriteId, iconId, labelLine1, labelLine2, isMulti){
+  async function ensureMarkerLabelComposite(mapInstance, labelSpriteId, iconId, labelLine1, labelLine2, isMulti, options = {}){
     if(!mapInstance || !labelSpriteId){
       return null;
     }
+    const { priority = false } = options || {};
     const compositeId = markerLabelCompositeId(labelSpriteId);
     const meta = markerLabelCompositeStore.get(labelSpriteId) || {};
     meta.iconId = iconId || meta.iconId || '';
     meta.labelLine1 = labelLine1 ?? meta.labelLine1 ?? '';
     meta.labelLine2 = labelLine2 ?? meta.labelLine2 ?? '';
     meta.isMulti = Boolean(isMulti ?? meta.isMulti);
+    meta.priority = Boolean(priority);
+    meta.lastUsed = nowTimestamp();
     markerLabelCompositeStore.set(labelSpriteId, meta);
     if(mapInstance.hasImage?.(compositeId)){
       return compositeId;
     }
     if(meta.image){
       try{
+        enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId], reserve: 1 });
         mapInstance.addImage(compositeId, meta.image, meta.options || {});
+        enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId] });
         return compositeId;
       }catch(err){
         console.error(err);
@@ -5889,8 +5968,10 @@ if (typeof slugify !== 'function') {
         return null;
       }
       try{
+        enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId], reserve: 1 });
         mapInstance.addImage(compositeId, imageData, options);
         markerLabelCompositeStore.set(labelSpriteId, Object.assign(meta, { image: imageData, options }));
+        enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId] });
         return compositeId;
       }catch(err){
         console.error(err);
@@ -5907,16 +5988,42 @@ if (typeof slugify !== 'function') {
     if(!mapInstance){
       return;
     }
+    const entries = [];
     markerLabelCompositeStore.forEach((entry, spriteId) => {
       if(!entry || !entry.image){
         return;
       }
-      const compositeId = markerLabelCompositeId(spriteId);
+      entries.push({
+        spriteId,
+        compositeId: markerLabelCompositeId(spriteId),
+        image: entry.image,
+        options: entry.options || {},
+        priority: Boolean(entry.priority),
+        lastUsed: Number.isFinite(entry.lastUsed) ? entry.lastUsed : 0
+      });
+    });
+    entries.sort((a, b) => {
+      if(a.priority !== b.priority){
+        return a.priority ? -1 : 1;
+      }
+      if(a.lastUsed !== b.lastUsed){
+        return (b.lastUsed || 0) - (a.lastUsed || 0);
+      }
+      return a.spriteId.localeCompare(b.spriteId);
+    });
+    entries.forEach(entry => {
+      let already = false;
+      if(typeof mapInstance.hasImage === 'function'){
+        try{ already = !!mapInstance.hasImage(entry.compositeId); }
+        catch(err){ already = false; }
+      }
+      if(already){
+        return;
+      }
       try{
-        if(mapInstance.hasImage?.(compositeId)){
-          return;
-        }
-        mapInstance.addImage(compositeId, entry.image, entry.options || {});
+        enforceMarkerLabelCompositeBudget(mapInstance, { keep: [entry.spriteId], reserve: 1 });
+        mapInstance.addImage(entry.compositeId, entry.image, entry.options || {});
+        enforceMarkerLabelCompositeBudget(mapInstance, { keep: [entry.spriteId] });
       }catch(err){
         console.error(err);
       }
@@ -7205,7 +7312,7 @@ function mulberry32(a){ return function(){var t=a+=0x6D2B79F5; t=Math.imul(t^t>>
         if(e.id.startsWith(MARKER_LABEL_COMPOSITE_PREFIX)){
           const spriteId = e.id.slice(MARKER_LABEL_COMPOSITE_PREFIX.length);
           const meta = markerLabelCompositeStore.get(spriteId) || {};
-          ensureMarkerLabelComposite(mapInstance, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti);
+          ensureMarkerLabelComposite(mapInstance, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti, { priority: meta.priority });
           return;
         }
         addIcon(e.id);
@@ -8226,6 +8333,30 @@ function makePosts(){
       if(!Number.isFinite(west) || !Number.isFinite(east) || !Number.isFinite(south) || !Number.isFinite(north)){
         return null;
       }
+      return { west, east, south, north };
+    }
+
+    function expandBounds(bounds, padding = {}){
+      const normalized = normalizeBounds(bounds);
+      if(!normalized) return null;
+      let latPad;
+      let lngPad;
+      if(typeof padding === 'number'){
+        latPad = lngPad = padding;
+      } else {
+        const latCandidate = padding.lat ?? padding.latitude ?? padding.y ?? padding.vertical;
+        const lngCandidate = padding.lng ?? padding.longitude ?? padding.x ?? padding.horizontal;
+        latPad = Number.isFinite(latCandidate) ? latCandidate : 0.25;
+        lngPad = Number.isFinite(lngCandidate) ? lngCandidate : 0.25;
+      }
+      latPad = Math.max(0, latPad);
+      lngPad = Math.max(0, lngPad);
+      let { west, east, south, north } = normalized;
+      west = Math.max(-180, west - lngPad);
+      east = Math.min(180, east + lngPad);
+      const clampLat = (value) => Math.max(-85, Math.min(85, value));
+      south = clampLat(south - latPad);
+      north = clampLat(north + latPad);
       return { west, east, south, north };
     }
 
@@ -10467,7 +10598,7 @@ if (!map.__pillHooksInstalled) {
             const spriteId = evt.id.slice(MARKER_LABEL_COMPOSITE_PREFIX.length);
             const meta = markerLabelCompositeStore.get(spriteId) || {};
             try{
-              ensureMarkerLabelComposite(map, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti);
+              ensureMarkerLabelComposite(map, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti, { priority: meta.priority });
             }catch(err){}
           }
         };
@@ -10978,21 +11109,62 @@ if (!map.__pillHooksInstalled) {
       }
       if(typeof ensureMarkerLabelComposite === 'function'){
         const spriteMeta = new Map();
+        const rawBounds = typeof map.getBounds === 'function' ? normalizeBounds(map.getBounds()) : null;
+        const priorityBounds = rawBounds ? expandBounds(rawBounds, { lat: 0.35, lng: 0.35 }) : null;
         postsData.features.forEach(feature => {
           if(!feature || !feature.properties) return;
           const props = feature.properties;
           const spriteId = props.labelSpriteId;
           if(!spriteId || spriteMeta.has(spriteId)) return;
+          const coords = Array.isArray(feature.geometry && feature.geometry.coordinates)
+            ? feature.geometry.coordinates
+            : null;
+          let inView = false;
+          if(coords && coords.length >= 2 && priorityBounds){
+            const [lng, lat] = coords;
+            if(Number.isFinite(lng) && Number.isFinite(lat)){
+              inView = pointWithinBounds(lng, lat, priorityBounds);
+            }
+          }
+          const existing = markerLabelCompositeStore.get(spriteId) || {};
+          const stored = spriteMeta.get(spriteId);
           spriteMeta.set(spriteId, {
             iconId: props.sub || props.baseSub || '',
             labelLine1: props.labelLine1 || '',
             labelLine2: props.labelLine2 || '',
-            isMulti: props.multi === 1
+            isMulti: props.multi === 1,
+            priority: (stored ? stored.priority : false) || inView,
+            lastUsed: Number.isFinite(existing.lastUsed) ? existing.lastUsed : 0
           });
         });
-        await Promise.all(Array.from(spriteMeta.entries()).map(([spriteId, meta]) =>
-          ensureMarkerLabelComposite(map, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti).catch(()=>{})
+        const spriteEntries = Array.from(spriteMeta.entries());
+        spriteEntries.sort((a, b) => {
+          const aMeta = a[1] || {};
+          const bMeta = b[1] || {};
+          const aPriority = aMeta.priority ? 1 : 0;
+          const bPriority = bMeta.priority ? 1 : 0;
+          if(aPriority !== bPriority){
+            return bPriority - aPriority;
+          }
+          const aLast = Number.isFinite(aMeta.lastUsed) ? aMeta.lastUsed : 0;
+          const bLast = Number.isFinite(bMeta.lastUsed) ? bMeta.lastUsed : 0;
+          if(aLast !== bLast){
+            return bLast - aLast;
+          }
+          return String(a[0]).localeCompare(String(b[0]));
+        });
+        await Promise.all(spriteEntries.map(([spriteId, meta]) =>
+          ensureMarkerLabelComposite(
+            map,
+            spriteId,
+            meta.iconId,
+            meta.labelLine1,
+            meta.labelLine2,
+            meta.isMulti,
+            { priority: meta.priority }
+          ).catch(()=>{})
         ));
+        enforceMarkerLabelCompositeBudget(map);
       }
       ensureMarkerLabelBackground(map);
       const markerLabelBaseConditions = [


### PR DESCRIPTION
## Summary
- add marker label composite bookkeeping with timestamped priority and an enforcement budget to avoid exhausting Mapbox image slots
- prioritize composite generation for markers within the current map bounds and drop older assets when the map moves
- ensure style-missing handlers and reapply logic regenerate prioritized composites without breaking existing markers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd31aa3ebc83319f2cc73ed81dc690