### PR TITLE
Ensure markers load immediately at threshold zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -10765,6 +10765,14 @@ if (!map.__pillHooksInstalled) {
         updatePostPanel();
         applyFilters();
         updateZoomState(getZoomFromEvent());
+        if(!markersLoaded){
+          const zoomLevel = Number.isFinite(lastKnownZoom) ? lastKnownZoom : getZoomFromEvent();
+          if(Number.isFinite(zoomLevel) && zoomLevel >= MARKER_ZOOM_THRESHOLD){
+            try{ loadPostMarkers(); }catch(err){ console.error(err); }
+            markersLoaded = true;
+            window.__markersLoaded = true;
+          }
+        }
         checkLoadPosts();
       });
 


### PR DESCRIPTION
## Summary
- ensure map markers are initialized during the initial map load when the zoom level is already at or above the display threshold
- fall back to the existing zoom-based loading flow when the initial zoom is below the threshold

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3470e3d083318abfd7f4bbb0d343