### PR TITLE
Preserve marker composite metadata during eviction

### DIFF
--- a/index.html
+++ b/index.html
@@ -5796,7 +5796,16 @@ if (typeof slugify !== 'function') {
     });
     entries.slice(effectiveLimit).forEach(entry => {
       if(keepSet.has(entry.spriteId)) return;
-      markerLabelCompositeStore.delete(entry.spriteId);
+      const meta = markerLabelCompositeStore.get(entry.spriteId);
+      if(meta){
+        if(meta.image){
+          try{ delete meta.image; }catch(err){ meta.image = null; }
+        }
+        if(meta.options){
+          try{ delete meta.options; }catch(err){ meta.options = undefined; }
+        }
+        markerLabelCompositeStore.set(entry.spriteId, meta);
+      }
       markerLabelCompositePending.delete(entry.spriteId);
       try{
         if(typeof mapInstance.hasImage === 'function' && mapInstance.hasImage(entry.compositeId)){


### PR DESCRIPTION
## Summary
- stop deleting composite store entries during eviction and only remove associated Mapbox images
- retain icon and label metadata while clearing cached image data so composites can be rebuilt when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0fd15334833181abae24fc53f745