### PR TITLE
Ensure marker composites persist across map refreshes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7321,6 +7321,10 @@ function mulberry32(a){ return function(){var t=a+=0x6D2B79F5; t=Math.imul(t^t>>
         if(e.id.startsWith(MARKER_LABEL_COMPOSITE_PREFIX)){
           const spriteId = e.id.slice(MARKER_LABEL_COMPOSITE_PREFIX.length);
           const meta = markerLabelCompositeStore.get(spriteId) || {};
+          const hasLabelText = Boolean((meta.labelLine1 && meta.labelLine1.trim()) || (meta.labelLine2 && meta.labelLine2.trim()));
+          if(!hasLabelText){
+            return;
+          }
           ensureMarkerLabelComposite(mapInstance, spriteId, meta.iconId, meta.labelLine1, meta.labelLine2, meta.isMulti, { priority: meta.priority });
           return;
         }
@@ -11043,6 +11047,7 @@ if (!map.__pillHooksInstalled) {
     }
 
     let addingPostSource = false;
+    let pendingAddPostSource = false;
 
     function loadPostMarkers(){
       try{
@@ -11053,7 +11058,13 @@ if (!map.__pillHooksInstalled) {
     }
 
     async function addPostSource(){
-      if(!map || addingPostSource) return;
+      if(!map){
+        return;
+      }
+      if(addingPostSource){
+        pendingAddPostSource = true;
+        return;
+      }
       addingPostSource = true;
       try{
       const markerList = filtersInitialized && Array.isArray(filtered) ? filtered : posts;
@@ -11108,13 +11119,28 @@ if (!map.__pillHooksInstalled) {
           }
           const existing = markerLabelCompositeStore.get(spriteId) || {};
           const stored = spriteMeta.get(spriteId);
+          const iconId = props.sub || props.baseSub || '';
+          const labelLine1 = props.labelLine1 || '';
+          const labelLine2 = props.labelLine2 || '';
+          const isMulti = props.multi === 1;
+          const priority = Boolean((stored ? stored.priority : false) || inView || existing.priority);
+          const lastUsed = Number.isFinite(existing.lastUsed) ? existing.lastUsed : 0;
+          const updatedMeta = Object.assign({}, existing, {
+            iconId,
+            labelLine1,
+            labelLine2,
+            isMulti,
+            priority,
+            lastUsed
+          });
+          markerLabelCompositeStore.set(spriteId, updatedMeta);
           spriteMeta.set(spriteId, {
-            iconId: props.sub || props.baseSub || '',
-            labelLine1: props.labelLine1 || '',
-            labelLine2: props.labelLine2 || '',
-            isMulti: props.multi === 1,
-            priority: (stored ? stored.priority : false) || inView,
-            lastUsed: Number.isFinite(existing.lastUsed) ? existing.lastUsed : 0
+            iconId,
+            labelLine1,
+            labelLine2,
+            isMulti,
+            priority,
+            lastUsed
           });
         });
         const spriteEntries = Array.from(spriteMeta.entries());
@@ -11581,9 +11607,14 @@ if (!map.__pillHooksInstalled) {
         console.error('addPostSource failed', err);
       } finally {
         addingPostSource = false;
+        const shouldReplay = pendingAddPostSource;
+        pendingAddPostSource = false;
+        if(shouldReplay){
+          addPostSource();
+        }
       }
-      }
-      window.addPostSource = addPostSource;
+    }
+    window.addPostSource = addPostSource;
     function renderLists(list){
       if(spinning || !postsLoaded) return;
       const sort = currentSort;


### PR DESCRIPTION
## Summary
- queue marker source refreshes so addPostSource reruns after in-flight updates finish
- persist label/icon metadata in the composite store and avoid generating blank pill sprites on style image misses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddfc697ad08331a0e6dc129da33253