### PR TITLE
Limit eager marker label composites to budget

### DIFF
--- a/index.html
+++ b/index.html
@@ -11194,7 +11194,17 @@ if (!map.__pillHooksInstalled) {
           }
           return String(a[0]).localeCompare(String(b[0]));
         });
-        await Promise.all(spriteEntries.map(([spriteId, meta]) =>
+        const compositeSafetyBuffer = 25;
+        let eagerSpriteEntries = spriteEntries;
+        if(Number.isFinite(MARKER_LABEL_COMPOSITE_LIMIT) && MARKER_LABEL_COMPOSITE_LIMIT > 0){
+          const maxEager = Math.max(0, MARKER_LABEL_COMPOSITE_LIMIT - Math.max(0, compositeSafetyBuffer));
+          if(maxEager <= 0){
+            eagerSpriteEntries = [];
+          } else if(spriteEntries.length > maxEager){
+            eagerSpriteEntries = spriteEntries.slice(0, maxEager);
+          }
+        }
+        await Promise.all(eagerSpriteEntries.map(([spriteId, meta]) =>
           ensureMarkerLabelComposite(
             map,
             spriteId,


### PR DESCRIPTION
## Summary
- limit eager marker label composite generation to the available budget to keep active sprites within the cap
- preserve marker label metadata for lazy composite creation when Mapbox requests missing images

## Testing
- not run (manual Mapbox verification required)

------
https://chatgpt.com/codex/tasks/task_e_68de6a67f4a88331bc48ab967db37700