### PR TITLE
Fix marker visibility rounding at zoom threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -8534,7 +8534,7 @@ function makePosts(){
     function updateLayerVisibility(zoom){
       const zoomValue = Number.isFinite(zoom) ? zoom : getZoomFromEvent();
       const zoomBucket = Number.isFinite(zoomValue)
-        ? Math.floor((zoomValue + 1e-6) * ZOOM_VISIBILITY_PRECISION)
+        ? Math.round(zoomValue * ZOOM_VISIBILITY_PRECISION)
         : NaN;
       const hasBucket = Number.isFinite(zoomBucket);
       const shouldShowMarkers = hasBucket ? zoomBucket >= MARKER_VISIBILITY_BUCKET : markerLayersVisible;


### PR DESCRIPTION
## Summary
- round the zoom bucket calculation to align with the visibility threshold at zoom level 8

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6bbcbdc08331ad06ba8aa36adef4