### PR TITLE
Allow geolocate control active styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3102,11 +3102,10 @@ body.filters-active #filterBtn{
   background-color:#ffffff;
   color:#000000;
 }
-#memberPanel .map-control-row .mapboxgl-ctrl-geolocate button,
+#memberPanel .map-control-row .mapboxgl-ctrl-geolocate button:not(.mapboxgl-ctrl-geolocate-active):not(.mapboxgl-ctrl-geolocate-loading),
 #memberPanel .map-control-row .mapboxgl-ctrl-compass button{
-  background-color:#ffffff !important;
-  background-image:none !important;
-  box-shadow:none !important;
+  background-color:#ffffff;
+  box-shadow:none;
 }
 #memberPanel .map-control-row .mapboxgl-ctrl-geolocate button svg,
 #memberPanel .map-control-row .mapboxgl-ctrl-compass button svg{
@@ -3117,19 +3116,26 @@ body.filters-active #filterBtn{
   width:35px;
   height:35px;
   border-radius:8px;
-  background-color:#ffffff;
   border:1px solid rgba(0,0,0,0.15);
   box-shadow:none;
+}
+
+.map-control-row .mapboxgl-ctrl-geolocate button:not(.mapboxgl-ctrl-geolocate-active):not(.mapboxgl-ctrl-geolocate-loading),
+.map-control-row .mapboxgl-ctrl-compass button{
+  background-color:#ffffff;
 }
 
 .mapboxgl-ctrl-geolocate button,
 .mapboxgl-ctrl-compass button{
   width:35px !important;
   height:35px !important;
-  background-color:#ffffff !important;
   border-radius:8px !important;
   border:1px solid rgba(0,0,0,0.15) !important;
   box-shadow:none !important;
+}
+
+.mapboxgl-ctrl-geolocate button:not(.mapboxgl-ctrl-geolocate-active):not(.mapboxgl-ctrl-geolocate-loading){
+  background-color:#ffffff;
 }
 
 .map-control-row .mapboxgl-ctrl-geolocate button:hover,


### PR DESCRIPTION
## Summary
- scope white background styling on the geolocate button to its idle state so Mapbox can apply active/loading visuals
- preserve existing sizing and border rules without suppressing Mapbox's built-in icon and animation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6c1075a08331b2c0e1203ca7495f