### PR TITLE
Ensure spin startup preserves default pitch

### DIFF
--- a/index.html
+++ b/index.html
@@ -10856,7 +10856,8 @@ if (!map.__pillHooksInstalled) {
       if(fromCurrent){
         requestAnimationFrame(step);
       }else{
-        map.easeTo({center:[0,0], zoom:startZoom, pitch:0, essential:true});
+        const targetPitch = Number.isFinite(startPitch) ? startPitch : LEGACY_DEFAULT_PITCH;
+        map.easeTo({center:[0,0], zoom:startZoom, pitch:targetPitch, essential:true});
         map.once('moveend', () => requestAnimationFrame(step));
       }
     }


### PR DESCRIPTION
## Summary
- preserve the default map pitch when auto-spin recenters the globe

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de64dbca7c8331bedfa1c2bcac27fc