### PR TITLE
Use floor-based zoom bucket for marker visibility threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -8540,7 +8540,7 @@ function makePosts(){
     function updateLayerVisibility(zoom){
       const zoomValue = Number.isFinite(zoom) ? zoom : getZoomFromEvent();
       const zoomBucket = Number.isFinite(zoomValue)
-        ? Math.round(zoomValue * ZOOM_VISIBILITY_PRECISION)
+        ? Math.floor((zoomValue + 1e-6) * ZOOM_VISIBILITY_PRECISION)
         : NaN;
       const hasBucket = Number.isFinite(zoomBucket);
       const shouldShowMarkers = hasBucket ? zoomBucket >= MARKER_VISIBILITY_BUCKET : markerLayersVisible;


### PR DESCRIPTION
## Summary
- revert the zoom bucket calculation to a floor-based approach with a small epsilon so the 8000 bucket is only reached when zoom ≥ 8
- keep existing marker versus balloon visibility comparisons to avoid gaps before marker layers render

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de71709c948331b9c953af0b8816cb