### PR TITLE
Set default map pitch to zero

### DIFF
--- a/index.html
+++ b/index.html
@@ -6246,7 +6246,7 @@ if (typeof slugify !== 'function') {
   window.callWhenDefined = window.callWhenDefined || callWhenDefined;
 
   let startPitch, startBearing, logoEls = [], geocoder;
-  const LEGACY_DEFAULT_PITCH = 90;
+  const LEGACY_DEFAULT_PITCH = 0;
   const geocoders = [];
   let lastGeocoderProximity = null;
 


### PR DESCRIPTION
## Summary
- set the legacy default map pitch to 0 degrees so first-time visitors start flat

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deac361944833199e82647cd4c9e11