### PR TITLE
Remove marker label composite limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -5733,7 +5733,7 @@ if (typeof slugify !== 'function') {
   const MARKER_LABEL_COMPOSITE_PREFIX = 'marker-label-composite-';
   const markerLabelCompositeStore = new Map();
   const markerLabelCompositePending = new Map();
-  const MARKER_LABEL_COMPOSITE_LIMIT = 900;
+  const MARKER_LABEL_COMPOSITE_LIMIT = Infinity;
   let markerLabelPillImagePromise = null;
 
   function nowTimestamp(){


### PR DESCRIPTION
## Summary
- allow unlimited marker label composites by setting the cache limit constant to Infinity so sprites are never evicted.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7db4b1748331b1c7a3cc6f672805