### PR TITLE
Fix welcome message editor toolbar focus behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -14363,10 +14363,12 @@ document.addEventListener('DOMContentLoaded', () => {
     hidden.value = hidden.value || placeholder;
     editor.innerHTML = hidden.value;
     editor.addEventListener('input', () => hidden.value = editor.innerHTML);
-document.querySelectorAll('.wysiwyg-toolbar button').forEach(btn => {
-      btn.addEventListener('click', () => {
-        document.execCommand(btn.dataset.command, false, null);
+    document.querySelectorAll('.wysiwyg-toolbar button').forEach(btn => {
+      btn.addEventListener('mousedown', (event) => {
+        event.preventDefault();
         editor.focus();
+        document.execCommand(btn.dataset.command, false, null);
+        hidden.value = editor.innerHTML;
       });
     });
   }


### PR DESCRIPTION
## Summary
- switch the welcome message editor toolbar buttons to respond on mousedown so they do not take focus
- focus the editor before running the formatting command and immediately sync the hidden textarea value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deb5435aa883318cc532b74dc0ea17