### PR TITLE
Reduce location radius to stay within city limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -7682,7 +7682,7 @@ function uniqueTitle(seed, cityName, idx){
   }
 
   function createRandomLocation(city, baseLng=0, baseLat=0, options={}){
-    const defaultRadius = 0.25;
+    const defaultRadius = 0.05;
     const radius = Number.isFinite(options.radius) ? Math.max(options.radius, 0) : defaultRadius;
     const coord = safeCoordinate(city, baseLng, baseLat, radius);
     const venueName = options.name || city || 'Event Venue';
@@ -8024,7 +8024,7 @@ function makePosts(){
     const offset = 1 + i%30;
     const date = new Date(todayTas);
     date.setDate(date.getDate() + (i<50 ? -offset : offset));
-    const location = createRandomLocation(tasCity, tasLng, tasLat, { radius: 0.1 });
+    const location = createRandomLocation(tasCity, tasLng, tasLat, { radius: 0.05 });
     pushPost({
       id,
       title,


### PR DESCRIPTION
## Summary
- decrease the default random location radius so generated venues stay closer to their cities
- tighten the Hobart, Tasmania radius to keep those posts within the local area

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc11e91888331bf43c4e925b043ce