### PR TITLE
Improve map marker highlighting and overlay styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
       z-index: 30;
     }
     .mapmarker-overlay.is-card-visible > .mapmarker-container{
-      display: none;
+      opacity: 1;
     }
     .mapmarker-overlay.is-card-visible{
       pointer-events: auto;
@@ -140,7 +140,6 @@
     .map-card--popup{
       background-color: #2e3a72;
     }
-    .post-card.is-map-highlight,
     .open-post .post-header.is-map-highlight{
       background-color: #2e3a72;
     }
@@ -3369,6 +3368,9 @@ body.filters-active #filterBtn{
   border-radius:0;
   border-bottom:1px solid rgba(255,255,255,0.12);
 }
+.post-board .post-card.is-map-highlight{
+  background-color:#2e3a72;
+}
 .post-board .post-card:last-child,
 .post-board .open-post:last-child{border-bottom:none;}
 .post-board > *:last-child{margin-bottom:0 !important;}
@@ -5009,20 +5011,31 @@ if (typeof slugify !== 'function') {
 // === 150x40 pill provider (sprite id: marker-label-bg) ===
 (function(){
   const PILL_ID = 'marker-label-bg';
+  const ACCENT_ID = `${PILL_ID}--accent`;
   const PILL_IMAGE_URL = 'assets/icons-30/150x40 pill 99.webp';
-  let cachedImage = null;
+  let cachedImages = null;
   let loadingImage = null;
   const pendingMaps = new Set();
 
   function applyImageToMap(map){
-    if(!map || typeof map.hasImage !== 'function' || !cachedImage){
+    if(!map || typeof map.hasImage !== 'function' || !cachedImages){
       return;
     }
     try{
       if(map.hasImage(PILL_ID)){
         try{ map.removeImage(PILL_ID); }catch(e){}
       }
-      map.addImage(PILL_ID, cachedImage, { pixelRatio: 1 });
+      if(map.hasImage(ACCENT_ID)){
+        try{ map.removeImage(ACCENT_ID); }catch(e){}
+      }
+      const baseImage = cachedImages.base || cachedImages.accent;
+      if(baseImage){
+        map.addImage(PILL_ID, baseImage, { pixelRatio: 1 });
+      }
+      const accentImage = cachedImages.accent || cachedImages.base;
+      if(accentImage){
+        map.addImage(ACCENT_ID, accentImage, { pixelRatio: 1 });
+      }
     }catch(e){ /* silent */ }
   }
 
@@ -5031,7 +5044,33 @@ if (typeof slugify !== 'function') {
       return;
     }
     if(loadingImage.complete && loadingImage.naturalWidth > 0){
-      cachedImage = loadingImage;
+      const width = loadingImage.naturalWidth || loadingImage.width || 150;
+      const height = loadingImage.naturalHeight || loadingImage.height || 40;
+      const tintImage = (color, alpha = 1)=>{
+        try{
+          const canvas = document.createElement('canvas');
+          canvas.width = Math.max(1, Math.round(width));
+          canvas.height = Math.max(1, Math.round(height));
+          const ctx = canvas.getContext('2d');
+          if(!ctx){
+            return null;
+          }
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.drawImage(loadingImage, 0, 0, canvas.width, canvas.height);
+          ctx.globalCompositeOperation = 'source-atop';
+          ctx.globalAlpha = alpha;
+          ctx.fillStyle = color;
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.globalAlpha = 1;
+          ctx.globalCompositeOperation = 'source-over';
+          return canvas;
+        }catch(err){
+          return null;
+        }
+      };
+      const base = tintImage('rgba(0,0,0,1)', 0.9) || loadingImage;
+      const accent = tintImage('#2e3a72', 1) || loadingImage;
+      cachedImages = { base, accent };
       pendingMaps.forEach((map)=>applyImageToMap(map));
     }
     pendingMaps.clear();
@@ -5058,7 +5097,7 @@ if (typeof slugify !== 'function') {
       if(!map || typeof map.hasImage !== 'function'){
         return;
       }
-      if(cachedImage){
+      if(cachedImages){
         applyImageToMap(map);
         return;
       }
@@ -5748,7 +5787,9 @@ if (typeof slugify !== 'function') {
   }
 
   const MARKER_LABEL_BG_ID = 'marker-label-bg';
+  const MARKER_LABEL_BG_ACCENT_ID = `${MARKER_LABEL_BG_ID}--accent`;
   const MARKER_LABEL_COMPOSITE_PREFIX = 'marker-label-composite-';
+  const MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX = '--accent';
   const markerLabelCompositeStore = new Map();
   const markerLabelCompositePending = new Map();
   const MARKER_LABEL_COMPOSITE_LIMIT = Infinity;
@@ -5825,12 +5866,24 @@ if (typeof slugify !== 'function') {
         if(meta.options){
           try{ delete meta.options; }catch(err){ meta.options = undefined; }
         }
+        if(meta.highlightImage){
+          try{ delete meta.highlightImage; }catch(err){ meta.highlightImage = null; }
+        }
+        if(meta.highlightOptions){
+          try{ delete meta.highlightOptions; }catch(err){ meta.highlightOptions = undefined; }
+        }
         markerLabelCompositeStore.set(entry.spriteId, meta);
       }
       markerLabelCompositePending.delete(entry.spriteId);
       try{
-        if(typeof mapInstance.hasImage === 'function' && mapInstance.hasImage(entry.compositeId)){
-          mapInstance.removeImage(entry.compositeId);
+        if(typeof mapInstance.hasImage === 'function'){
+          if(mapInstance.hasImage(entry.compositeId)){
+            mapInstance.removeImage(entry.compositeId);
+          }
+          const highlightId = `${entry.compositeId}${MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX}`;
+          if(mapInstance.hasImage(highlightId)){
+            mapInstance.removeImage(highlightId);
+          }
         }
       }catch(err){}
     });
@@ -5892,10 +5945,17 @@ if (typeof slugify !== 'function') {
     if(mapInstance.hasImage?.(compositeId)){
       return compositeId;
     }
-    if(meta.image){
+    if(meta.image && meta.highlightImage){
       try{
         enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId], reserve: 1 });
+        try{ if(mapInstance.hasImage?.(compositeId)) mapInstance.removeImage(compositeId); }catch(err){}
         mapInstance.addImage(compositeId, meta.image, meta.options || {});
+        const highlightId = `${compositeId}${MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX}`;
+        if(meta.highlightImage){
+          try{ if(mapInstance.hasImage?.(highlightId)) mapInstance.removeImage(highlightId); }catch(err){}
+          try{ mapInstance.addImage(highlightId, meta.highlightImage, meta.highlightOptions || meta.options || {}); }
+          catch(err){ console.error(err); }
+        }
         enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId] });
         return compositeId;
       }catch(err){
@@ -5922,28 +5982,9 @@ if (typeof slugify !== 'function') {
       }
       const rawWidth = pillImg.naturalWidth || pillImg.width || markerLabelBackgroundWidthPx;
       const rawHeight = pillImg.naturalHeight || pillImg.height || markerLabelBackgroundHeightPx;
-      const canvas = document.createElement('canvas');
-      canvas.width = Math.max(1, Math.round(Number.isFinite(rawWidth) && rawWidth > 0 ? rawWidth : markerLabelBackgroundWidthPx));
-      canvas.height = Math.max(1, Math.round(Number.isFinite(rawHeight) && rawHeight > 0 ? rawHeight : markerLabelBackgroundHeightPx));
-      const ctx = canvas.getContext('2d');
-      if(!ctx){
-        return null;
-      }
-      const canvasWidth = canvas.width;
-      const canvasHeight = canvas.height;
-      ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-      ctx.drawImage(pillImg, 0, 0, canvasWidth, canvasHeight);
+      const canvasWidth = Math.max(1, Math.round(Number.isFinite(rawWidth) && rawWidth > 0 ? rawWidth : markerLabelBackgroundWidthPx));
+      const canvasHeight = Math.max(1, Math.round(Number.isFinite(rawHeight) && rawHeight > 0 ? rawHeight : markerLabelBackgroundHeightPx));
       const pixelRatio = canvasWidth / markerLabelBackgroundWidthPx;
-      if(iconImg){
-        const iconSizePx = markerIconBaseSizePx * markerIconSize * pixelRatio;
-        const destX = markerLabelMarkerInsetPx * pixelRatio;
-        const destY = (canvasHeight - iconSizePx) / 2;
-        try{
-          ctx.drawImage(iconImg, destX, destY, iconSizePx, iconSizePx);
-        }catch(err){
-          console.error(err);
-        }
-      }
       const labelLines = [];
       const line1 = (meta.labelLine1 || '').trim();
       const line2 = (meta.labelLine2 || '').trim();
@@ -5953,54 +5994,107 @@ if (typeof slugify !== 'function') {
       if(line2){
         labelLines.push({ text: line2, color: meta.isMulti ? '#d0d0d0' : '#ffffff' });
       }
-      if(labelLines.length){
-        const fontSizePx = markerLabelTextSize * pixelRatio;
-        const lineGapPx = Math.max(0, (markerLabelTextLineHeight - 1) * markerLabelTextSize * pixelRatio);
-        const totalHeight = labelLines.length * fontSizePx + Math.max(0, labelLines.length - 1) * lineGapPx;
-        let textY = (canvasHeight - totalHeight) / 2;
-        if(!Number.isFinite(textY) || textY < 0){
-          textY = 0;
-        }
-        const textX = markerLabelTextPaddingPx * pixelRatio;
-        ctx.font = `${fontSizePx}px "Open Sans", "Arial Unicode MS Regular", sans-serif`;
-        ctx.textBaseline = 'top';
-        ctx.textAlign = 'left';
-        ctx.shadowColor = 'rgba(0,0,0,0.4)';
-        ctx.shadowBlur = 2 * pixelRatio;
-        ctx.shadowOffsetX = 0;
-        ctx.shadowOffsetY = 1 * pixelRatio;
-        labelLines.forEach(line => {
-          ctx.fillStyle = line.color;
+      const drawForeground = (ctx)=>{
+        if(iconImg){
+          const iconSizePx = markerIconBaseSizePx * markerIconSize * pixelRatio;
+          const destX = markerLabelMarkerInsetPx * pixelRatio;
+          const destY = (canvasHeight - iconSizePx) / 2;
           try{
-            ctx.fillText(line.text, textX, textY);
+            ctx.drawImage(iconImg, destX, destY, iconSizePx, iconSizePx);
           }catch(err){
             console.error(err);
           }
-          textY += fontSizePx + lineGapPx;
-        });
-        ctx.shadowColor = 'transparent';
+        }
+        if(labelLines.length){
+          const fontSizePx = markerLabelTextSize * pixelRatio;
+          const lineGapPx = Math.max(0, (markerLabelTextLineHeight - 1) * markerLabelTextSize * pixelRatio);
+          const totalHeight = labelLines.length * fontSizePx + Math.max(0, labelLines.length - 1) * lineGapPx;
+          let textY = (canvasHeight - totalHeight) / 2;
+          if(!Number.isFinite(textY) || textY < 0){
+            textY = 0;
+          }
+          const textX = markerLabelTextPaddingPx * pixelRatio;
+          ctx.font = `${fontSizePx}px "Open Sans", "Arial Unicode MS Regular", sans-serif`;
+          ctx.textBaseline = 'top';
+          ctx.textAlign = 'left';
+          ctx.shadowColor = 'rgba(0,0,0,0.4)';
+          ctx.shadowBlur = 2 * pixelRatio;
+          ctx.shadowOffsetX = 0;
+          ctx.shadowOffsetY = 1 * pixelRatio;
+          labelLines.forEach(line => {
+            ctx.fillStyle = line.color;
+            try{
+              ctx.fillText(line.text, textX, textY);
+            }catch(err){
+              console.error(err);
+            }
+            textY += fontSizePx + lineGapPx;
+          });
+          ctx.shadowColor = 'transparent';
+        }
+      };
+      const buildComposite = (tintColor, tintAlpha = 1)=>{
+        const canvas = document.createElement('canvas');
+        canvas.width = canvasWidth;
+        canvas.height = canvasHeight;
+        const ctx = canvas.getContext('2d');
+        if(!ctx){
+          return null;
+        }
+        ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+        ctx.drawImage(pillImg, 0, 0, canvasWidth, canvasHeight);
+        if(tintColor){
+          ctx.globalCompositeOperation = 'source-atop';
+          ctx.globalAlpha = tintAlpha;
+          ctx.fillStyle = tintColor;
+          ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+          ctx.globalAlpha = 1;
+          ctx.globalCompositeOperation = 'source-over';
+        }
+        drawForeground(ctx);
+        let imageData = null;
+        try{
+          imageData = ctx.getImageData(0, 0, canvasWidth, canvasHeight);
+        }catch(err){
+          console.error(err);
+          imageData = null;
+        }
+        if(!imageData){
+          return null;
+        }
+        const options = { pixelRatio: Number.isFinite(pixelRatio) && pixelRatio > 0 ? pixelRatio : 1 };
+        return { image: imageData, options };
+      };
+      const baseComposite = buildComposite('rgba(0,0,0,1)', 0.9);
+      const accentComposite = buildComposite('#2e3a72', 1);
+      if(!baseComposite){
+        return null;
       }
-      const options = { pixelRatio: Number.isFinite(pixelRatio) && pixelRatio > 0 ? pixelRatio : 1 };
+      const highlightComposite = accentComposite || baseComposite;
       try{
         if(mapInstance.hasImage?.(compositeId)){
           mapInstance.removeImage(compositeId);
         }
+        const highlightId = `${compositeId}${MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX}`;
+        if(mapInstance.hasImage?.(highlightId)){
+          mapInstance.removeImage(highlightId);
+        }
       }catch(err){
         console.error(err);
-      }
-      let imageData = null;
-      try{
-        imageData = ctx.getImageData(0, 0, canvasWidth, canvasHeight);
-      }catch(err){
-        console.error(err);
-      }
-      if(!imageData){
-        return null;
       }
       try{
         enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId], reserve: 1 });
-        mapInstance.addImage(compositeId, imageData, options);
-        markerLabelCompositeStore.set(labelSpriteId, Object.assign(meta, { image: imageData, options }));
+        mapInstance.addImage(compositeId, baseComposite.image, baseComposite.options || {});
+        if(highlightComposite && highlightComposite.image){
+          const highlightId = `${compositeId}${MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX}`;
+          mapInstance.addImage(highlightId, highlightComposite.image, highlightComposite.options || baseComposite.options || {});
+        }
+        markerLabelCompositeStore.set(labelSpriteId, Object.assign(meta, {
+          image: baseComposite.image,
+          options: baseComposite.options,
+          highlightImage: highlightComposite.image,
+          highlightOptions: highlightComposite.options || baseComposite.options
+        }));
         enforceMarkerLabelCompositeBudget(mapInstance, { keep: [labelSpriteId] });
         return compositeId;
       }catch(err){
@@ -6028,6 +6122,8 @@ if (typeof slugify !== 'function') {
         compositeId: markerLabelCompositeId(spriteId),
         image: entry.image,
         options: entry.options || {},
+        highlightImage: entry.highlightImage,
+        highlightOptions: entry.highlightOptions || entry.options || {},
         priority: Boolean(entry.priority),
         lastUsed: Number.isFinite(entry.lastUsed) ? entry.lastUsed : 0
       });
@@ -6053,6 +6149,12 @@ if (typeof slugify !== 'function') {
       try{
         enforceMarkerLabelCompositeBudget(mapInstance, { keep: [entry.spriteId], reserve: 1 });
         mapInstance.addImage(entry.compositeId, entry.image, entry.options || {});
+        if(entry.highlightImage){
+          const highlightId = `${entry.compositeId}${MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX}`;
+          try{ if(mapInstance.hasImage?.(highlightId)) mapInstance.removeImage(highlightId); }catch(err){}
+          try{ mapInstance.addImage(highlightId, entry.highlightImage, entry.highlightOptions || entry.options || {}); }
+          catch(err){ console.error(err); }
+        }
         enforceMarkerLabelCompositeBudget(mapInstance, { keep: [entry.spriteId] });
       }catch(err){
         console.error(err);
@@ -6788,6 +6890,57 @@ if (typeof slugify !== 'function') {
     let postSourceEventsBound = false;
     let touchMarker = null;
     let activePostId = null;
+    let markerFeatureIndex = new Map();
+    let lastHighlightedPostIds = [];
+    let highlightedFeatureKeys = [];
+    function updateMapFeatureHighlights(postIds){
+      const normalized = Array.from(new Set((Array.isArray(postIds) ? postIds : [postIds])
+        .filter(id => id !== undefined && id !== null)
+        .map(id => String(id))
+        .filter(Boolean)));
+      lastHighlightedPostIds = normalized;
+      if(!map || typeof map.setFeatureState !== 'function'){
+        if(!normalized.length){
+          highlightedFeatureKeys = [];
+        }
+        return;
+      }
+      if(!normalized.length){
+        highlightedFeatureKeys.forEach(entry => {
+          try{ map.setFeatureState({ source: entry.source, id: entry.id }, { isHighlighted: false }); }
+          catch(err){}
+        });
+        highlightedFeatureKeys = [];
+        return;
+      }
+      const nextEntries = [];
+      const nextKeys = new Set();
+      normalized.forEach(id => {
+        const entries = markerFeatureIndex instanceof Map ? markerFeatureIndex.get(id) : null;
+        if(!entries || !entries.length) return;
+        entries.forEach(entry => {
+          if(!entry) return;
+          const source = entry.source || 'posts';
+          const featureId = entry.id;
+          if(featureId === undefined || featureId === null) return;
+          const compositeKey = `${source}::${featureId}`;
+          if(nextKeys.has(compositeKey)) return;
+          nextKeys.add(compositeKey);
+          nextEntries.push({ source, id: featureId });
+        });
+      });
+      highlightedFeatureKeys.forEach(entry => {
+        const compositeKey = `${entry.source}::${entry.id}`;
+        if(nextKeys.has(compositeKey)) return;
+        try{ map.setFeatureState({ source: entry.source, id: entry.id }, { isHighlighted: false }); }
+        catch(err){}
+      });
+      nextEntries.forEach(entry => {
+        try{ map.setFeatureState({ source: entry.source, id: entry.id }, { isHighlighted: true }); }
+        catch(err){}
+      });
+      highlightedFeatureKeys = nextEntries;
+    }
     let selectedVenueKey = null;
     const BASE_URL = (()=>{ let b = location.origin + location.pathname.split('/post/')[0]; if(!b.endsWith('/')) b+='/'; return b; })();
 
@@ -6986,20 +7139,23 @@ if (typeof slugify !== 'function') {
         el.classList.remove(markerHighlightClass);
       });
 
-      const getOverlayElement = ()=>{
-        if(hoverPopup && typeof hoverPopup.getElement === 'function'){
-          return hoverPopup.getElement();
+      const overlayEl = hoverPopup && typeof hoverPopup.getElement === 'function'
+        ? hoverPopup.getElement()
+        : null;
+      const overlayId = overlayEl && overlayEl.dataset ? String(overlayEl.dataset.id || '') : '';
+      let fallbackId = '';
+      if(!overlayId){
+        if(activePostId !== undefined && activePostId !== null){
+          fallbackId = String(activePostId);
+        } else {
+          const openEl = document.querySelector('.post-board .open-post[data-id]');
+          fallbackId = openEl && openEl.dataset ? String(openEl.dataset.id || '') : '';
         }
-        return null;
-      };
-      const overlayEl = getOverlayElement();
-      const activeId = overlayEl && overlayEl.dataset ? overlayEl.dataset.id : null;
-      if(!activeId){
-        return;
       }
-      const activeMarker = overlayEl.querySelector('.mapmarker-container');
-      if(activeMarker){
-        activeMarker.classList.add(markerHighlightClass);
+      const idsToHighlight = Array.from(new Set([overlayId, fallbackId].filter(Boolean)));
+      if(!idsToHighlight.length){
+        updateMapFeatureHighlights([]);
+        return;
       }
       const escapeAttr = (value)=> String(value).replace(/"/g, '\\"');
       const applyHighlight = (el)=>{
@@ -7010,11 +7166,17 @@ if (typeof slugify !== 'function') {
         el.classList.add(highlightClass);
         el.setAttribute('aria-selected', 'true');
       };
-      const selectorId = escapeAttr(activeId);
-      const listCard = postsWideEl ? postsWideEl.querySelector(`.post-card[data-id="${selectorId}"]`) : null;
-      applyHighlight(listCard);
-      const openHeader = document.querySelector(`.open-post[data-id="${selectorId}"] .post-header`);
-      applyHighlight(openHeader);
+      idsToHighlight.forEach(id => {
+        const selectorId = escapeAttr(id);
+        const listCard = postsWideEl ? postsWideEl.querySelector(`.post-card[data-id="${selectorId}"]`) : null;
+        applyHighlight(listCard);
+        const openHeader = document.querySelector(`.open-post[data-id="${selectorId}"] .post-header`);
+        applyHighlight(openHeader);
+        document.querySelectorAll(`.mapmarker-overlay[data-id="${selectorId}"] .mapmarker-container`).forEach(el => {
+          el.classList.add(markerHighlightClass);
+        });
+      });
+      updateMapFeatureHighlights(idsToHighlight);
     }
 
     function hashString(str){
@@ -8698,13 +8860,15 @@ function makePosts(){
     const markerDataCache = {
       signature: null,
       postsData: EMPTY_FEATURE_COLLECTION,
-      multiData: EMPTY_FEATURE_COLLECTION
+      multiData: EMPTY_FEATURE_COLLECTION,
+      featureIndex: new Map()
     };
 
     function invalidateMarkerDataCache(){
       markerDataCache.signature = null;
       markerDataCache.postsData = EMPTY_FEATURE_COLLECTION;
       markerDataCache.multiData = EMPTY_FEATURE_COLLECTION;
+      markerDataCache.featureIndex = new Map();
     }
 
     function markerSignatureForList(list){
@@ -8738,6 +8902,26 @@ function makePosts(){
       return parts.join('|');
     }
 
+    function buildMarkerFeatureIndex(postsData){
+      const index = new Map();
+      const features = Array.isArray(postsData?.features) ? postsData.features : [];
+      features.forEach(feature => {
+        if(!feature || !feature.properties) return;
+        const props = feature.properties;
+        const baseId = props.id;
+        if(baseId === undefined || baseId === null) return;
+        const key = String(baseId);
+        const sourceId = props.multi === 1 ? 'multi-posts' : 'posts';
+        const fid = feature.id ?? props.featureId;
+        if(fid === undefined || fid === null) return;
+        if(!index.has(key)){
+          index.set(key, []);
+        }
+        index.get(key).push({ source: sourceId, id: fid });
+      });
+      return index;
+    }
+
     function getMarkerCollections(list){
       const signature = markerSignatureForList(list);
       if(markerDataCache.signature === signature && markerDataCache.postsData){
@@ -8745,18 +8929,21 @@ function makePosts(){
           postsData: markerDataCache.postsData,
           multiData: markerDataCache.multiData,
           signature,
-          changed: false
+          changed: false,
+          featureIndex: markerDataCache.featureIndex
         };
       }
       if(!Array.isArray(list) || !list.length){
         markerDataCache.signature = signature;
         markerDataCache.postsData = EMPTY_FEATURE_COLLECTION;
         markerDataCache.multiData = EMPTY_FEATURE_COLLECTION;
+        markerDataCache.featureIndex = new Map();
         return {
           postsData: EMPTY_FEATURE_COLLECTION,
           multiData: EMPTY_FEATURE_COLLECTION,
           signature,
-          changed: true
+          changed: true,
+          featureIndex: markerDataCache.featureIndex
         };
       }
       const postsData = postsToGeoJSON(list);
@@ -8767,13 +8954,15 @@ function makePosts(){
       markerDataCache.signature = signature;
       markerDataCache.postsData = postsData;
       markerDataCache.multiData = multiData;
-      return { postsData, multiData, signature, changed: true };
+      markerDataCache.featureIndex = buildMarkerFeatureIndex(postsData);
+      return { postsData, multiData, signature, changed: true, featureIndex: markerDataCache.featureIndex };
     }
 
     function syncMarkerSources(list, options = {}){
       const { force = false } = options;
       const collections = getMarkerCollections(list);
-      const { postsData, multiData, signature } = collections;
+      const { postsData, multiData, signature, featureIndex } = collections;
+      markerFeatureIndex = featureIndex instanceof Map ? featureIndex : new Map();
       let updated = false;
       if(map && typeof map.getSource === 'function'){
         const postsSource = map.getSource('posts');
@@ -8788,6 +8977,9 @@ function makePosts(){
           multiSource.__markerSignature = signature;
           updated = true;
         }
+      }
+      if(updated || force){
+        updateMapFeatureHighlights(lastHighlightedPostIds);
       }
       return { updated, signature };
     }
@@ -11607,7 +11799,8 @@ if (!map.__pillHooksInstalled) {
       try{
       const markerList = filtersInitialized && Array.isArray(filtered) ? filtered : posts;
       const collections = getMarkerCollections(markerList);
-      const { postsData, multiData, signature } = collections;
+      const { postsData, multiData, signature, featureIndex } = collections;
+      markerFeatureIndex = featureIndex instanceof Map ? featureIndex : new Map();
       const featureCount = Array.isArray(postsData.features) ? postsData.features.length : 0;
       if(featureCount > 1000){
         await new Promise(resolve => scheduleIdle(resolve, 120));
@@ -11737,6 +11930,7 @@ if (!map.__pillHooksInstalled) {
         enforceMarkerLabelCompositeBudget(map);
       }
       ensureMarkerLabelBackground(map);
+      updateMapFeatureHighlights(lastHighlightedPostIds);
       const markerLabelBaseConditions = [
         ['!',['has','point_count']],
         ['has','title']
@@ -11749,8 +11943,16 @@ if (!map.__pillHooksInstalled) {
       const markerLabelIconImage = ['let', 'spriteId', ['coalesce', ['get','labelSpriteId'], ''],
         ['case',
           ['==', ['var','spriteId'], ''],
-          MARKER_LABEL_BG_ID,
-          ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','spriteId']]
+          ['case',
+            ['boolean', ['feature-state', 'isHighlighted'], false],
+            MARKER_LABEL_BG_ACCENT_ID,
+            MARKER_LABEL_BG_ID
+          ],
+          ['case',
+            ['boolean', ['feature-state', 'isHighlighted'], false],
+            ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','spriteId'], MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX],
+            ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','spriteId']]
+          ]
         ]
       ];
 


### PR DESCRIPTION
## Summary
- keep map overlay pills visible while interactive and ensure highlighted cards override board styling
- enhance marker highlight logic to fall back to the open post and set feature-state flags for map sprites
- tint marker assets and composites so hovered or open markers use the #2e3a72 accent while others remain translucent black

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc2e599f08331bf91b80c3e6d9711