### PR TITLE
Anchor multi-venue events to real city coordinates

### DIFF
--- a/index.html
+++ b/index.html
@@ -8636,87 +8636,255 @@ function makePosts(){
   }
 
   function buildMultiVenuePool(){
-    const REGION_SPECS = [
+    const cityLookup = singleVenueBases.reduce((acc, base)=>{
+      if(!base || !base.city) return acc;
+      if(Number.isFinite(base.lng) && Number.isFinite(base.lat)){
+        acc[base.city] = { lng: base.lng, lat: base.lat };
+      }
+      return acc;
+    }, Object.create(null));
+
+    const MULTI_REGION_CITY_LISTS = [
       {
-        name: 'North America',
-        count: 750,
-        bounds: [
-          { west: -168, east: -52, south: 18, north: 72 },
-          { west: -130, east: -60, south: 25, north: 52 },
-          { west: -115, east: -80, south: 30, north: 55 }
+        region: 'North America',
+        cityNames: [
+          'Anchorage, USA',
+          'Honolulu, USA',
+          'San Francisco, USA',
+          'Seattle, USA',
+          'Vancouver, Canada',
+          'Calgary, Canada',
+          'Toronto, Canada',
+          'Montreal, Canada',
+          'Boston, USA',
+          'New Orleans, USA',
+          'Chicago, USA',
+          'Miami, USA',
+          'Dallas, USA',
+          'Denver, USA',
+          'Phoenix, USA',
+          'Los Angeles, USA'
         ]
       },
       {
-        name: 'South America',
-        count: 450,
-        bounds: [
-          { west: -82, east: -50, south: -40, north: 13 },
-          { west: -76, east: -60, south: -20, north: 5 }
+        region: 'Central & South America',
+        cityNames: [
+          'Mexico City, Mexico',
+          'Guadalajara, Mexico',
+          'Bogotá, Colombia',
+          'Lima, Peru',
+          'Quito, Ecuador',
+          'Santiago, Chile',
+          'Buenos Aires, Argentina',
+          'Montevideo, Uruguay',
+          'São Paulo, Brazil',
+          'Rio de Janeiro, Brazil',
+          'Brasília, Brazil',
+          'Recife, Brazil',
+          'Fortaleza, Brazil',
+          'Caracas, Venezuela',
+          'San Juan, Puerto Rico'
         ]
       },
       {
-        name: 'Europe',
-        count: 700,
-        bounds: [
-          { west: -11, east: 30, south: 36, north: 71 },
-          { west: 10, east: 35, south: 40, north: 60 }
+        region: 'Europe',
+        cityNames: [
+          'Reykjavík, Iceland',
+          'Oslo, Norway',
+          'Stockholm, Sweden',
+          'Helsinki, Finland',
+          'Copenhagen, Denmark',
+          'Edinburgh, UK',
+          'Dublin, Ireland',
+          'Glasgow, UK',
+          'London, UK',
+          'Manchester, UK',
+          'Paris, France',
+          'Lyon, France',
+          'Marseille, France',
+          'Madrid, Spain',
+          'Barcelona, Spain',
+          'Valencia, Spain',
+          'Lisbon, Portugal',
+          'Berlin, Germany',
+          'Hamburg, Germany',
+          'Munich, Germany',
+          'Frankfurt, Germany',
+          'Prague, Czechia',
+          'Vienna, Austria',
+          'Zurich, Switzerland',
+          'Warsaw, Poland',
+          'Kraków, Poland',
+          'Budapest, Hungary',
+          'Bucharest, Romania',
+          'Athens, Greece'
         ]
       },
       {
-        name: 'Africa',
-        count: 650,
-        bounds: [
-          { west: -18, east: 51, south: -35, north: 37 },
-          { west: 10, east: 40, south: -5, north: 20 }
+        region: 'Africa',
+        cityNames: [
+          'Cairo, Egypt',
+          'Casablanca, Morocco',
+          'Marrakesh, Morocco',
+          'Algiers, Algeria',
+          'Tunis, Tunisia',
+          'Tripoli, Libya',
+          'Khartoum, Sudan',
+          'Addis Ababa, Ethiopia',
+          'Nairobi, Kenya',
+          'Kampala, Uganda',
+          'Dar es Salaam, Tanzania',
+          'Kigali, Rwanda',
+          'Lagos, Nigeria',
+          'Accra, Ghana',
+          "Abidjan, Côte d'Ivoire",
+          'Dakar, Senegal',
+          'Kinshasa, DR Congo',
+          'Luanda, Angola',
+          'Johannesburg, South Africa',
+          'Cape Town, South Africa',
+          'Windhoek, Namibia',
+          'Gaborone, Botswana',
+          'Harare, Zimbabwe',
+          'Maputo, Mozambique'
         ]
       },
       {
-        name: 'Asia',
-        count: 1100,
-        bounds: [
-          { west: 26, east: 90, south: 5, north: 55 },
-          { west: 70, east: 110, south: 8, north: 45 },
-          { west: 95, east: 140, south: -10, north: 50 }
+        region: 'Middle East',
+        cityNames: [
+          'Riyadh, Saudi Arabia',
+          'Jeddah, Saudi Arabia',
+          'Doha, Qatar',
+          'Dubai, UAE',
+          'Muscat, Oman',
+          'Kuwait City, Kuwait',
+          'Manama, Bahrain',
+          'Tehran, Iran',
+          'Baghdad, Iraq',
+          'Amman, Jordan',
+          'Beirut, Lebanon',
+          'Jerusalem'
         ]
       },
       {
-        name: 'Oceania',
-        count: 350,
-        bounds: [
-          { west: 110, east: 155, south: -45, north: -10 },
-          { west: 140, east: 175, south: -25, north: 5 }
+        region: 'Asia',
+        cityNames: [
+          'Mumbai, India',
+          'Delhi, India',
+          'Bengaluru, India',
+          'Hyderabad, India',
+          'Chennai, India',
+          'Kolkata, India',
+          'Kathmandu, Nepal',
+          'Dhaka, Bangladesh',
+          'Colombo, Sri Lanka',
+          'Bangkok, Thailand',
+          'Chiang Mai, Thailand',
+          'Vientiane, Laos',
+          'Phnom Penh, Cambodia',
+          'Ho Chi Minh City, Vietnam',
+          'Hanoi, Vietnam',
+          'Yangon, Myanmar',
+          'Singapore',
+          'Kuala Lumpur, Malaysia',
+          'Jakarta, Indonesia',
+          'Surabaya, Indonesia',
+          'Manila, Philippines',
+          'Cebu, Philippines',
+          'Hong Kong',
+          'Macau',
+          'Taipei, Taiwan',
+          'Seoul, South Korea',
+          'Busan, South Korea',
+          'Tokyo, Japan',
+          'Osaka, Japan',
+          'Nagoya, Japan',
+          'Sapporo, Japan',
+          'Beijing, China',
+          'Shanghai, China',
+          'Guangzhou, China',
+          'Shenzhen, China',
+          'Chengdu, China',
+          "Xi'an, China",
+          'Ulaanbaatar, Mongolia',
+          'Almaty, Kazakhstan',
+          'Bishkek, Kyrgyzstan',
+          'Tashkent, Uzbekistan',
+          'Astana, Kazakhstan',
+          'Moscow, Russia',
+          'Saint Petersburg, Russia',
+          'Novosibirsk, Russia',
+          'Yekaterinburg, Russia'
+        ]
+      },
+      {
+        region: 'Oceania',
+        cityNames: [
+          'Perth, Australia',
+          'Adelaide, Australia',
+          'Melbourne, Australia',
+          'Sydney, Australia',
+          'Brisbane, Australia',
+          'Hobart, Australia',
+          'Auckland, New Zealand',
+          'Wellington, New Zealand',
+          'Christchurch, New Zealand',
+          'Suva, Fiji'
         ]
       }
     ];
+
+    const deterministicOffset = (label, axis)=>{
+      let hash = 0;
+      for(let i = 0; i < label.length; i++){
+        const charCode = label.charCodeAt(i);
+        hash = (hash * 33 + charCode + (axis + 1) * 131) & 0xffffffff;
+      }
+      const normalized = ((hash % 2001) / 2000) - 0.5;
+      return normalized * 0.002;
+    };
+
     const pool = [];
     const seen = new Set();
-    const pickBound = (bounds)=> bounds[Math.floor(rnd() * bounds.length)] || null;
-    REGION_SPECS.forEach(spec => {
-      if(!spec || !spec.bounds || !spec.bounds.length || spec.count <= 0) return;
-      let produced = 0;
-      while(produced < spec.count){
-        const bound = pickBound(spec.bounds);
-        if(!bound){
-          break;
-        }
-        const rawLng = bound.west + rnd() * (bound.east - bound.west);
-        const rawLat = bound.south + rnd() * (bound.north - bound.south);
-        const lng = normalizeLongitude(rawLng);
-        const lat = clampLatitude(rawLat);
-        const key = toVenueCoordKey(lng, lat);
+
+    MULTI_REGION_CITY_LISTS.forEach(spec => {
+      if(!spec || !spec.region || !Array.isArray(spec.cityNames)) return;
+      spec.cityNames.forEach(cityName => {
+        if(!cityName) return;
+        const base = cityLookup[cityName];
+        if(!base) return;
+        const label = `${spec.region}:${cityName}`;
+        let lng = normalizeLongitude(base.lng + deterministicOffset(label, 0));
+        let lat = clampLatitude(base.lat + deterministicOffset(label, 1));
+        let key = toVenueCoordKey(lng, lat);
         if(!key || seen.has(key)){
-          continue;
+          let attempts = 0;
+          let adjustment = 0.0003;
+          while(attempts < 5 && key && seen.has(key)){
+            const delta = adjustment * (attempts % 2 === 0 ? 1 : -1);
+            lng = normalizeLongitude(base.lng + delta);
+            lat = clampLatitude(base.lat + delta);
+            key = toVenueCoordKey(lng, lat);
+            attempts++;
+            adjustment += 0.0001;
+          }
+          if((!key || seen.has(key)) && toVenueCoordKey(base.lng, base.lat) && !seen.has(toVenueCoordKey(base.lng, base.lat))){
+            lng = normalizeLongitude(base.lng);
+            lat = clampLatitude(base.lat);
+            key = toVenueCoordKey(lng, lat);
+          }
+        }
+        if(!key || seen.has(key)){
+          return;
         }
         seen.add(key);
-        produced++;
-        const indexLabel = produced.toString().padStart(3, '0');
         pool.push({
-          city: `${spec.name} ${indexLabel}`,
-          region: spec.name,
+          city: cityName,
+          region: spec.region,
           lng,
           lat
         });
-      }
+      });
     });
     return pool;
   }


### PR DESCRIPTION
## Summary
- build the multi-venue pool from curated city lists that reuse verified single-venue coordinates per region
- add a deterministic micro-jitter and uniqueness guard so real city anchors remain distinct in the pool

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc5d49bb88331b396cad90173d182