### PR TITLE
Remove mobile-specific Mapbox marker resizing logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -5679,9 +5679,7 @@ if (typeof slugify !== 'function') {
   }
 
   const isTouchDevice = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (window.matchMedia && window.matchMedia('(pointer: coarse)').matches);
-  const narrowScreenQuery = typeof window.matchMedia === 'function' ? window.matchMedia('(max-width: 600px)') : null;
-  const isNarrowScreen = narrowScreenQuery ? narrowScreenQuery.matches : window.innerWidth <= 600;
-  const markerIconSize = (isTouchDevice || isNarrowScreen) ? 1.35 : 1;
+  const markerIconSize = 1;
   const markerIconBaseSizePx = 30;
   const markerLabelBackgroundWidthPx = 150;
   const markerLabelBackgroundHeightPx = 40;


### PR DESCRIPTION
## Summary
- remove the touch and narrow screen marker scaling override so markers stay at the default size

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe272ac7c83319a81b88a95400ea4