### PR TITLE
Rebuild multi-post map marker container

### DIFF
--- a/index.html
+++ b/index.html
@@ -4752,76 +4752,75 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   white-space: nowrap;
 }
 
-.multi-post-map-card-container {
-  background-color: rgba(0, 0, 0, 0.7);
-  border-radius: 20px;
-  padding: 10px;
+.multi-post-map-container {
   position: absolute;
   z-index: 20050;
-  max-height: 80vh;
-  max-width: 400px;
-  overflow: hidden;
+  padding: 10px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
   display: flex;
   flex-direction: column;
+  gap: 10px;
   box-sizing: border-box;
-  color: #fff;
-}
-
-.multi-post-map-card-header {
-  font-family: var(--global-font, inherit);
-  font-size: 13px;
-  color: #fff;
-  margin-bottom: 8px;
-  line-height: 1.3;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.multi-post-map-card-header .header-line {
-  font-size: 13px;
-  color: #fff;
-}
-
-.multi-post-map-card-header .date-range {
-  display: block;
-  color: #b3b3b3;
-  font-size: 13px;
-}
-
-.multi-post-mapmarker-list {
+  max-height: 80vh;
   overflow-y: auto;
-  max-height: calc(80vh - 60px);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding-right: 2px;
+  pointer-events: auto;
 }
 
-.mapmarker-sprite {
+.multi-post-marker-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   background: rgba(0, 0, 0, 0.6);
   border-radius: 12px;
-  padding: 6px 10px;
-  cursor: pointer;
+  padding: 8px 12px;
   border: none;
-  color: #fff;
+  color: inherit;
+  font: inherit;
   text-align: left;
+  cursor: pointer;
 }
 
-.mapmarker-sprite:focus {
+.multi-post-marker-item:hover {
+  background: rgba(46, 58, 114, 0.8);
+}
+
+.multi-post-marker-item:focus-visible {
   outline: 2px solid #2e3a72;
   outline-offset: 2px;
 }
 
-.multi-post-mapmarker-item-label {
+.multi-post-marker-item--summary {
+  background: transparent;
+  padding: 0;
+  cursor: default;
+}
+
+.multi-post-marker-item--summary:hover,
+.multi-post-marker-item--summary:focus-visible {
+  background: transparent;
+  outline: none;
+}
+
+.multi-post-marker-icon {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  object-fit: contain;
+}
+
+.multi-post-marker-label {
   display: flex;
   flex-direction: column;
   gap: 2px;
   font-size: 12px;
   line-height: 1.2;
+}
+
+.multi-post-marker-label--summary {
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .hero img.lqip{
@@ -7442,24 +7441,6 @@ function scheduleMultiPostCardRemoval(delay=160){
   }, delay);
 }
 
-function formatMultiPostDateRange(items){
-  const allDates = items.flatMap(p => Array.isArray(p.dates) ? p.dates : []).filter(Boolean).sort();
-  const first = allDates[0] || null;
-  const last = allDates[allDates.length - 1] || first;
-  const fmt = (iso)=>{
-    if(!iso) return 'Unknown date';
-    try{
-      return parseISODate(iso).toLocaleDateString('en-GB',{weekday:'short', day:'numeric', month:'short', year:'numeric'}).replace(',', '').replace(/ (\d{4})$/, ', $1');
-    }catch(err){
-      return iso;
-    }
-  };
-  return {
-    startText: fmt(first),
-    endText: fmt(last)
-  };
-}
-
 function positionMultiPostCardContainer(point){
   if(!multiPostCardState || !multiPostCardState.element) return;
   const containerEl = map && typeof map.getContainer === 'function' ? map.getContainer() : null;
@@ -7482,12 +7463,9 @@ function positionMultiPostCardContainer(point){
   const height = root.offsetHeight;
   const anchor = point || multiPostCardState.anchorPoint || { x: mapRect.width / 2, y: mapRect.height / 2 };
   let left = anchor.x + 16;
-  let top = anchor.y - height - 16;
-  if(top < topPad){
-    top = anchor.y + 16;
-  }
+  let top = anchor.y + 16;
   if(top + height > mapRect.height - pad){
-    top = mapRect.height - height - pad;
+    top = Math.max(topPad, mapRect.height - height - pad);
   }
   if(top < topPad){
     top = topPad;
@@ -7562,23 +7540,9 @@ function showMultiPostCardContainer(point, items, options = {}){
   const { lockOnOpen = false, venueKey = null } = options;
   destroyMultiPostCardContainer();
   const root = document.createElement('div');
-  root.className = 'multi-post-map-card-container';
+  root.className = 'multi-post-map-container';
   root.style.visibility = 'hidden';
-  const header = document.createElement('div');
-  header.className = 'multi-post-map-card-header';
-  const { startText, endText } = formatMultiPostDateRange(items);
-  const headerLine1 = document.createElement('div');
-  headerLine1.className = 'header-line';
-  const postCount = items.length;
-  headerLine1.textContent = `${postCount} posts here`;
-  const headerLine2 = document.createElement('span');
-  headerLine2.className = 'date-range';
-  headerLine2.textContent = `${startText} – ${endText}`;
-  header.append(headerLine1, headerLine2);
-  const markerList = document.createElement('div');
-  markerList.className = 'multi-post-mapmarker-list';
   const ordered = sortMultiPostItems(items);
-  const fragment = document.createDocumentFragment();
   const markerSources = window.subcategoryMarkers || {};
   const markerIds = window.subcategoryMarkerIds || {};
   const slugifyFn = typeof slugify === 'function'
@@ -7595,45 +7559,55 @@ function showMultiPostCardContainer(point, items, options = {}){
     const url = candidates.map(id => (id && markerSources[id]) || null).find(Boolean);
     return url || MULTI_POST_MAPMARKER_URL;
   };
-  ordered.forEach(post => {
-    if(!post) return;
-    const item = document.createElement('div');
-    item.className = 'mapmarker-sprite';
-    item.setAttribute('role', 'button');
-    item.setAttribute('tabindex', '0');
-    if(post.id) item.dataset.id = String(post.id);
 
+  const createIcon = (url)=>{
     const icon = new Image();
     try{ icon.decoding = 'async'; }catch(err){}
     icon.alt = '';
-    icon.className = 'mapmarker';
+    icon.className = 'multi-post-marker-icon';
     icon.draggable = false;
-    const iconUrl = markerIconUrlFor(post);
     icon.onerror = ()=>{
       icon.onerror = null;
       icon.src = MULTI_POST_MAPMARKER_URL;
     };
-    icon.src = iconUrl;
+    icon.src = url || MULTI_POST_MAPMARKER_URL;
+    return icon;
+  };
 
+  const summaryItem = document.createElement('div');
+  summaryItem.className = 'multi-post-marker-item multi-post-marker-item--summary';
+  summaryItem.setAttribute('aria-hidden', 'true');
+  const summaryIcon = createIcon(MULTI_POST_MAPMARKER_URL);
+  const summaryLabel = document.createElement('div');
+  summaryLabel.className = 'multi-post-marker-label multi-post-marker-label--summary';
+  const summaryLine = document.createElement('span');
+  summaryLine.textContent = `${ordered.length} posts here`;
+  summaryLabel.appendChild(summaryLine);
+  summaryItem.append(summaryIcon, summaryLabel);
+  root.appendChild(summaryItem);
+
+  ordered.forEach(post => {
+    if(!post) return;
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'multi-post-marker-item';
+    if(post.id) item.dataset.id = String(post.id);
+    const iconUrl = markerIconUrlFor(post);
+    item.appendChild(createIcon(iconUrl));
     const labelWrap = document.createElement('div');
-    labelWrap.className = 'multi-post-mapmarker-item-label';
+    labelWrap.className = 'multi-post-marker-label';
     const labelLines = getMarkerLabelLines(post);
-    const labelLine1 = document.createElement('div');
-    labelLine1.textContent = labelLines.line1 || '';
-    labelWrap.appendChild(labelLine1);
+    const line1 = document.createElement('span');
+    line1.textContent = labelLines.line1 || '';
+    labelWrap.appendChild(line1);
     if(labelLines.line2){
-      const labelLine2 = document.createElement('div');
-      labelLine2.textContent = labelLines.line2;
-      labelWrap.appendChild(labelLine2);
+      const line2 = document.createElement('span');
+      line2.textContent = labelLines.line2;
+      labelWrap.appendChild(line2);
     }
-
-    item.append(icon, labelWrap);
-    fragment.appendChild(item);
+    item.appendChild(labelWrap);
+    root.appendChild(item);
   });
-  markerList.appendChild(fragment);
-  markerList.scrollTop = 0;
-  root.appendChild(header);
-  root.appendChild(markerList);
   containerEl.appendChild(root);
   multiPostCardState = {
     element: root,
@@ -7695,15 +7669,15 @@ function showMultiPostCardContainer(point, items, options = {}){
     openPostFromCard(id);
   };
 
-  markerList.addEventListener('click', (evt)=>{
-    const item = evt.target.closest('.mapmarker-sprite');
+  root.addEventListener('click', (evt)=>{
+    const item = evt.target.closest('.multi-post-marker-item[data-id]');
     handleCardActivation(item, evt);
   }, { capture: true });
 
-  markerList.addEventListener('keydown', (evt)=>{
+  root.addEventListener('keydown', (evt)=>{
     const isActivationKey = evt.key === 'Enter' || evt.key === ' ' || evt.key === 'Spacebar';
     if(!isActivationKey) return;
-    const item = evt.target.closest('.mapmarker-sprite');
+    const item = evt.target.closest('.multi-post-marker-item[data-id]');
     handleCardActivation(item, evt);
   }, { capture: true });
 


### PR DESCRIPTION
## Summary
- replace the old multi-post card implementation with a fresh multi-post map container that stacks the primary marker and its children vertically with 10px spacing
- adjust positioning logic so the container prefers to appear beneath the anchor point while respecting viewport bounds
- wire up item interactions so inner markers trigger the same open-post behaviour while supporting lock-on-open handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff14202008331ab4e63ff2b9bf42d