### PR TITLE
Adjust marker min zoom to threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -12226,7 +12226,7 @@ if (!map.__pillHooksInstalled) {
       if(featureCount > 1000){
         await new Promise(resolve => scheduleIdle(resolve, 120));
       }
-      const MARKER_MIN_ZOOM = MARKER_SPRITE_ZOOM;
+      const MARKER_MIN_ZOOM = MARKER_ZOOM_THRESHOLD;
       const existing = map.getSource('posts');
       if(!existing){
         map.addSource('posts', { type:'geojson', data: postsData, promoteId: 'featureId' });


### PR DESCRIPTION
## Summary
- derive marker minimum zoom for post layers from the existing zoom threshold
- ensure marker label layers keep min zoom aligned with the updated value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dffe49f2188331901af5d75569d542