### PR TITLE
Simplify marker label icon expressions

### DIFF
--- a/index.html
+++ b/index.html
@@ -12426,28 +12426,21 @@ if (!map.__pillHooksInstalled) {
       const markerFallbackIcon = ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID];
       const markerFallbackHighlightIcon = ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID];
 
-      const markerLabelIconImage = ['let', 'spriteId', ['coalesce', ['get','labelSpriteId'], ''],
-        ['let', 'compositeId', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','spriteId']],
-          ['case',
-            ['==', ['var','spriteId'], ''],
-            markerFallbackIcon,
-            ['has-image', ['var','compositeId']],
-            ['var','compositeId'],
-            markerFallbackIcon
-          ]
-        ]
+      const markerLabelSpriteId = ['coalesce', ['get','labelSpriteId'], ''];
+      const markerLabelIconImage = ['case',
+        ['==', markerLabelSpriteId, ''],
+        markerFallbackIcon,
+        ['has-image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId]],
+        ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId],
+        markerFallbackIcon
       ];
 
-      const markerLabelHighlightIconImage = ['let', 'spriteId', ['coalesce', ['get','labelSpriteId'], ''],
-        ['let', 'highlightCompositeId', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var','spriteId'], MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX],
-          ['case',
-            ['==', ['var','spriteId'], ''],
-            markerFallbackHighlightIcon,
-            ['has-image', ['var','highlightCompositeId']],
-            ['var','highlightCompositeId'],
-            markerFallbackHighlightIcon
-          ]
-        ]
+      const markerLabelHighlightIconImage = ['case',
+        ['==', markerLabelSpriteId, ''],
+        markerFallbackHighlightIcon,
+        ['has-image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId, MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX]],
+        ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId, MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX],
+        markerFallbackHighlightIcon
       ];
 
       const highlightedStateExpression = ['boolean', ['feature-state', 'isHighlighted'], false];


### PR DESCRIPTION
## Summary
- replace marker label icon expressions with direct `case` expressions that build composite sprite IDs via `concat`
- apply the same fallback logic to highlight markers for consistent behavior

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e02d716b448331b220d4f3881a906a