### PR TITLE
Adjust price filter inputs and pointer dismissal handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5331,9 +5331,9 @@ if (typeof slugify !== 'function') {
             </div>
             <div class="field price-range-row">
               <div class="input price-inputs">
-                <input id="min-price-input" type="number" inputmode="decimal" min="0" placeholder="Min price" aria-label="Minimum price" />
+                <input id="min-price-input" type="text" inputmode="decimal" pattern="\\d*(\\.\\d{0,2})?" placeholder="Min price" aria-label="Minimum price" />
                 <span class="price-separator" aria-hidden="true">-</span>
-                <input id="max-price-input" type="number" inputmode="decimal" min="0" placeholder="Max price" aria-label="Maximum price" />
+                <input id="max-price-input" type="text" inputmode="decimal" pattern="\\d*(\\.\\d{0,2})?" placeholder="Max price" aria-label="Maximum price" />
                 <div class="price-clear-button" role="button" aria-label="Clear price range">X</div>
               </div>
             </div>
@@ -14398,7 +14398,7 @@ function openPostModal(id){
              p.lat >= postPanel.getSouth() && p.lat <= postPanel.getNorth();
     }
     function kwMatch(p){ const kw = $('#keyword-textbox').value.trim().toLowerCase(); if(!kw) return true; return (p.title+' '+p.city+' '+p.category+' '+p.subcategory).toLowerCase().includes(kw); }
-    function parsePriceInputValue(value){ if(typeof value!=='string') return null; const trimmed=value.trim(); if(!trimmed) return null; const normalized=trimmed.replace(/[^0-9.,]/g,''); if(!normalized) return null; const num=parseFloat(normalized.replace(/,/g,'')); return Number.isFinite(num)?num:null; }
+function parsePriceInputValue(value){ if(typeof value!=='string') return null; const trimmed=typeof value.trim==='function'?value.trim():String(value).trim(); if(!trimmed) return null; const normalized=trimmed.replace(/[^0-9.,]/g,''); if(!normalized) return null; const num=parseFloat(normalized.replace(/,/g,'')); return Number.isFinite(num)?num:null; }
     function parsePriceNumbers(str){ if(typeof str!=='string') return []; const matches=str.match(/[0-9]+(?:[.,][0-9]+)?/g); if(!matches) return []; return matches.map(s=>parseFloat(s.replace(/,/g,''))).filter(n=>Number.isFinite(n)); }
     function getPostPriceBounds(p){ if(!p) return null; if(p.__priceMin!==undefined){ if(p.__priceMin===null) return null; return {min:p.__priceMin,max:p.__priceMax}; } const nums=[]; if(typeof p.price==='string'){ nums.push(...parsePriceNumbers(p.price)); } if(Array.isArray(p.locations)){ p.locations.forEach(loc=>{ if(loc && typeof loc.price==='string'){ nums.push(...parsePriceNumbers(loc.price)); } }); } if(!nums.length){ p.__priceMin=null; p.__priceMax=null; return null; } const min=Math.min(...nums); const max=Math.max(...nums); p.__priceMin=min; p.__priceMax=max; return {min,max}; }
     function priceMatch(p){ const minEl=$('#min-price-input'); const maxEl=$('#max-price-input'); const minVal=minEl?parsePriceInputValue(minEl.value):null; const maxVal=maxEl?parsePriceInputValue(maxEl.value):null; if(minVal===null && maxVal===null) return true; const bounds=getPostPriceBounds(p); if(!bounds) return false; if(minVal!==null && bounds.max < minVal) return false; if(maxVal!==null && bounds.min > maxVal) return false; return true; }
@@ -14887,6 +14887,8 @@ document.addEventListener('keydown', e=>{
   }
 });
 
+let pointerStartedInsideFilter = false;
+
 function handleDocInteract(e){
   if(e.target.closest('.image-modal-container')) return;
   if(logoEls.some(el => el.contains(e.target))) return;
@@ -14904,6 +14906,7 @@ function handleDocInteract(e){
     const pinBtn = filterPanel.querySelector('.pin-panel');
     const pinned = pinBtn && pinBtn.getAttribute('aria-pressed')==='true';
     if(content && !content.contains(e.target) && !pinned){
+      if(pointerStartedInsideFilter) return;
       closePanel(filterPanel);
     }
   }
@@ -14912,7 +14915,16 @@ function handleDocInteract(e){
 document.addEventListener('click', handleDocInteract);
 document.addEventListener('pointerdown', (e) => {
   const target = e.target;
-  requestAnimationFrame(() => handleDocInteract({ target }));
+  pointerStartedInsideFilter = !!target.closest('#filterPanel .panel-content');
+  if(!pointerStartedInsideFilter){
+    requestAnimationFrame(() => handleDocInteract({ target }));
+  }
+});
+document.addEventListener('pointerup', () => {
+  pointerStartedInsideFilter = false;
+});
+document.addEventListener('pointercancel', () => {
+  pointerStartedInsideFilter = false;
 });
 
 // Panels and admin/member interactions


### PR DESCRIPTION
## Summary
- switch the min/max price filter inputs to text fields with decimal patterns and updated parsing
- ensure price parsing trims values before normalization for text input support
- track pointer origins so the filter panel only dismisses on outside interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e03168bc3c833186f63da74d6bfb95