### PR TITLE
Update balloon cluster imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -6684,7 +6684,7 @@ if (typeof slugify !== 'function') {
         const BALLOON_LAYER_ID = 'post-balloons';
         const BALLOON_LAYER_IDS = [BALLOON_LAYER_ID];
         const BALLOON_IMAGE_ID = 'seed-balloon-icon';
-        const BALLOON_IMAGE_URL = 'assets/balloons/Colourful-Balloons-80.png';
+        const BALLOON_IMAGE_URL = 'assets/balloons/balloons-and-confetti-80.png';
         const BALLOON_MIN_ZOOM = 0;
         const BALLOON_MAX_ZOOM = MARKER_ZOOM_THRESHOLD;
         let balloonLayersVisible = true;
@@ -9773,7 +9773,7 @@ function makePosts(){
       if(p.member && p.member.avatar){
         return p.member.avatar;
       }
-      return 'assets/balloons/Colourful-Balloons-80.png';
+      return 'assets/balloons/balloons-and-confetti-80.png';
     }
 
     function mapCardHTML(p, opts={}){


### PR DESCRIPTION
## Summary
- point the balloon cluster imagery to the new balloons-and-confetti asset
- update the default fallback image used for balloon clusters to match the new artwork

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0315f3ac0833193b166a6b4e0e579