### PR TITLE
Refine marker label fallback expressions

### DIFF
--- a/index.html
+++ b/index.html
@@ -12451,24 +12451,21 @@ if (!map.__pillHooksInstalled) {
         multi: ['all', ...markerLabelBaseConditions, ['==', ['coalesce', ['get','multi'], 0], 1]]
       };
 
-      const markerFallbackIcon = ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID];
-      const markerFallbackHighlightIcon = ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID];
-
       const markerLabelSpriteId = ['coalesce', ['get','labelSpriteId'], ''];
       const markerLabelIconImage = ['case',
         ['==', markerLabelSpriteId, ''],
-        markerFallbackIcon,
+        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID],
         ['boolean', ['has-image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId]], false],
         ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId],
-        markerFallbackIcon
+        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID]
       ];
 
       const markerLabelHighlightIconImage = ['case',
         ['==', markerLabelSpriteId, ''],
-        markerFallbackHighlightIcon,
+        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID],
         ['boolean', ['has-image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId, MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX]], false],
         ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId, MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX],
-        markerFallbackHighlightIcon
+        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID]
       ];
 
       const highlightedStateExpression = ['boolean', ['feature-state', 'isHighlighted'], false];


### PR DESCRIPTION
## Summary
- simplify the marker label icon expressions to use a single case statement that checks composite sprites via concat
- apply the same fallback structure for the highlighted marker label icons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0334e9c588331a75984403f4309b2