### PR TITLE
Fix marker label icon image validation error

### DIFF
--- a/index.html
+++ b/index.html
@@ -12452,20 +12452,30 @@ if (!map.__pillHooksInstalled) {
       };
 
       const markerLabelSpriteId = ['coalesce', ['get','labelSpriteId'], ''];
-      const markerLabelIconImage = ['case',
-        ['==', markerLabelSpriteId, ''],
-        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID],
-        ['boolean', ['has-image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId]], false],
-        ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId],
-        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID]
+      const markerLabelIconImage = ['let', 'markerLabelFallbackId', ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ID],
+        ['let', 'markerLabelSpriteKey', markerLabelSpriteId,
+          ['case',
+            ['==', ['var', 'markerLabelSpriteKey'], ''],
+            ['image', ['var', 'markerLabelFallbackId']],
+            ['coalesce',
+              ['image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var', 'markerLabelSpriteKey']]],
+              ['image', ['var', 'markerLabelFallbackId']]
+            ]
+          ]
+        ]
       ];
 
-      const markerLabelHighlightIconImage = ['case',
-        ['==', markerLabelSpriteId, ''],
-        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID],
-        ['boolean', ['has-image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId, MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX]], false],
-        ['concat', MARKER_LABEL_COMPOSITE_PREFIX, markerLabelSpriteId, MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX],
-        ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID]
+      const markerLabelHighlightIconImage = ['let', 'markerLabelHighlightFallbackId', ['coalesce', ['get','sub'], ['get','baseSub'], MARKER_LABEL_BG_ACCENT_ID],
+        ['let', 'markerLabelSpriteKey', markerLabelSpriteId,
+          ['case',
+            ['==', ['var', 'markerLabelSpriteKey'], ''],
+            ['image', ['var', 'markerLabelHighlightFallbackId']],
+            ['coalesce',
+              ['image', ['concat', MARKER_LABEL_COMPOSITE_PREFIX, ['var', 'markerLabelSpriteKey'], MARKER_LABEL_COMPOSITE_ACCENT_SUFFIX]],
+              ['image', ['var', 'markerLabelHighlightFallbackId']]
+            ]
+          ]
+        ]
       ];
 
       const highlightedStateExpression = ['boolean', ['feature-state', 'isHighlighted'], false];


### PR DESCRIPTION
## Summary
- replace marker label icon image expressions to use resolved images without relying on has-image checks
- ensure highlighted and default marker label layers fall back to base sprites correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0372a9d048331b6c676626f867c63