### PR TITLE
Adjust marker label min zoom to sprite level

### DIFF
--- a/index.html
+++ b/index.html
@@ -12591,7 +12591,7 @@ if (!map.__pillHooksInstalled) {
       const markerLabelHighlightOpacity = ['case', highlightedStateExpression, 1, 0];
       const markerLabelBaseOpacity = ['case', highlightedStateExpression, 0, 1];
 
-      const markerLabelMinZoom = MARKER_MIN_ZOOM;
+      const markerLabelMinZoom = MARKER_SPRITE_ZOOM;
       const labelLayersConfig = [
         { id:'marker-label', source:'posts', sortKey: 1100, filter: markerLabelFilters.single, iconImage: markerLabelIconImage, iconOpacity: markerLabelBaseOpacity, minzoom: markerLabelMinZoom },
         { id:'marker-label-highlight', source:'posts', sortKey: 1101, filter: markerLabelFilters.single, iconImage: markerLabelHighlightIconImage, iconOpacity: markerLabelHighlightOpacity, minzoom: markerLabelMinZoom },


### PR DESCRIPTION
## Summary
- set marker label minimum zoom to use the sprite zoom threshold so marker labels only appear at zoom 12 and above

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0439c894c833180c9844d56402d75