### PR TITLE
Set multi-post container minimum zoom to 8

### DIFF
--- a/index.html
+++ b/index.html
@@ -6699,7 +6699,7 @@ if (typeof slugify !== 'function') {
       const MARKER_VISIBILITY_BUCKET = Math.round(MARKER_ZOOM_THRESHOLD * ZOOM_VISIBILITY_PRECISION);
       const MARKER_PRELOAD_OFFSET = 0.2;
       const MARKER_PRELOAD_ZOOM = Math.max(MARKER_ZOOM_THRESHOLD - MARKER_PRELOAD_OFFSET, 0);
-      const MULTI_CARD_MIN_ZOOM = 0;
+      const MULTI_CARD_MIN_ZOOM = 8;
       const MARKER_LAYER_IDS = [
         'hover-fill',
         'marker-label',


### PR DESCRIPTION
## Summary
- lower the multi-post map container gate to zoom level 8 by updating MULTI_CARD_MIN_ZOOM

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0449d75e08331847a8298046d440b