### PR TITLE
Ensure price range inputs use white background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1950,7 +1950,8 @@ button[aria-expanded="true"] .results-arrow{
 
 .price-range-row .price-inputs input{
   min-width: 0;
-  background-color: #fff;
+  background: #fff;
+  color: var(--ink);
 }
 
 .price-range-row .price-separator{


### PR DESCRIPTION
## Summary
- force the price range inputs to use a white background and retain readable text color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0497219e083319e31f8db4e985104