### PR TITLE
Add fallback rendering for map marker pills

### DIFF
--- a/index.html
+++ b/index.html
@@ -5064,6 +5064,49 @@ if (typeof slugify !== 'function') {
   let loadingTask = null;
   const pendingMaps = new Set();
 
+  const DEFAULT_PILL_WIDTH = 150;
+  const DEFAULT_PILL_HEIGHT = 40;
+
+  function drawRoundedRect(ctx, width, height, radius){
+    const r = Math.min(radius, width / 2, height / 2);
+    ctx.beginPath();
+    ctx.moveTo(r, 0);
+    ctx.lineTo(width - r, 0);
+    ctx.quadraticCurveTo(width, 0, width, r);
+    ctx.lineTo(width, height - r);
+    ctx.quadraticCurveTo(width, height, width - r, height);
+    ctx.lineTo(r, height);
+    ctx.quadraticCurveTo(0, height, 0, height - r);
+    ctx.lineTo(0, r);
+    ctx.quadraticCurveTo(0, 0, r, 0);
+    ctx.closePath();
+  }
+
+  function createFallbackPillCanvas({ width = DEFAULT_PILL_WIDTH, height = DEFAULT_PILL_HEIGHT, fill = 'rgba(0,0,0,0.9)', stroke = 'rgba(255,255,255,0.12)' } = {}){
+    const canvas = document.createElement('canvas');
+    const w = Math.max(1, Math.round(width));
+    const h = Math.max(1, Math.round(height));
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    if(!ctx){
+      return null;
+    }
+    drawRoundedRect(ctx, w, h, h / 2);
+    ctx.fillStyle = fill;
+    ctx.fill();
+    if(stroke){
+      ctx.strokeStyle = stroke;
+      ctx.lineWidth = Math.max(1, Math.round(h * 0.05));
+      ctx.stroke();
+    }
+    return canvas;
+  }
+
+  if(typeof window !== 'undefined' && !window.__createPillFallbackCanvas){
+    window.__createPillFallbackCanvas = createFallbackPillCanvas;
+  }
+
   function applyImageToMap(map){
     if(!map || typeof map.hasImage !== 'function' || !cachedImages){
       return;
@@ -5118,8 +5161,16 @@ if (typeof slugify !== 'function') {
 
   function prepareCachedImages(baseImage, accentImage){
     if(!baseImage){
+      const factory = (typeof window !== 'undefined' && window.__createPillFallbackCanvas) || createFallbackPillCanvas;
+      baseImage = factory({ fill: 'rgba(0,0,0,0.9)' });
+    }
+    if(!baseImage){
       cachedImages = null;
       return;
+    }
+    if(!accentImage){
+      const factory = (typeof window !== 'undefined' && window.__createPillFallbackCanvas) || createFallbackPillCanvas;
+      accentImage = factory({ fill: '#2f3b73', stroke: 'rgba(255,255,255,0.18)' });
     }
     const tintedBase = tintImage(baseImage, 'rgba(0,0,0,1)', 0.9) || baseImage;
     let highlight = null;
@@ -6016,6 +6067,45 @@ if (typeof slugify !== 'function') {
     });
   }
 
+  function createMarkerLabelFallback(fillColor = 'rgba(0,0,0,0.9)', strokeColor = 'rgba(255,255,255,0.12)'){
+    const factory = (typeof window !== 'undefined' && window.__createPillFallbackCanvas) || null;
+    if(factory){
+      const canvas = factory({ fill: fillColor, stroke: strokeColor });
+      if(canvas){
+        return canvas;
+      }
+    }
+    const canvas = document.createElement('canvas');
+    const width = 150;
+    const height = 40;
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if(!ctx){
+      return null;
+    }
+    const radius = height / 2;
+    ctx.beginPath();
+    ctx.moveTo(radius, 0);
+    ctx.lineTo(width - radius, 0);
+    ctx.quadraticCurveTo(width, 0, width, radius);
+    ctx.lineTo(width, height - radius);
+    ctx.quadraticCurveTo(width, height, width - radius, height);
+    ctx.lineTo(radius, height);
+    ctx.quadraticCurveTo(0, height, 0, height - radius);
+    ctx.lineTo(0, radius);
+    ctx.quadraticCurveTo(0, 0, radius, 0);
+    ctx.closePath();
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+    if(strokeColor){
+      ctx.strokeStyle = strokeColor;
+      ctx.lineWidth = Math.max(1, Math.round(height * 0.05));
+      ctx.stroke();
+    }
+    return canvas;
+  }
+
   async function ensureMarkerLabelPillImage(){
     if(markerLabelPillImagePromise){
       return markerLabelPillImagePromise;
@@ -6026,10 +6116,12 @@ if (typeof slugify !== 'function') {
       loadMarkerLabelImage(baseUrl),
       loadMarkerLabelImage(accentUrl).catch(() => null)
     ]).then(([baseImg, accentImg]) => {
-      if(!baseImg){
+      let resolvedBase = baseImg || createMarkerLabelFallback('rgba(0,0,0,0.9)', 'rgba(255,255,255,0.12)');
+      if(!resolvedBase){
         return null;
       }
-      return { base: baseImg, highlight: accentImg };
+      const resolvedAccent = accentImg || createMarkerLabelFallback('#2f3b73', 'rgba(255,255,255,0.18)');
+      return { base: resolvedBase, highlight: resolvedAccent };
     }).catch(err => {
       console.error(err);
       return null;


### PR DESCRIPTION
## Summary
- add a reusable canvas fallback for 150x40 map marker pill assets when the source images fail to load
- ensure marker label composites always receive a pill background so labels remain visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e04c8c4aec8331b083519fd8de73e9