### PR TITLE
Ensure pill image preparation always runs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5214,11 +5214,9 @@ if (typeof slugify !== 'function') {
       loadImage(PILL_BASE_IMAGE_URL),
       loadImage(PILL_ACCENT_IMAGE_URL)
     ]).then(([baseImage, accentImage]) => {
-      if(baseImage){
-        prepareCachedImages(baseImage, accentImage);
-        if(cachedImages){
-          pendingMaps.forEach((map) => applyImageToMap(map));
-        }
+      prepareCachedImages(baseImage, accentImage);
+      if(cachedImages){
+        pendingMaps.forEach((map) => applyImageToMap(map));
       }
     }).catch(() => {
       cachedImages = null;


### PR DESCRIPTION
## Summary
- always call `prepareCachedImages` after pill image loading completes
- keep Mapbox updates guarded so only populated caches trigger marker refreshes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0526549b88331857be7eccb67bdcb