### PR TITLE
Adjust filter input colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1275,10 +1275,6 @@ button[aria-expanded="true"] .results-arrow{
   background:#333333;
   border: none;
 }
-#filterPanel input[type="text"]{
-  background: var(--panel-bg);
-  color: var(--panel-text);
-}
 #filterPanel .calendar-container{
   background: var(--dropdown-bg);
   position:absolute;
@@ -1885,7 +1881,8 @@ button[aria-expanded="true"] .results-arrow{
   border-radius: var(--dropdown-radius);
 }
 #filterPanel #keyword-textbox{
-  background: var(--keyword-bg);
+  background: #333333;
+  color: var(--date-range-text);
 }
 #filterPanel #daterange-textbox{
   background: #333333;
@@ -1944,7 +1941,7 @@ button[aria-expanded="true"] .results-arrow{
 .price-range-row .price-inputs input{
   min-width: 0;
   background: #fff;
-  color: var(--ink);
+  color: var(--dropdown-text);
 }
 
 .price-range-row .price-separator{


### PR DESCRIPTION
## Summary
- stop the global `#filterPanel input[type="text"]` rule from forcing dark backgrounds on every text field
- apply dark styling directly to the keyword and date range inputs while keeping price inputs light
- ensure price inputs use dark text to remain legible against their white background

## Testing
- npm test
- Manual verification of filter input colors in browser

------
https://chatgpt.com/codex/tasks/task_e_68e05af7fef083319a192e11c2b9f372