### PR TITLE
Remove panel color custom properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,8 +581,6 @@
       --btn-selected-hover: #3c4b8a;
       --btn-selected-active: #232e59;
       --btn-disabled: #bbbbbb;
-      --panel-bg: rgba(0,0,0,1);
-      --panel-text: #000000;
       --footer-h: 0px;
       --list-background: rgba(0,0,0,0.37);
       --closed-card-bg: rgba(0,0,0,0.37);
@@ -626,10 +624,8 @@
       --geocoder-h: var(--control-h);
       --panel-label-font: system-ui, sans-serif;
       --panel-label-size: 14px;
-      --panel-label-color: #ffffff;
       --panel-title-font: system-ui, sans-serif;
       --panel-title-size: 16px;
-      --panel-title-color: #ffffff;
       --post-mode-bg-color: 0,0,0;
       --post-mode-bg-opacity: 0;
       --safe-top: env(safe-area-inset-top, 0px);
@@ -854,13 +850,13 @@ textarea::placeholder{
 }
 
 .field label{
-  color: var(--panel-label-color);
+  color:#fff;
   font-size: var(--panel-label-size);
 }
 
 .panel-content .title,
 .panel-content .t{
-  color: var(--panel-title-color);
+  color:#fff;
   font-size: var(--panel-title-size);
 }
 
@@ -2937,7 +2933,7 @@ body.filters-active #filterBtn{
   border-radius: 8px;
   object-fit: cover;
   display: block;
-  background: var(--panel-bg);
+  background: rgba(0,0,0,1);
   transition: filter .22s ease;
 }
 


### PR DESCRIPTION
## Summary
- remove panel-wide color custom properties from the global :root declaration in index.html
- update panel labels, titles, and thumbnails to use explicit colors that match the existing design
- verified the filter, admin, and member panels continue to display with the intended colors without relying on the removed variables

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e05e3a8c60833189759e6f019ceb5d