### PR TITLE
Adjust marker visibility zoom threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -5928,7 +5928,7 @@ if (typeof slugify !== 'function') {
   const markerLabelCompositeStore = new Map();
   const markerLabelCompositePending = new Map();
   const MARKER_LABEL_COMPOSITE_LIMIT = Infinity;
-  const MARKER_SPRITE_RETAIN_ZOOM = 12;
+  const MARKER_SPRITE_RETAIN_ZOOM = 8;
   let markerLabelPillImagePromise = null;
 
   function nowTimestamp(){


### PR DESCRIPTION
## Summary
- lower the marker sprite retention zoom level so markers, pills, and labels appear from zoom 8

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0856864688331812c8b3f71e2d4a0