### PR TITLE
Adjust map marker popup positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,14 +70,14 @@
       position: absolute;
       left: 0;
       top: 0;
-      transform: translate(-30px, -30px);
+      transform: translate(-112px, calc(-100% - 12px));
       pointer-events: auto;
       z-index: 30;
     }
     .mapmarker-overlay.is-card-visible > .mapmarker-container{
       opacity: 1;
       visibility: visible;
-      transform: translate(-50%, calc(-50% - 45px));
+      transform: translate(-50%, -50%);
     }
     .mapmarker-overlay.is-card-visible{
       pointer-events: auto;


### PR DESCRIPTION
## Summary
- ensure the map marker pill maintains centered alignment when the popup card is visible
- reposition the popup card so it clears the pill vertically when shown

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e12b31ab788331b79b6075ca6bc38a