### PR TITLE
Ensure multi-post marker labels stay visible at all zoom levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -12452,6 +12452,7 @@ if (!map.__pillHooksInstalled) {
         const isMultiPostLayer = MULTI_POST_MARKER_LAYER_IDS.includes(id);
         const fallbackMinZoom = isMultiPostLayer ? MULTI_POST_LABEL_MIN_ZOOM : markerLabelMinZoom;
         const layerMinZoom = Number.isFinite(minZoom) ? minZoom : fallbackMinZoom;
+        const zoomRangeMin = isMultiPostLayer ? MULTI_POST_LABEL_MIN_ZOOM : layerMinZoom;
         let layerExists = !!map.getLayer(id);
         if(!layerExists){
           try{
@@ -12460,7 +12461,7 @@ if (!map.__pillHooksInstalled) {
               type:'symbol',
               source,
               filter: filter || markerLabelFilters.single,
-              minzoom: layerMinZoom,
+              minzoom: zoomRangeMin,
               layout:{
                 'icon-image': iconImage || markerLabelIconImage,
                 'icon-size': 1,
@@ -12497,7 +12498,7 @@ if (!map.__pillHooksInstalled) {
         try{ map.setPaintProperty(id,'icon-translate',[markerLabelBgTranslatePx,0]); }catch(e){}
         try{ map.setPaintProperty(id,'icon-translate-anchor','viewport'); }catch(e){}
         try{ map.setPaintProperty(id,'icon-opacity', iconOpacity || 1); }catch(e){}
-        try{ map.setLayerZoomRange(id, layerMinZoom, 24); }catch(e){}
+        try{ map.setLayerZoomRange(id, zoomRangeMin, 24); }catch(e){}
       });
       ALL_MARKER_LAYER_IDS.forEach(id=>{
         if(map.getLayer(id)){


### PR DESCRIPTION
## Summary
- ensure multi-post marker labels use their dedicated low minzoom when created so they render across the full zoom range
- apply the same low minzoom when updating layer zoom ranges to keep the labels available at every scale

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1891c8be08331a517633a77c95b98