### PR TITLE
Adjust multi-post child offsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -5695,8 +5695,8 @@ if (typeof slugify !== 'function') {
   const markerLabelBgTranslatePx = -(markerIconBaseSizePx * markerIconSize / 2 + markerLabelMarkerInsetPx);
   const markerLabelEllipsisChar = '\u2026';
   const mapCardTitleWidthPx = 165;
-  const multiPostChildHorizontalOffsetPx = markerLabelBackgroundWidthPx / 2 + markerLabelBgTranslatePx;
-  const multiPostChildVerticalOffsetPx = markerLabelBackgroundHeightPx / 2 + 10;
+  const multiPostChildHorizontalOffsetPx = (markerIconBaseSizePx * markerIconSize - markerLabelBackgroundWidthPx) / 2;
+  const multiPostChildVerticalOffsetPx = markerIconBaseSizePx * markerIconSize + 10;
   let markerLabelMeasureContext = null;
   const markerLabelCompositePlaceholderIds = new Set();
 


### PR DESCRIPTION
## Summary
- recalculate the multi-post child horizontal offset so the child labels align with the parent marker edge
- drop the child marker stack by the full icon height plus gap to maintain the intended spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1c3307f24833187c6c1b4995418dd