### PR TITLE
Allow multi-post marker pills to follow shared styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4801,11 +4801,6 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   border-radius: 16px;
 }
 
-.multi-post-marker-children .mapmarker-pill {
-  visibility: visible;
-  opacity: 0.9;
-}
-
 .multi-post-marker-stack.is-highlighted .multi-post-marker-children .mapmarker-container,
 .multi-post-marker-children .mapmarker-container.is-active,
 .multi-post-marker-children .mapmarker-container:hover,
@@ -7511,8 +7506,6 @@ function createMarkerPill(){
   pill.src = 'assets/icons-30/150x40-pill-70.webp';
   pill.className = 'mapmarker-pill';
   pill.draggable = false;
-  pill.style.opacity = '0.9';
-  pill.style.visibility = 'visible';
   return pill;
 }
 


### PR DESCRIPTION
## Summary
- remove the multi-post marker pill opacity/visibility overrides in the stylesheet so it uses the shared pill styling
- stop hard-coding those overrides when creating marker pills in JavaScript to respect highlight classes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1c41df5d08331848e84fec53dd74b