### PR TITLE
Align map marker overlay sizing with Mapbox anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,11 @@
     }
     .mapmarker-overlay{
       position: relative;
-      width: 0;
-      height: 0;
+      width: 150px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transform: translateZ(0);
       pointer-events: none;
       isolation: isolate;
@@ -99,12 +102,9 @@
       z-index: 0;
     }
     .mapmarker-container{
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 150px;
-      height: 40px;
-      transform: translate(-50%, -50%);
+      position: relative;
+      width: 100%;
+      height: 100%;
       pointer-events: none;
       border-radius: 999px;
       background: rgba(0, 0, 0, 0.9);


### PR DESCRIPTION
## Summary
- size the map marker overlay to a 150px by 40px flex container to align with Mapbox center anchoring
- update the base map marker container to fill the overlay without absolute positioning so specialized stacks continue to work

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26fe1d77c8331b3fa2a1e493a40c2