### PR TITLE
Add hover-activated multi-post marker flyout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4767,15 +4767,74 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   white-space: nowrap;
 }
 
+
 .multi-post-marker-stack {
+  position: relative;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
+  align-items: center;
+  gap: 10px;
   pointer-events: auto;
   touch-action: pan-y;
-  width: 150px;
   margin-top: 0;
+}
+
+.multi-post-marker-trigger,
+.multi-post-marker-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 4px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.multi-post-marker-trigger:focus-visible,
+.multi-post-marker-icon-button:focus-visible {
+  outline: 2px solid #2e3a72;
+  outline-offset: 4px;
+}
+
+.multi-post-marker-trigger .mapmarker,
+.multi-post-marker-icon-button .mapmarker {
+  pointer-events: none;
+}
+
+.multi-post-marker-container {
+  display: none;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  width: 220px;
+  padding: 16px 16px 14px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+}
+
+.multi-post-marker-stack:hover .multi-post-marker-container,
+.multi-post-marker-stack.is-hovered .multi-post-marker-container,
+.multi-post-marker-stack.is-open .multi-post-marker-container {
+  display: flex;
+  pointer-events: auto;
+}
+
+.multi-post-marker-stack:hover .multi-post-marker-trigger,
+.multi-post-marker-stack.is-hovered .multi-post-marker-trigger,
+.multi-post-marker-stack.is-open .multi-post-marker-trigger {
+  display: none;
+}
+
+.multi-post-marker-icon-button {
+  background: none;
+  align-self: center;
+  margin-bottom: 4px;
 }
 
 .multi-post-marker-children {
@@ -4783,6 +4842,10 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   flex-direction: column;
   align-items: stretch;
   gap: 6px;
+}
+
+.multi-post-marker-children .mapmarker-container {
+  width: 100%;
 }
 
 .multi-post-marker-children .mapmarker-container {
@@ -7562,27 +7625,75 @@ function ensureMultiMarkerOverlay(venueKey, coords, posts){
     const root = document.createElement('div');
     root.className = 'multi-post-marker-stack';
     root.dataset.venueKey = venueKey;
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'multi-post-marker-trigger';
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-label', 'Show posts at this location');
+    const triggerIcon = createMarkerIcon(MULTI_POST_MAPMARKER_URL);
+    triggerIcon.classList.add('multi-post-marker-trigger-icon');
+    trigger.append(triggerIcon);
+
+    const container = document.createElement('div');
+    container.className = 'multi-post-marker-container';
+
+    const iconButton = document.createElement('button');
+    iconButton.type = 'button';
+    iconButton.className = 'multi-post-marker-icon-button';
+    iconButton.setAttribute('aria-label', 'Show posts at this location');
+    const iconButtonIcon = createMarkerIcon(MULTI_POST_MAPMARKER_URL);
+    iconButtonIcon.classList.add('multi-post-marker-trigger-icon');
+    iconButton.append(iconButtonIcon);
+
     const childrenRoot = document.createElement('div');
     childrenRoot.className = 'multi-post-marker-children';
-    root.append(childrenRoot);
+
+    container.append(iconButton, childrenRoot);
+    root.append(trigger, container);
 
     const marker = new mapboxgl.Marker({ element: root, anchor: 'top' });
     entry = {
       marker,
       element: root,
       childrenRoot,
+      container,
+      trigger,
+      iconButton,
+      isLockedOpen: false,
       postIds: [],
       childMarkers: new Map(),
       venueKey
     };
     multiMarkerOverlays.set(venueKey, entry);
 
+    const setHoverState = (active)=>{
+      if(active){
+        root.classList.add('is-hovered');
+      } else if(!entry.isLockedOpen){
+        root.classList.remove('is-hovered');
+      }
+    };
+
+    const setLockedOpen = (locked)=>{
+      entry.isLockedOpen = !!locked;
+      root.classList.toggle('is-open', entry.isLockedOpen);
+      trigger.setAttribute('aria-expanded', entry.isLockedOpen ? 'true' : 'false');
+      const label = entry.isLockedOpen ? 'Hide posts at this location' : 'Show posts at this location';
+      trigger.setAttribute('aria-label', label);
+      iconButton.setAttribute('aria-label', label);
+    };
+
     const highlightGroup = ()=>{
+      setHoverState(true);
       if(entry.postIds.length){
         setMarkerHoverIds(entry.postIds);
       }
     };
     const restoreGroup = ()=>{
+      if(entry.isLockedOpen){
+        return;
+      }
+      setHoverState(false);
       if(persistentMultiHighlight && persistentMultiHighlight.venueKey === venueKey && persistentMultiHighlight.ids){
         if(persistentMultiHighlight.activeId){
           setMarkerHoverIds([persistentMultiHighlight.activeId]);
@@ -7593,6 +7704,36 @@ function ensureMultiMarkerOverlay(venueKey, coords, posts){
         clearMarkerHoverIds();
       }
     };
+    const toggleLockedOpen = (ev)=>{
+      if(ev){
+        try{ ev.preventDefault(); }catch(err){}
+        try{ ev.stopPropagation(); }catch(err){}
+      }
+      const next = !entry.isLockedOpen;
+      setLockedOpen(next);
+      if(next){
+        highlightGroup();
+      } else {
+        restoreGroup();
+      }
+    };
+    ['pointerdown','mousedown','touchstart'].forEach(type => {
+      trigger.addEventListener(type, ev => {
+        if(type !== 'touchstart'){
+          try{ ev.preventDefault(); }catch(err){}
+        }
+        try{ ev.stopPropagation(); }catch(err){}
+      }, { capture: true });
+      iconButton.addEventListener(type, ev => {
+        if(type !== 'touchstart'){
+          try{ ev.preventDefault(); }catch(err){}
+        }
+        try{ ev.stopPropagation(); }catch(err){}
+      }, { capture: true });
+    });
+    trigger.addEventListener('click', toggleLockedOpen);
+    iconButton.addEventListener('click', toggleLockedOpen);
+
     root.addEventListener('mouseenter', highlightGroup);
     root.addEventListener('mouseleave', restoreGroup);
     root.addEventListener('focusin', highlightGroup);


### PR DESCRIPTION
## Summary
- style multi-post marker overlays with a dark rounded container that appears on hover
- add dedicated trigger and toggle logic so the marker list can be locked open when clicked

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e27896a998833194d40feae85876ca