### PR TITLE
Fix marker translate expression

### DIFF
--- a/index.html
+++ b/index.html
@@ -11990,7 +11990,7 @@ if (!map.__pillHooksInstalled) {
       const markerLabelHighlightOpacity = ['case', highlightedStateExpression, 1, 0];
       const markerLabelBaseOpacity = ['case', highlightedStateExpression, 0, 1];
       const markerStackOffsetExpression = ['coalesce', ['get','stackOffsetPx'], ['*', ['coalesce', ['get','stackIndex'], 0], markerStackSpacingPx]];
-      const markerIconTranslateExpression = ['case', ['has','iconTranslate'], ['get','iconTranslate'], ['array', 'number', markerLabelBgTranslatePx, markerStackOffsetExpression]];
+      const markerIconTranslateExpression = ['case', ['has','iconTranslate'], ['get','iconTranslate'], ['array', markerLabelBgTranslatePx, markerStackOffsetExpression]];
 
       const markerLabelMinZoom = MARKER_MIN_ZOOM;
       const labelLayersConfig = [


### PR DESCRIPTION
## Summary
- adjust the marker icon translate expression to use a valid Mapbox array expression so marker layers load without validation errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b94363608331a06454ae234add1a