### PR TITLE
Fix marker translate fallback expression type

### DIFF
--- a/index.html
+++ b/index.html
@@ -11990,7 +11990,7 @@ if (!map.__pillHooksInstalled) {
       const markerLabelHighlightOpacity = ['case', highlightedStateExpression, 1, 0];
       const markerLabelBaseOpacity = ['case', highlightedStateExpression, 0, 1];
       const markerStackOffsetExpression = ['coalesce', ['get','stackOffsetPx'], ['*', ['coalesce', ['get','stackIndex'], 0], markerStackSpacingPx]];
-      const markerIconTranslateExpression = ['case', ['has','iconTranslate'], ['get','iconTranslate'], ['array', markerLabelBgTranslatePx, markerStackOffsetExpression]];
+      const markerIconTranslateExpression = ['case', ['has','iconTranslate'], ['get','iconTranslate'], ['array', 'number', markerLabelBgTranslatePx, markerStackOffsetExpression]];
 
       const markerLabelMinZoom = MARKER_MIN_ZOOM;
       const labelLayersConfig = [


### PR DESCRIPTION
## Summary
- ensure the marker icon translate fallback expression explicitly declares the array type literal to keep values dynamic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2baffc0dc833191f92ea7659cd0a8