### PR TITLE
Preserve hover popup when reentering marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -12186,6 +12186,7 @@ if (!map.__pillHooksInstalled) {
             else if(eventLngLat){ marker.setLngLat(eventLngLat); }
             marker.addTo(map);
             marker.__fixedLngLat = fixedLngLat;
+            marker.__postId = overlayRoot.dataset.id || (post && String(post.id));
             window.__overCard = false;
             registerPopup(marker);
             return marker;
@@ -12255,29 +12256,51 @@ if (!map.__pillHooksInstalled) {
 
       // Cursor + popup for marker points
       
-      const handleMarkerMouseEnter = (e)=>{
-        map.getCanvas().style.cursor = 'pointer';
-        const f = e.features && e.features[0]; if(!f) return;
-        const props = f.properties || {};
-        const id = props.id;
-        const venueKey = props.venueKey || null;
-        const coords = f.geometry && f.geometry.coordinates;
-        const hasCoords = Array.isArray(coords) && coords.length >= 2 && Number.isFinite(coords[0]) && Number.isFinite(coords[1]);
-        const baseLngLat = hasCoords ? { lng: coords[0], lat: coords[1] } : (e && e.lngLat ? { lng: e.lngLat.lng, lat: e.lngLat.lat } : null);
-        const fixedLngLat = baseLngLat || (e && e.lngLat ? { lng: e.lngLat.lng, lat: e.lngLat.lat } : null);
-        const targetLngLat = baseLngLat || (e ? e.lngLat : null);
-        const p = posts.find(x=>x.id===id);
-        if(!p){
-          return;
-        }
-        if(hoverPopup){
-          try{ hoverPopup.remove(); }catch(e){}
-          hoverPopup = null;
+        const handleMarkerMouseEnter = (e)=>{
+          map.getCanvas().style.cursor = 'pointer';
+          const f = e.features && e.features[0]; if(!f) return;
+          const props = f.properties || {};
+          const id = props.id;
+          const hoveredId = (id !== undefined && id !== null) ? String(id) : null;
+          if(!hoveredId){
+            return;
+          }
+          const venueKey = props.venueKey || null;
+          const coords = f.geometry && f.geometry.coordinates;
+          const hasCoords = Array.isArray(coords) && coords.length >= 2 && Number.isFinite(coords[0]) && Number.isFinite(coords[1]);
+          const baseLngLat = hasCoords ? { lng: coords[0], lat: coords[1] } : (e && e.lngLat ? { lng: e.lngLat.lng, lat: e.lngLat.lat } : null);
+          const fixedLngLat = baseLngLat || (e && e.lngLat ? { lng: e.lngLat.lng, lat: e.lngLat.lat } : null);
+          const targetLngLat = baseLngLat || (e ? e.lngLat : null);
+          const p = posts.find(x=>x.id===id);
+          if(!p){
+            return;
+          }
+          if(hoverPopup){
+            let currentId = null;
+            try{
+              const existingEl = typeof hoverPopup.getElement === 'function' ? hoverPopup.getElement() : null;
+              if(existingEl && existingEl.dataset && existingEl.dataset.id){
+                currentId = existingEl.dataset.id;
+              } else if(hoverPopup.__postId !== undefined && hoverPopup.__postId !== null){
+                currentId = String(hoverPopup.__postId);
+              }
+            }catch(err){ currentId = null; }
+            if(currentId === hoveredId){
+              hoverPopup.__fixedLngLat = fixedLngLat;
+              const nextLngLat = targetLngLat || fixedLngLat;
+              if(nextLngLat && Number.isFinite(nextLngLat.lng) && Number.isFinite(nextLngLat.lat)){
+                try{ hoverPopup.setLngLat(nextLngLat); }catch(err){}
+              }
+              updateSelectedMarkerRing();
+              return;
+            }
+            try{ hoverPopup.remove(); }catch(err){}
+            hoverPopup = null;
+            updateSelectedMarkerRing();
+          }
+          hoverPopup = createMapCardOverlay(p, { targetLngLat, fixedLngLat, eventLngLat: e && e.lngLat, venueKey });
           updateSelectedMarkerRing();
-        }
-        hoverPopup = createMapCardOverlay(p, { targetLngLat, fixedLngLat, eventLngLat: e && e.lngLat, venueKey });
-        updateSelectedMarkerRing();
-      };
+        };
       MARKER_INTERACTIVE_LAYERS.forEach(layer => map.on('mouseenter', layer, handleMarkerMouseEnter));
 
       const onMarkerMove = window.rafThrottle((evt)=>{


### PR DESCRIPTION
## Summary
- store the marker post id on the hover popup marker for later comparisons
- reuse the existing hover popup when hovering the same marker by updating its coordinates instead of recreating it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e30a94e9e08331822d73f246142c42