### PR TITLE
Preserve card background during hover highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -12524,6 +12524,18 @@ if (!map.__pillHooksInstalled) {
       const id = cardEl.dataset.id;
       if(!id) return;
       const highlight = !!shouldHighlight;
+      if(highlight){
+        if(!cardEl.dataset.hoverBg){
+          cardEl.dataset.hoverBg = cardEl.style.background || '';
+        }
+        cardEl.style.background = CARD_HIGHLIGHT;
+      } else {
+        const cachedBg = cardEl.dataset.hoverBg;
+        const fallbackBg = cardEl.dataset.surfaceBg || '';
+        const restoreBg = cachedBg ? cachedBg : fallbackBg;
+        cardEl.style.background = restoreBg;
+        delete cardEl.dataset.hoverBg;
+      }
       cardEl.classList.toggle(HOVER_HIGHLIGHT_CLASS, highlight);
       const selectorId = escapeCardSelector(id);
       const relatedSelector = `.mapmarker-overlay[data-id="${selectorId}"]`;


### PR DESCRIPTION
## Summary
- cache each card's inline background before applying the hover highlight color
- restore the saved or default background once the hover highlight is removed while keeping related map overlays in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e324c859388331999c3244afdef946