### PR TITLE
Handle multi-post venue overlays on map markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,20 +150,21 @@
       left: 0;
       top: 0;
       transform: translate(-50%, -50%);
-      display: none;
+      display: flex;
       flex-direction: column;
       gap: 8px;
       padding: 10px;
       border-radius: 20px;
-      background: #000;
-      opacity: 0.7;
+      background: rgba(0, 0, 0, 0.9);
       color: #fff;
-      pointer-events: none;
+      pointer-events: auto;
       box-sizing: border-box;
       z-index: 20010;
     }
+    .multi-post-map-container:not(.is-open) .small-map-card{
+      display: none;
+    }
     .multi-post-map-container.is-open{
-      display: flex;
       pointer-events: auto;
     }
     .multi-post-map-card{
@@ -12159,7 +12160,8 @@ if (!map.__pillHooksInstalled) {
           try{
             const overlayRoot = document.createElement('div');
             overlayRoot.className = 'mapmarker-overlay';
-            overlayRoot.dataset.id = String(post.id);
+            const overlayId = String(post.id);
+            overlayRoot.dataset.id = overlayId;
             if(overlayVenueKey){
               overlayRoot.dataset.venueKey = overlayVenueKey;
             }
@@ -12167,61 +12169,184 @@ if (!map.__pillHooksInstalled) {
             overlayRoot.style.pointerEvents = 'none';
             overlayRoot.style.userSelect = 'none';
 
-            const markerContainer = document.createElement('div');
-            markerContainer.className = 'small-map-card';
-            markerContainer.dataset.id = overlayRoot.dataset.id;
-            markerContainer.setAttribute('aria-hidden', 'true');
-            markerContainer.style.pointerEvents = 'none';
-            markerContainer.style.userSelect = 'none';
-
-            const markerIcon = new Image();
-            try{ markerIcon.decoding = 'async'; }catch(e){}
-            markerIcon.alt = '';
-            markerIcon.className = 'mapmarker';
-            markerIcon.draggable = false;
             const markerSources = window.subcategoryMarkers || {};
             const markerIds = window.subcategoryMarkerIds || {};
-            const slugifyFn = typeof slugify === 'function' ? slugify : (window.slugify || (str => (str || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')));
-            const markerIdCandidates = [];
-            if(post && post.subcategory){
-              const mappedId = markerIds[post.subcategory];
-              if(mappedId) markerIdCandidates.push(mappedId);
-              markerIdCandidates.push(slugifyFn(post.subcategory));
-            }
-            const markerIconUrl = markerIdCandidates.map(id => (id && markerSources[id]) || null).find(Boolean) || '';
+            const slugifyFn = typeof slugify === 'function'
+              ? slugify
+              : (window.slugify || (str => (str || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')));
             const markerFallback = 'assets/icons-30/whats-on-category-icon-30.webp';
-            markerIcon.referrerPolicy = 'no-referrer';
-            markerIcon.loading = 'lazy';
-            markerIcon.onerror = ()=>{
-              markerIcon.onerror = null;
-              markerIcon.src = markerFallback;
+
+            const buildMarkerIconUrl = (sourcePost)=>{
+              if(!sourcePost) return '';
+              const candidates = [];
+              if(sourcePost.subcategory){
+                const mappedId = markerIds[sourcePost.subcategory];
+                if(mappedId) candidates.push(mappedId);
+                candidates.push(slugifyFn(sourcePost.subcategory));
+              }
+              for(let idx = 0; idx < candidates.length; idx++){
+                const candidateId = candidates[idx];
+                if(!candidateId) continue;
+                const iconUrl = markerSources[candidateId];
+                if(iconUrl) return iconUrl;
+              }
+              return '';
             };
-            markerIcon.src = markerIconUrl || markerFallback;
 
-            const markerPill = new Image();
-            try{ markerPill.decoding = 'async'; }catch(e){}
-            markerPill.alt = '';
-            markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
-            markerPill.className = 'mapmarker-pill';
-            markerPill.style.opacity = '0.9';
-            markerPill.style.visibility = 'visible';
-            markerPill.draggable = false;
+            const createMarkerCard = (sourcePost, options = {})=>{
+              const {
+                cardClass = 'small-map-card',
+                labelOverride = null,
+                dataId,
+                interactive = false,
+                includeIcon = true,
+                iconUrl
+              } = options;
+              const card = document.createElement('div');
+              card.className = cardClass;
+              const resolvedId = dataId !== undefined ? dataId : (sourcePost && sourcePost.id);
+              if(resolvedId !== undefined && resolvedId !== null){
+                card.dataset.id = String(resolvedId);
+              }
+              card.setAttribute('aria-hidden', 'true');
+              card.style.userSelect = 'none';
+              card.style.pointerEvents = interactive ? 'auto' : 'none';
 
-            const labelLines = getMarkerLabelLines(post);
-            const markerLabel = document.createElement('div');
-            markerLabel.className = 'mapmarker-label';
-            const markerLine1 = document.createElement('div');
-            markerLine1.className = 'mapmarker-label-line';
-            markerLine1.textContent = labelLines.line1;
-            markerLabel.appendChild(markerLine1);
-            if(labelLines.line2){
-              const markerLine2 = document.createElement('div');
-              markerLine2.className = 'mapmarker-label-line';
-              markerLine2.textContent = labelLines.line2;
-              markerLabel.appendChild(markerLine2);
+              const pillImg = new Image();
+              try{ pillImg.decoding = 'async'; }catch(e){}
+              pillImg.alt = '';
+              pillImg.src = 'assets/icons-30/150x40-pill-70.webp';
+              pillImg.className = 'mapmarker-pill';
+              pillImg.style.opacity = '0.9';
+              pillImg.style.visibility = 'visible';
+              pillImg.draggable = false;
+
+              let markerIcon = null;
+              if(includeIcon){
+                markerIcon = new Image();
+                try{ markerIcon.decoding = 'async'; }catch(e){}
+                markerIcon.alt = '';
+                markerIcon.className = 'mapmarker';
+                markerIcon.draggable = false;
+                markerIcon.referrerPolicy = 'no-referrer';
+                markerIcon.loading = 'lazy';
+                markerIcon.onerror = ()=>{
+                  markerIcon.onerror = null;
+                  markerIcon.src = markerFallback;
+                };
+                markerIcon.src = iconUrl || buildMarkerIconUrl(sourcePost) || markerFallback;
+              }
+
+              const markerLabel = document.createElement('div');
+              markerLabel.className = 'mapmarker-label';
+              const labelLines = labelOverride
+                ? {
+                    line1: labelOverride.line1 || '',
+                    line2: labelOverride.line2 || ''
+                  }
+                : getMarkerLabelLines(sourcePost);
+              const markerLine1 = document.createElement('div');
+              markerLine1.className = 'mapmarker-label-line';
+              markerLine1.textContent = labelLines.line1;
+              markerLabel.appendChild(markerLine1);
+              if(labelLines.line2){
+                const markerLine2 = document.createElement('div');
+                markerLine2.className = 'mapmarker-label-line';
+                markerLine2.textContent = labelLines.line2;
+                markerLabel.appendChild(markerLine2);
+              }
+
+              if(includeIcon && markerIcon){
+                card.append(pillImg, markerIcon, markerLabel);
+              } else {
+                card.append(pillImg, markerLabel);
+              }
+
+              return { card, labelLines };
+            };
+
+            const { card: markerContainer, labelLines } = createMarkerCard(post, { dataId: overlayId });
+
+            let relatedPostsAtVenue = [];
+            if(overlayVenueKey){
+              const seenPostIds = new Set();
+              const addCandidate = (candidate, entry)=>{
+                if(!candidate) return;
+                const candidateId = candidate.id;
+                const key = candidateId !== undefined && candidateId !== null ? String(candidateId) : null;
+                if(key && seenPostIds.has(key)) return;
+                if(key){
+                  seenPostIds.add(key);
+                }
+                relatedPostsAtVenue.push({ post: candidate, entry });
+              };
+              const baseEntries = collectLocationEntries(post) || [];
+              const baseMatch = baseEntries.find(entry => entry && entry.key === overlayVenueKey) || baseEntries[0] || null;
+              addCandidate(post, baseMatch);
+              posts.forEach(candidate => {
+                if(!candidate || candidate === post) return;
+                const entries = collectLocationEntries(candidate);
+                const matchEntry = entries.find(entry => entry && entry.key === overlayVenueKey);
+                if(matchEntry){
+                  addCandidate(candidate, matchEntry);
+                }
+              });
             }
 
-            markerContainer.append(markerPill, markerIcon, markerLabel);
+            const hasMultiplePostsAtVenue = relatedPostsAtVenue.length > 1;
+            if(hasMultiplePostsAtVenue){
+              markerContainer.style.pointerEvents = 'auto';
+            }
+
+            let multiPostContainer = null;
+            if(hasMultiplePostsAtVenue){
+              multiPostContainer = document.createElement('div');
+              multiPostContainer.className = 'multi-post-map-container';
+              if(overlayVenueKey){
+                multiPostContainer.dataset.venueKey = overlayVenueKey;
+              }
+              multiPostContainer.dataset.count = String(relatedPostsAtVenue.length);
+
+              const venueNameSource = relatedPostsAtVenue.find(item => item && item.entry && item.entry.loc && item.entry.loc.venue);
+              const summaryVenueName = venueNameSource && venueNameSource.entry && venueNameSource.entry.loc && venueNameSource.entry.loc.venue
+                ? venueNameSource.entry.loc.venue
+                : (getPrimaryVenueName(post) || post.city || '');
+              const postCountLabel = `${relatedPostsAtVenue.length} ${relatedPostsAtVenue.length === 1 ? 'post' : 'posts'} here`;
+              const summaryCardData = createMarkerCard(post, {
+                cardClass: 'multi-post-map-card',
+                labelOverride: { line1: postCountLabel, line2: summaryVenueName || '' },
+                dataId: overlayVenueKey ? `venue:${overlayVenueKey}` : null,
+                interactive: true
+              });
+              const summaryCard = summaryCardData.card;
+              summaryCard.dataset.summary = 'true';
+              summaryCard.setAttribute('aria-hidden', 'false');
+              if(overlayVenueKey){
+                summaryCard.dataset.venueKey = overlayVenueKey;
+              }
+              multiPostContainer.appendChild(summaryCard);
+
+              relatedPostsAtVenue.forEach(item => {
+                if(!item || !item.post) return;
+                const targetPost = item.post;
+                const targetId = targetPost.id;
+                const isPrimary = String(targetId) === overlayId;
+                let cardElement = null;
+                if(isPrimary){
+                  cardElement = markerContainer;
+                } else {
+                  const cardData = createMarkerCard(targetPost, { interactive: true });
+                  cardElement = cardData.card;
+                }
+                if(!cardElement) return;
+                if(targetId !== undefined && targetId !== null){
+                  cardElement.dataset.id = String(targetId);
+                }
+                cardElement.setAttribute('aria-hidden', 'false');
+                cardElement.style.pointerEvents = 'auto';
+                multiPostContainer.appendChild(cardElement);
+              });
+            }
 
             const cardRoot = document.createElement('div');
             cardRoot.className = 'big-map-card big-map-card--popup';
@@ -12282,7 +12407,12 @@ if (!map.__pillHooksInstalled) {
             }
 
             cardRoot.append(pillImg, thumbImg, labelEl);
-            overlayRoot.append(markerContainer, cardRoot);
+            if(multiPostContainer){
+              overlayRoot.append(multiPostContainer);
+            } else {
+              overlayRoot.append(markerContainer);
+            }
+            overlayRoot.append(cardRoot);
             overlayRoot.classList.add('is-card-visible');
             overlayRoot.style.pointerEvents = '';
 


### PR DESCRIPTION
## Summary
- detect when multiple posts share a venue key while building marker overlays and collect their data for aggregation
- render a multi-post map container with a summary pill plus per-post cards so existing multi-post interactions can control it
- tweak multi-post container styling to keep the summary visible while showing child cards only when expanded

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e32afdfe4c8331a961c8b09da187d5