### PR TITLE
Use dedicated icon for multi-post map cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -7575,6 +7575,10 @@ function mulberry32(a){ return function(){var t=a+=0x6D2B79F5; t=Math.imul(t^t>>
     const subcategoryIcons = window.subcategoryIcons = {};
     const subcategoryMarkers = window.subcategoryMarkers = {};
     const subcategoryMarkerIds = window.subcategoryMarkerIds = {};
+    const MULTI_POST_MAPMARKER_ID = 'multi-post-mapmarker';
+    const MULTI_POST_MAPMARKER_URL = 'assets/icons-30/multi-post-icon-30.webp';
+    subcategoryMarkers[MULTI_POST_MAPMARKER_ID] = MULTI_POST_MAPMARKER_URL;
+    subcategoryMarkerIds[MULTI_POST_MAPMARKER_ID] = MULTI_POST_MAPMARKER_ID;
     const categoryShapes = window.categoryShapes = {};
 
     // --- Icon loader: ensures Mapbox images are available and quiets missing-image logs ---
@@ -7582,7 +7586,7 @@ function mulberry32(a){ return function(){var t=a+=0x6D2B79F5; t=Math.imul(t^t>>
       if(!mapInstance) return () => Promise.resolve(false);
       const KNOWN = [
         'freebies','live-sport','volunteers','goods-and-services','clubs','artwork',
-        'live-gigs','for-sale','education-centres','tutors'
+        'live-gigs','for-sale','education-centres','tutors','multi-post-mapmarker'
       ];
       const BASES = [
         'assets/icons/subcategories/',
@@ -12223,6 +12227,10 @@ if (!map.__pillHooksInstalled) {
 
               let markerIcon = null;
               if(includeIcon){
+                const isMultiPostCard = cardClass === 'multi-post-map-card';
+                const fallbackIcon = isMultiPostCard ? MULTI_POST_MAPMARKER_URL : markerFallback;
+                const resolvedIcon = iconUrl
+                  || (isMultiPostCard ? MULTI_POST_MAPMARKER_URL : buildMarkerIconUrl(sourcePost));
                 markerIcon = new Image();
                 try{ markerIcon.decoding = 'async'; }catch(e){}
                 markerIcon.alt = '';
@@ -12232,9 +12240,9 @@ if (!map.__pillHooksInstalled) {
                 markerIcon.loading = 'lazy';
                 markerIcon.onerror = ()=>{
                   markerIcon.onerror = null;
-                  markerIcon.src = markerFallback;
+                  markerIcon.src = fallbackIcon;
                 };
-                markerIcon.src = iconUrl || buildMarkerIconUrl(sourcePost) || markerFallback;
+                markerIcon.src = resolvedIcon || fallbackIcon;
               }
 
               const markerLabel = document.createElement('div');


### PR DESCRIPTION
## Summary
- register the multi-post marker asset and preload identifier for Mapbox
- ensure grouped overlay cards render with the dedicated multi-post marker icon

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e32ed0c3dc8331bf251a7619130643