### PR TITLE
Fix multi-post map card placement and marker rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,9 @@
       box-sizing: border-box;
       transition: background-color 0.2s ease;
     }
+    .multi-post-map-card{
+      transform: translate(calc(-50% + 55px), -50%);
+    }
     .mapmarker{
       position: relative;
       left: auto;
@@ -168,6 +171,28 @@
     }
     .multi-post-map-card{
       pointer-events: auto;
+      gap: 0;
+    }
+    .multi-post-map-card .mapmarker-pill{
+      z-index: 0;
+    }
+    .multi-post-map-card .mapmarker{
+      position: relative;
+      z-index: 1;
+    }
+    .multi-post-map-label{
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 1px;
+      margin-left: 5px;
+      text-align: left;
+      color: inherit;
+      z-index: 1;
+      min-width: 0;
+    }
+    .multi-post-map-label .mapmarker-label-line{
+      width: 100%;
     }
     .multi-post-map-container .small-map-card{
       position: relative;
@@ -7330,6 +7355,7 @@ if (typeof slugify !== 'function') {
         ? hoverPopup.getElement()
         : null;
       const overlayId = overlayEl && overlayEl.dataset ? String(overlayEl.dataset.id || '') : '';
+      const overlayMultiIds = overlayEl && overlayEl.dataset ? parseMultiPostIds(overlayEl.dataset.multiPostIds || '') : [];
       let fallbackId = '';
       if(!overlayId){
         if(activePostId !== undefined && activePostId !== null){
@@ -7339,7 +7365,7 @@ if (typeof slugify !== 'function') {
           fallbackId = openEl && openEl.dataset ? String(openEl.dataset.id || '') : '';
         }
       }
-      const idsToHighlight = Array.from(new Set([overlayId, fallbackId].filter(Boolean)));
+      const idsToHighlight = Array.from(new Set([overlayId, fallbackId, ...overlayMultiIds].filter(Boolean)));
       if(!idsToHighlight.length){
         updateMapFeatureHighlights([]);
         return;
@@ -7365,6 +7391,17 @@ if (typeof slugify !== 'function') {
         });
         document.querySelectorAll(`.mapmarker-overlay[data-id="${selectorId}"] .big-map-card`).forEach(el => {
           el.classList.add(highlightClass);
+        });
+      });
+      const highlightIdSet = new Set(idsToHighlight.map(String));
+      document.querySelectorAll('.mapmarker-overlay[data-multi-post-ids]').forEach(overlay => {
+        const idsAttr = overlay && overlay.dataset ? overlay.dataset.multiPostIds || '' : '';
+        if(!idsAttr) return;
+        const overlayIds = parseMultiPostIds(idsAttr);
+        if(!overlayIds.length) return;
+        const shouldHighlight = overlayIds.some(pid => highlightIdSet.has(String(pid)));
+        overlay.querySelectorAll('.multi-post-map-card').forEach(card => {
+          card.classList.toggle(markerHighlightClass, shouldHighlight);
         });
       });
       updateMapFeatureHighlights(idsToHighlight);
@@ -7575,6 +7612,10 @@ function mulberry32(a){ return function(){var t=a+=0x6D2B79F5; t=Math.imul(t^t>>
     const subcategoryMarkers = window.subcategoryMarkers = {};
     const subcategoryMarkerIds = window.subcategoryMarkerIds = {};
     const categoryShapes = window.categoryShapes = {};
+
+    const MULTI_POST_MAPMARKER_ID = 'multi-post-mapmarker';
+    const MULTI_POST_MAPMARKER_URL = 'assets/icons-30/multi-post-icon-30.webp';
+    subcategoryMarkers[MULTI_POST_MAPMARKER_ID] = MULTI_POST_MAPMARKER_URL;
 
     // --- Icon loader: ensures Mapbox images are available and quiets missing-image logs ---
     function attachIconLoader(mapInstance){
@@ -9510,6 +9551,162 @@ function makePosts(){
     let postBoardScrollOptions = null;
     const INITIAL_RENDER_COUNT = 50;
     const POST_BATCH_SIZE = 25;
+
+    function postMatchesVenueKey(post, key){
+      if(!post || !key) return false;
+      const normalizedKey = String(key);
+      if(Array.isArray(post.locations) && post.locations.length){
+        for(const loc of post.locations){
+          if(!loc) continue;
+          const locKey = toVenueCoordKey(loc.lng, loc.lat);
+          if(locKey && locKey === normalizedKey){
+            return true;
+          }
+        }
+      }
+      if(Number.isFinite(post.lng) && Number.isFinite(post.lat)){
+        const locKey = toVenueCoordKey(post.lng, post.lat);
+        if(locKey && locKey === normalizedKey){
+          return true;
+        }
+      }
+      return false;
+    }
+
+    function getPrimaryVenueKeyForPost(post){
+      if(!post) return '';
+      if(Array.isArray(post.locations) && post.locations.length){
+        for(const loc of post.locations){
+          if(!loc) continue;
+          const locKey = toVenueCoordKey(loc.lng, loc.lat);
+          if(locKey){
+            return locKey;
+          }
+        }
+      }
+      if(Number.isFinite(post.lng) && Number.isFinite(post.lat)){
+        const locKey = toVenueCoordKey(post.lng, post.lat);
+        if(locKey){
+          return locKey;
+        }
+      }
+      return '';
+    }
+
+    function getActivePostsForVenue(){
+      if(filtersInitialized){
+        return Array.isArray(filtered) ? filtered : [];
+      }
+      if(Array.isArray(filtered) && filtered.length){
+        return filtered;
+      }
+      return Array.isArray(posts) ? posts : [];
+    }
+
+    function getVenuePosts(venueKey){
+      const key = typeof venueKey === 'string' ? venueKey : '';
+      if(!key){
+        return [];
+      }
+      const list = getActivePostsForVenue();
+      const result = [];
+      const seen = new Set();
+      (Array.isArray(list) ? list : []).forEach(post => {
+        if(!post) return;
+        const id = post.id;
+        if(id !== undefined && id !== null && seen.has(id)){
+          return;
+        }
+        if(postMatchesVenueKey(post, key)){
+          result.push(post);
+          if(id !== undefined && id !== null){
+            seen.add(id);
+          }
+        }
+      });
+      return result;
+    }
+
+    function getVenueNameForKey(post, key){
+      if(!post){
+        return '';
+      }
+      if(Array.isArray(post.locations) && post.locations.length){
+        const match = post.locations.find(loc => loc && toVenueCoordKey(loc.lng, loc.lat) === key && loc.venue);
+        if(match && match.venue){
+          return match.venue;
+        }
+      }
+      if(post.venue){
+        return post.venue;
+      }
+      return getPrimaryVenueName(post);
+    }
+
+    function getFirstPostForVenue(venueKey){
+      const key = typeof venueKey === 'string' ? venueKey : '';
+      if(!key){
+        return null;
+      }
+      const matches = getVenuePosts(key);
+      if(!matches.length){
+        return null;
+      }
+      if(Array.isArray(sortedPostList) && sortedPostList.length){
+        for(const post of sortedPostList){
+          if(postMatchesVenueKey(post, key)){
+            return post;
+          }
+        }
+      }
+      return matches[0] || null;
+    }
+
+    function parseMultiPostIds(attr){
+      if(!attr) return [];
+      return attr.split(',').map(id => id.trim()).filter(Boolean);
+    }
+
+    function updateMultiPostCardOverlays(){
+      document.querySelectorAll('.mapmarker-overlay[data-multi="true"]').forEach(overlay => {
+        if(!overlay || !overlay.dataset) return;
+        const venueKey = overlay.dataset.venueKey || '';
+        if(!venueKey){
+          return;
+        }
+        const postsAtVenue = getVenuePosts(venueKey);
+        const ids = postsAtVenue.map(post => String(post.id));
+        overlay.dataset.multiPostIds = ids.join(',');
+        overlay.dataset.multiCount = String(ids.length);
+        const primary = getFirstPostForVenue(venueKey);
+        const primaryId = primary && primary.id !== undefined && primary.id !== null
+          ? String(primary.id)
+          : (ids[0] || '');
+        if(primaryId){
+          overlay.dataset.id = primaryId;
+          overlay.dataset.primaryPostId = primaryId;
+        }
+        const card = overlay.querySelector('.multi-post-map-card');
+        if(card){
+          card.dataset.count = String(ids.length);
+          const countLine = card.querySelector('.multi-post-map-count');
+          if(countLine){
+            countLine.textContent = `${ids.length} posts here`;
+          }
+          const venueLine = card.querySelector('.multi-post-map-venue');
+          if(venueLine){
+            const venueName = primary ? getVenueNameForKey(primary, venueKey) : '';
+            venueLine.textContent = venueName;
+          }
+        }
+        if(hoverPopup && typeof getPopupElement === 'function'){
+          const popupEl = getPopupElement(hoverPopup);
+          if(popupEl === overlay && primaryId){
+            hoverPopup.__postId = primaryId;
+          }
+        }
+      });
+    }
 
     function appendPostBatch(count = POST_BATCH_SIZE){
       const slice = sortedPostList.slice(renderedPostCount, renderedPostCount + count);
@@ -11881,6 +12078,58 @@ if (!map.__pillHooksInstalled) {
       if(!Array.isArray(list) || !list.length){
         return { type:'FeatureCollection', features };
       }
+      const venuePostBuckets = new Map();
+      let anonPostKeyCounter = 0;
+      const toPostKey = (post) => {
+        if(!post) return '';
+        if(post.id !== undefined && post.id !== null){
+          return `id:${post.id}`;
+        }
+        if(post.slug){
+          return `slug:${post.slug}`;
+        }
+        if(post.title || post.created){
+          return `fallback:${post.title || ''}|${post.created || ''}`;
+        }
+        anonPostKeyCounter += 1;
+        return `anon:${anonPostKeyCounter}`;
+      };
+      list.forEach(p => {
+        if(!p) return;
+        const entries = collectLocationEntries(p);
+        if(!entries.length) return;
+        const postKey = toPostKey(p);
+        const seenVenueKeys = new Set();
+        entries.forEach(entry => {
+          if(!entry || !entry.key) return;
+          const key = entry.key;
+          if(seenVenueKeys.has(key)) return;
+          seenVenueKeys.add(key);
+          let bucket = venuePostBuckets.get(key);
+          if(!bucket){
+            bucket = {
+              postKeys: new Set(),
+              ids: new Set(),
+              posts: [],
+              venueName: entry.loc && entry.loc.venue ? entry.loc.venue : '',
+              lng: entry.lng,
+              lat: entry.lat
+            };
+            venuePostBuckets.set(key, bucket);
+          }
+          bucket.postKeys.add(postKey);
+          if(p && p.id !== undefined && p.id !== null){
+            bucket.ids.add(String(p.id));
+          }
+          bucket.posts.push(p);
+          if(!bucket.venueName){
+            const fallbackVenue = entry.loc && entry.loc.venue
+              ? entry.loc.venue
+              : getPrimaryVenueName(p);
+            bucket.venueName = fallbackVenue || bucket.venueName || '';
+          }
+        });
+      });
       list.forEach(p => {
         if(!p) return;
         const entries = collectLocationEntries(p);
@@ -11889,9 +12138,26 @@ if (!map.__pillHooksInstalled) {
           const key = entry.key;
           const post = entry.post || p;
           const baseSub = subcategoryMarkerIds[post.subcategory] || slugify(post.subcategory);
-          const labelLines = getMarkerLabelLines(post);
+          const bucket = venuePostBuckets.get(key);
+          const bucketCount = bucket ? Math.max(bucket.ids.size || 0, bucket.postKeys.size || 0) : 0;
+          const multiCount = bucketCount > 0 ? bucketCount : 1;
+          const isMultiVenue = multiCount > 1;
+          const venueLabel = bucket && bucket.venueName
+            ? bucket.venueName
+            : (entry.loc && entry.loc.venue ? entry.loc.venue : getPrimaryVenueName(post));
+          const baseLabelLines = getMarkerLabelLines(post);
+          let labelLines = baseLabelLines;
+          if(isMultiVenue){
+            const venueText = shortenMarkerLabelText(venueLabel || '', markerLabelTextAreaWidthPx);
+            labelLines = Object.assign({}, baseLabelLines, {
+              line1: shortenMarkerLabelText(`${multiCount} posts here`, markerLabelTextAreaWidthPx),
+              line2: venueText,
+              venueLine: shortenMarkerLabelText(venueLabel || '', mapCardTitleWidthPx)
+            });
+          }
+          const iconId = isMultiVenue ? MULTI_POST_MAPMARKER_ID : (baseSub || '');
           const combinedLabel = buildMarkerLabelText(post, labelLines);
-          const spriteSource = [baseSub || '', labelLines.line1 || '', labelLines.line2 || ''].join('|');
+          const spriteSource = [iconId || '', labelLines.line1 || '', labelLines.line2 || ''].join('|');
           const labelSpriteId = hashString(spriteSource);
           const featureId = `post:${post.id}::${key}::${entry.index}`;
           const venueName = entry.loc && entry.loc.venue ? entry.loc.venue : getPrimaryVenueName(post);
@@ -11909,10 +12175,16 @@ if (!map.__pillHooksInstalled) {
               venueName,
               city: post.city,
               cat: post.category,
-              sub: baseSub,
+              sub: iconId,
               baseSub,
               venueKey: key,
-              locationIndex: entry.index
+              locationIndex: entry.index,
+              isMulti: isMultiVenue,
+              multiCount,
+              multiVenueName: venueLabel || '',
+              multiPostIds: bucket && bucket.ids && bucket.ids.size
+                ? Array.from(bucket.ids).join(',')
+                : ''
             },
             geometry:{ type:'Point', coordinates:[entry.lng, entry.lat] }
           });
@@ -11996,7 +12268,7 @@ if (!map.__pillHooksInstalled) {
           const iconId = props.sub || props.baseSub || '';
           const labelLine1 = props.labelLine1 || '';
           const labelLine2 = props.labelLine2 || '';
-          const isMulti = false;
+          const isMulti = Boolean(props.isMulti);
           const priority = Boolean((stored ? stored.priority : false) || inView || existing.priority);
           const lastUsed = Number.isFinite(existing.lastUsed) ? existing.lastUsed : 0;
           const updatedMeta = Object.assign({}, existing, {
@@ -12159,171 +12431,304 @@ if (!map.__pillHooksInstalled) {
           try{
             const overlayRoot = document.createElement('div');
             overlayRoot.className = 'mapmarker-overlay';
-            overlayRoot.dataset.id = String(post.id);
-            if(overlayVenueKey){
-              overlayRoot.dataset.venueKey = overlayVenueKey;
-            }
             overlayRoot.setAttribute('aria-hidden', 'true');
             overlayRoot.style.pointerEvents = 'none';
             overlayRoot.style.userSelect = 'none';
 
-            const markerContainer = document.createElement('div');
-            markerContainer.className = 'small-map-card';
-            markerContainer.dataset.id = overlayRoot.dataset.id;
-            markerContainer.setAttribute('aria-hidden', 'true');
-            markerContainer.style.pointerEvents = 'none';
-            markerContainer.style.userSelect = 'none';
-
-            const markerIcon = new Image();
-            try{ markerIcon.decoding = 'async'; }catch(e){}
-            markerIcon.alt = '';
-            markerIcon.className = 'mapmarker';
-            markerIcon.draggable = false;
-            const markerSources = window.subcategoryMarkers || {};
-            const markerIds = window.subcategoryMarkerIds || {};
-            const slugifyFn = typeof slugify === 'function' ? slugify : (window.slugify || (str => (str || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')));
-            const markerIdCandidates = [];
-            if(post && post.subcategory){
-              const mappedId = markerIds[post.subcategory];
-              if(mappedId) markerIdCandidates.push(mappedId);
-              markerIdCandidates.push(slugifyFn(post.subcategory));
-            }
-            const markerIconUrl = markerIdCandidates.map(id => (id && markerSources[id]) || null).find(Boolean) || '';
-            const markerFallback = 'assets/icons-30/whats-on-category-icon-30.webp';
-            markerIcon.referrerPolicy = 'no-referrer';
-            markerIcon.loading = 'lazy';
-            markerIcon.onerror = ()=>{
-              markerIcon.onerror = null;
-              markerIcon.src = markerFallback;
-            };
-            markerIcon.src = markerIconUrl || markerFallback;
-
-            const markerPill = new Image();
-            try{ markerPill.decoding = 'async'; }catch(e){}
-            markerPill.alt = '';
-            markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
-            markerPill.className = 'mapmarker-pill';
-            markerPill.style.opacity = '0.9';
-            markerPill.style.visibility = 'visible';
-            markerPill.draggable = false;
-
-            const labelLines = getMarkerLabelLines(post);
-            const markerLabel = document.createElement('div');
-            markerLabel.className = 'mapmarker-label';
-            const markerLine1 = document.createElement('div');
-            markerLine1.className = 'mapmarker-label-line';
-            markerLine1.textContent = labelLines.line1;
-            markerLabel.appendChild(markerLine1);
-            if(labelLines.line2){
-              const markerLine2 = document.createElement('div');
-              markerLine2.className = 'mapmarker-label-line';
-              markerLine2.textContent = labelLines.line2;
-              markerLabel.appendChild(markerLine2);
+            const resolvedVenueKey = overlayVenueKey || getPrimaryVenueKeyForPost(post);
+            if(resolvedVenueKey){
+              overlayRoot.dataset.venueKey = resolvedVenueKey;
+            } else if(overlayRoot.dataset && overlayRoot.dataset.venueKey){
+              delete overlayRoot.dataset.venueKey;
             }
 
-            markerContainer.append(markerPill, markerIcon, markerLabel);
+            const venuePosts = resolvedVenueKey ? getVenuePosts(resolvedVenueKey) : [];
+            const multiCount = venuePosts.length;
+            const isMultiVenue = resolvedVenueKey && multiCount > 1;
+            const primaryPost = isMultiVenue ? (getFirstPostForVenue(resolvedVenueKey) || post) : post;
+            const primaryId = primaryPost && primaryPost.id !== undefined && primaryPost.id !== null
+              ? String(primaryPost.id)
+              : (post && post.id !== undefined && post.id !== null ? String(post.id) : '');
 
-            const cardRoot = document.createElement('div');
-            cardRoot.className = 'big-map-card big-map-card--popup';
-            cardRoot.dataset.id = overlayRoot.dataset.id;
-            cardRoot.setAttribute('aria-hidden', 'true');
-            cardRoot.style.pointerEvents = 'auto';
-            cardRoot.style.userSelect = 'none';
-
-            const pillImg = new Image();
-            try{ pillImg.decoding = 'async'; }catch(e){}
-            pillImg.alt = '';
-            pillImg.src = 'assets/icons-30/225x60-pill-99.webp';
-            pillImg.className = 'big-map-card-pill';
-            pillImg.style.opacity = '0.9';
-            pillImg.draggable = false;
-
-            const thumbImg = new Image();
-            try{ thumbImg.decoding = 'async'; }catch(e){}
-            thumbImg.alt = '';
-            const thumbFallback = 'assets/funmap-logo-small.png';
-            thumbImg.loading = 'lazy';
-            thumbImg.onerror = ()=>{
-              thumbImg.onerror = null;
-              thumbImg.src = thumbFallback;
-            };
-            thumbImg.src = imgThumb(post) || thumbFallback;
-            thumbImg.className = 'big-map-card-thumb';
-            thumbImg.referrerPolicy = 'no-referrer';
-            thumbImg.draggable = false;
-
-            const labelEl = document.createElement('div');
-            labelEl.className = 'big-map-card-label';
-            const titleWrap = document.createElement('div');
-            titleWrap.className = 'big-map-card-title';
-            const cardTitleLines = Array.isArray(labelLines.cardTitleLines) && labelLines.cardTitleLines.length
-              ? labelLines.cardTitleLines.slice(0, 2)
-              : [labelLines.line1, labelLines.line2].filter(Boolean).slice(0, 2);
-            cardTitleLines.forEach(line => {
-              if(!line) return;
-              const lineEl = document.createElement('div');
-              lineEl.className = 'big-map-card-title-line';
-              lineEl.textContent = line;
-              titleWrap.appendChild(lineEl);
-            });
-            if(!titleWrap.childElementCount){
-              const lineEl = document.createElement('div');
-              lineEl.className = 'big-map-card-title-line';
-              lineEl.textContent = '';
-              titleWrap.appendChild(lineEl);
-            }
-            labelEl.appendChild(titleWrap);
-            const venueLine = labelLines.venueLine || shortenMarkerLabelText(getPrimaryVenueName(post), mapCardTitleWidthPx);
-            if(venueLine){
-              const venueEl = document.createElement('div');
-              venueEl.className = 'big-map-card-venue';
-              venueEl.textContent = venueLine;
-              labelEl.appendChild(venueEl);
+            if(primaryId){
+              overlayRoot.dataset.id = primaryId;
+              overlayRoot.dataset.primaryPostId = primaryId;
+            } else {
+              overlayRoot.dataset.id = '';
+              if(overlayRoot.dataset.primaryPostId){
+                delete overlayRoot.dataset.primaryPostId;
+              }
             }
 
-            cardRoot.append(pillImg, thumbImg, labelEl);
-            overlayRoot.append(markerContainer, cardRoot);
-            overlayRoot.classList.add('is-card-visible');
-            overlayRoot.style.pointerEvents = '';
+            if(isMultiVenue){
+              overlayRoot.dataset.multi = 'true';
+              overlayRoot.dataset.multiPostIds = venuePosts.map(p => String(p.id)).join(',');
+              overlayRoot.dataset.multiCount = String(multiCount);
+            } else {
+              if(overlayRoot.dataset.multi){
+                delete overlayRoot.dataset.multi;
+              }
+              if(overlayRoot.dataset.multiPostIds){
+                delete overlayRoot.dataset.multiPostIds;
+              }
+              if(overlayRoot.dataset.multiCount){
+                delete overlayRoot.dataset.multiCount;
+              }
+            }
 
-            const handleOverlayClick = (ev)=>{
-              ev.preventDefault();
-              ev.stopPropagation();
-              const pid = overlayRoot.dataset.id;
-              if(!pid) return;
-              callWhenDefined('openPost', (fn)=>{
-                requestAnimationFrame(() => {
-                  try{
-                    touchMarker = null;
-                    stopSpin();
-                    if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
-                      try{ closePanel(filterPanel); }catch(err){}
-                    }
-                    fn(pid, false, true);
-                  }catch(err){ console.error(err); }
-                });
-              });
-            };
-            cardRoot.addEventListener('click', handleOverlayClick, { capture: true });
-            ['pointerdown','mousedown','touchstart'].forEach(type => {
-              cardRoot.addEventListener(type, (ev)=>{
-                const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
-                const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
-                if(!isTouchLike){
-                  try{ ev.preventDefault(); }catch(err){}
+            if(isMultiVenue){
+              const markerContainer = document.createElement('div');
+              markerContainer.className = 'multi-post-map-card';
+              markerContainer.dataset.id = overlayRoot.dataset.id || '';
+              markerContainer.dataset.count = String(multiCount);
+              markerContainer.dataset.venueKey = resolvedVenueKey;
+              markerContainer.setAttribute('aria-hidden', 'true');
+              markerContainer.style.pointerEvents = 'auto';
+              markerContainer.style.userSelect = 'none';
+
+              const markerPill = new Image();
+              try{ markerPill.decoding = 'async'; }catch(e){}
+              markerPill.alt = '';
+              markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+              markerPill.className = 'mapmarker-pill';
+              markerPill.style.opacity = '0.9';
+              markerPill.style.visibility = 'visible';
+              markerPill.draggable = false;
+
+              const markerIcon = new Image();
+              try{ markerIcon.decoding = 'async'; }catch(e){}
+              markerIcon.alt = '';
+              markerIcon.className = 'mapmarker';
+              markerIcon.draggable = false;
+              markerIcon.referrerPolicy = 'no-referrer';
+              markerIcon.loading = 'lazy';
+              markerIcon.onerror = ()=>{
+                markerIcon.onerror = null;
+                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+              };
+              markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+
+              const markerLabel = document.createElement('div');
+              markerLabel.className = 'mapmarker-label multi-post-map-label';
+              const countLine = document.createElement('div');
+              countLine.className = 'mapmarker-label-line multi-post-map-count';
+              countLine.textContent = `${multiCount} posts here`;
+              markerLabel.appendChild(countLine);
+              const venueLineEl = document.createElement('div');
+              venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
+              const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
+              venueLineEl.textContent = venueText || '';
+              markerLabel.appendChild(venueLineEl);
+
+              markerContainer.append(markerPill, markerIcon, markerLabel);
+              overlayRoot.append(markerContainer);
+              overlayRoot.classList.add('is-card-visible');
+              overlayRoot.style.pointerEvents = '';
+
+              const handleMultiCardClick = (ev)=>{
+                ev.preventDefault();
+                ev.stopPropagation();
+                const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
+                const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
+                if(!pid) return;
+                activePostId = firstPost.id;
+                if(resolvedVenueKey){
+                  selectedVenueKey = resolvedVenueKey;
                 }
-                try{ ev.stopPropagation(); }catch(err){}
-              }, { capture: true });
-            });
-            cardRoot.addEventListener('mouseenter', ()=>{
-              window.__overCard = true;
-            });
-            cardRoot.addEventListener('mouseleave', ()=>{
-              window.__overCard = false;
-              if(listLocked) return;
-              const currentPopup = hoverPopup;
-              schedulePopupRemoval(currentPopup, 160);
-            });
+                updateSelectedMarkerRing();
+                callWhenDefined('openPost', (fn)=>{
+                  requestAnimationFrame(() => {
+                    try{
+                      touchMarker = null;
+                      stopSpin();
+                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                        try{ closePanel(filterPanel); }catch(err){}
+                      }
+                      fn(pid, false, true);
+                    }catch(err){ console.error(err); }
+                  });
+                });
+              };
+              markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
+              ['pointerdown','mousedown','touchstart'].forEach(type => {
+                markerContainer.addEventListener(type, (ev)=>{
+                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+                  if(!isTouchLike){
+                    try{ ev.preventDefault(); }catch(err){}
+                  }
+                  try{ ev.stopPropagation(); }catch(err){}
+                }, { capture: true });
+              });
+              markerContainer.addEventListener('mouseenter', ()=>{
+                window.__overCard = true;
+              });
+              markerContainer.addEventListener('mouseleave', ()=>{
+                window.__overCard = false;
+                if(listLocked) return;
+                const currentPopup = hoverPopup;
+                schedulePopupRemoval(currentPopup, 160);
+              });
+              updateMultiPostCardOverlays();
+            } else {
+              const markerContainer = document.createElement('div');
+              markerContainer.className = 'small-map-card';
+              markerContainer.dataset.id = overlayRoot.dataset.id;
+              markerContainer.setAttribute('aria-hidden', 'true');
+              markerContainer.style.pointerEvents = 'none';
+              markerContainer.style.userSelect = 'none';
+
+              const markerIcon = new Image();
+              try{ markerIcon.decoding = 'async'; }catch(e){}
+              markerIcon.alt = '';
+              markerIcon.className = 'mapmarker';
+              markerIcon.draggable = false;
+              const markerSources = window.subcategoryMarkers || {};
+              const markerIds = window.subcategoryMarkerIds || {};
+              const slugifyFn = typeof slugify === 'function' ? slugify : (window.slugify || (str => (str || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')));
+              const markerIdCandidates = [];
+              if(post && post.subcategory){
+                const mappedId = markerIds[post.subcategory];
+                if(mappedId) markerIdCandidates.push(mappedId);
+                markerIdCandidates.push(slugifyFn(post.subcategory));
+              }
+              const markerIconUrl = markerIdCandidates.map(id => (id && markerSources[id]) || null).find(Boolean) || '';
+              const markerFallback = 'assets/icons-30/whats-on-category-icon-30.webp';
+              markerIcon.referrerPolicy = 'no-referrer';
+              markerIcon.loading = 'lazy';
+              markerIcon.onerror = ()=>{
+                markerIcon.onerror = null;
+                markerIcon.src = markerFallback;
+              };
+              markerIcon.src = markerIconUrl || markerFallback;
+
+              const markerPill = new Image();
+              try{ markerPill.decoding = 'async'; }catch(e){}
+              markerPill.alt = '';
+              markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+              markerPill.className = 'mapmarker-pill';
+              markerPill.style.opacity = '0.9';
+              markerPill.style.visibility = 'visible';
+              markerPill.draggable = false;
+
+              const labelLines = getMarkerLabelLines(post);
+              const markerLabel = document.createElement('div');
+              markerLabel.className = 'mapmarker-label';
+              const markerLine1 = document.createElement('div');
+              markerLine1.className = 'mapmarker-label-line';
+              markerLine1.textContent = labelLines.line1;
+              markerLabel.appendChild(markerLine1);
+              if(labelLines.line2){
+                const markerLine2 = document.createElement('div');
+                markerLine2.className = 'mapmarker-label-line';
+                markerLine2.textContent = labelLines.line2;
+                markerLabel.appendChild(markerLine2);
+              }
+
+              markerContainer.append(markerPill, markerIcon, markerLabel);
+
+              const cardRoot = document.createElement('div');
+              cardRoot.className = 'big-map-card big-map-card--popup';
+              cardRoot.dataset.id = overlayRoot.dataset.id;
+              cardRoot.setAttribute('aria-hidden', 'true');
+              cardRoot.style.pointerEvents = 'auto';
+              cardRoot.style.userSelect = 'none';
+
+              const pillImg = new Image();
+              try{ pillImg.decoding = 'async'; }catch(e){}
+              pillImg.alt = '';
+              pillImg.src = 'assets/icons-30/225x60-pill-99.webp';
+              pillImg.className = 'big-map-card-pill';
+              pillImg.style.opacity = '0.9';
+              pillImg.draggable = false;
+
+              const thumbImg = new Image();
+              try{ thumbImg.decoding = 'async'; }catch(e){}
+              thumbImg.alt = '';
+              const thumbFallback = 'assets/funmap-logo-small.png';
+              thumbImg.loading = 'lazy';
+              thumbImg.onerror = ()=>{
+                thumbImg.onerror = null;
+                thumbImg.src = thumbFallback;
+              };
+              thumbImg.src = imgThumb(post) || thumbFallback;
+              thumbImg.className = 'big-map-card-thumb';
+              thumbImg.referrerPolicy = 'no-referrer';
+              thumbImg.draggable = false;
+
+              const labelEl = document.createElement('div');
+              labelEl.className = 'big-map-card-label';
+              const titleWrap = document.createElement('div');
+              titleWrap.className = 'big-map-card-title';
+              const cardTitleLines = Array.isArray(labelLines.cardTitleLines) && labelLines.cardTitleLines.length
+                ? labelLines.cardTitleLines.slice(0, 2)
+                : [labelLines.line1, labelLines.line2].filter(Boolean).slice(0, 2);
+              cardTitleLines.forEach(line => {
+                if(!line) return;
+                const lineEl = document.createElement('div');
+                lineEl.className = 'big-map-card-title-line';
+                lineEl.textContent = line;
+                titleWrap.appendChild(lineEl);
+              });
+              if(!titleWrap.childElementCount){
+                const lineEl = document.createElement('div');
+                lineEl.className = 'big-map-card-title-line';
+                lineEl.textContent = '';
+                titleWrap.appendChild(lineEl);
+              }
+              labelEl.appendChild(titleWrap);
+              const venueLine = labelLines.venueLine || shortenMarkerLabelText(getPrimaryVenueName(post), mapCardTitleWidthPx);
+              if(venueLine){
+                const venueEl = document.createElement('div');
+                venueEl.className = 'big-map-card-venue';
+                venueEl.textContent = venueLine;
+                labelEl.appendChild(venueEl);
+              }
+
+              cardRoot.append(pillImg, thumbImg, labelEl);
+              overlayRoot.append(markerContainer, cardRoot);
+              overlayRoot.classList.add('is-card-visible');
+              overlayRoot.style.pointerEvents = '';
+
+              const handleOverlayClick = (ev)=>{
+                ev.preventDefault();
+                ev.stopPropagation();
+                const pid = overlayRoot.dataset.id;
+                if(!pid) return;
+                callWhenDefined('openPost', (fn)=>{
+                  requestAnimationFrame(() => {
+                    try{
+                      touchMarker = null;
+                      stopSpin();
+                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                        try{ closePanel(filterPanel); }catch(err){}
+                      }
+                      fn(pid, false, true);
+                    }catch(err){ console.error(err); }
+                  });
+                });
+              };
+              cardRoot.addEventListener('click', handleOverlayClick, { capture: true });
+              ['pointerdown','mousedown','touchstart'].forEach(type => {
+                cardRoot.addEventListener(type, (ev)=>{
+                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+                  if(!isTouchLike){
+                    try{ ev.preventDefault(); }catch(err){}
+                  }
+                  try{ ev.stopPropagation(); }catch(err){}
+                }, { capture: true });
+              });
+              cardRoot.addEventListener('mouseenter', ()=>{
+                window.__overCard = true;
+              });
+              cardRoot.addEventListener('mouseleave', ()=>{
+                window.__overCard = false;
+                if(listLocked) return;
+                const currentPopup = hoverPopup;
+                schedulePopupRemoval(currentPopup, 160);
+              });
+            }
 
             const marker = new mapboxgl.Marker({ element: overlayRoot, anchor: 'center' });
             if(typeof marker.setZIndexOffset === 'function'){
@@ -12338,7 +12743,9 @@ if (!map.__pillHooksInstalled) {
             else if(eventLngLat){ marker.setLngLat(eventLngLat); }
             marker.addTo(map);
             marker.__fixedLngLat = fixedLngLat;
-            marker.__postId = overlayRoot.dataset.id || (post && String(post.id));
+            marker.__postId = overlayRoot.dataset.id || (primaryPost && primaryPost.id !== undefined && primaryPost.id !== null
+              ? String(primaryPost.id)
+              : (post && String(post.id)));
             window.__overCard = false;
             registerPopup(marker);
             return marker;
@@ -12557,6 +12964,7 @@ if (!map.__pillHooksInstalled) {
       } else {
         postBoardScrollOptions = addPassiveScrollListener(postsWideEl, onPostBoardScroll);
       }
+      updateMultiPostCardOverlays();
     }
     function updateResultCount(n){
       const el = $('#resultCount');
@@ -12688,6 +13096,17 @@ if (!map.__pillHooksInstalled) {
       const relatedSelector = `.mapmarker-overlay[data-id="${selectorId}"]`;
       document.querySelectorAll(`${relatedSelector} .small-map-card, ${relatedSelector} .multi-post-map-card, ${relatedSelector} .big-map-card`).forEach(el => {
         el.classList.toggle(HOVER_HIGHLIGHT_CLASS, highlight);
+      });
+      document.querySelectorAll('.mapmarker-overlay[data-multi-post-ids]').forEach(overlay => {
+        const idsAttr = overlay && overlay.dataset ? overlay.dataset.multiPostIds || '' : '';
+        if(!idsAttr) return;
+        const overlayIds = parseMultiPostIds(idsAttr);
+        if(!overlayIds.length) return;
+        const shouldToggle = overlayIds.includes(String(id));
+        if(!shouldToggle) return;
+        overlay.querySelectorAll('.multi-post-map-card').forEach(el => {
+          el.classList.toggle(HOVER_HIGHLIGHT_CLASS, highlight);
+        });
       });
     }
 
@@ -14186,6 +14605,7 @@ function openPostModal(id){
       }
       if(render) renderLists(filtered);
       syncMarkerSources(filtered);
+      updateMultiPostCardOverlays();
       updateLayerVisibility(lastKnownZoom);
       filtersInitialized = true;
     }


### PR DESCRIPTION
## Summary
- introduce a dedicated multi-post map card style and interactions that surface venue counts and open the first post based on the current sort order
- add venue-aware helpers and overlay updates so clustered markers react to filter changes and highlight related posts consistently across the UI
- refresh marker and list flows to keep multi-post card counts accurate while preserving existing behaviours for single-post venues
- ensure multi-post map cards render with the correct icon/text on the map, update counts per venue, and align the overlay with the venue coordinate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3442023648331bb70ae82c05e365b