### PR TITLE
Fix hover drift on multi-post map cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,8 @@
       transition: background-color 0.2s ease;
     }
     .multi-post-map-card{
-      transform: translate(calc(-50% + 55px), -50%);
+      /* Keep the card anchored relative to the marker regardless of hover state */
+      transform: translate(-20px, -50%);
     }
     .mapmarker{
       position: relative;


### PR DESCRIPTION
## Summary
- keep multi-post map cards anchored by using a fixed translate offset
- document the positioning to prevent future hover drift regressions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e35607d1a88331827191357a22dd58