### PR TITLE
Fix multi-post marker duplication handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,8 @@
       transition: background-color 0.2s ease;
     }
     .multi-post-map-card{
-      transform: translate(calc(-50% + 55px), -50%);
+      /* Keep the summary pill anchored consistently when hovering */
+      transform: translate(-20px, -50%);
       background: transparent;
       transition: none;
     }
@@ -9685,7 +9686,15 @@ function makePosts(){
           overlay.dataset.id = primaryId;
           overlay.dataset.primaryPostId = primaryId;
         }
-        const card = overlay.querySelector('.multi-post-map-card');
+        const cards = overlay.querySelectorAll('.multi-post-map-card');
+        if(cards.length > 1){
+          cards.forEach((node, index) => {
+            if(index > 0){
+              node.remove();
+            }
+          });
+        }
+        const card = cards[0] || null;
         if(card){
           card.dataset.count = String(ids.length);
           const countLine = card.querySelector('.multi-post-map-count');
@@ -12476,100 +12485,120 @@ if (!map.__pillHooksInstalled) {
             }
 
             if(isMultiVenue){
-              const markerContainer = document.createElement('div');
-              markerContainer.className = 'multi-post-map-card';
+              let markerContainer = overlayRoot.querySelector('.multi-post-map-card');
+              const existingCard = !!markerContainer;
+              if(!markerContainer){
+                markerContainer = document.createElement('div');
+                markerContainer.className = 'multi-post-map-card';
+                markerContainer.setAttribute('aria-hidden', 'true');
+                markerContainer.style.pointerEvents = 'auto';
+                markerContainer.style.userSelect = 'none';
+
+                const markerPill = new Image();
+                try{ markerPill.decoding = 'async'; }catch(e){}
+                markerPill.alt = '';
+                markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+                markerPill.className = 'mapmarker-pill';
+                markerPill.draggable = false;
+                markerContainer.appendChild(markerPill);
+
+                const markerIcon = new Image();
+                try{ markerIcon.decoding = 'async'; }catch(e){}
+                markerIcon.alt = '';
+                markerIcon.className = 'mapmarker';
+                markerIcon.draggable = false;
+                markerIcon.referrerPolicy = 'no-referrer';
+                markerIcon.loading = 'lazy';
+                markerIcon.onerror = ()=>{
+                  markerIcon.onerror = null;
+                  markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+                };
+                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+                markerContainer.appendChild(markerIcon);
+
+                const markerLabel = document.createElement('div');
+                markerLabel.className = 'mapmarker-label multi-post-map-label';
+                const countLine = document.createElement('div');
+                countLine.className = 'mapmarker-label-line multi-post-map-count';
+                markerLabel.appendChild(countLine);
+                const venueLineEl = document.createElement('div');
+                venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
+                markerLabel.appendChild(venueLineEl);
+                markerContainer.appendChild(markerLabel);
+
+                overlayRoot.append(markerContainer);
+                overlayRoot.classList.add('is-card-visible');
+                overlayRoot.style.pointerEvents = '';
+
+                const handleMultiCardClick = (ev)=>{
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
+                  const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
+                  if(!pid) return;
+                  activePostId = firstPost.id;
+                  if(resolvedVenueKey){
+                    selectedVenueKey = resolvedVenueKey;
+                  }
+                  updateSelectedMarkerRing();
+                  callWhenDefined('openPost', (fn)=>{
+                    requestAnimationFrame(() => {
+                      try{
+                        touchMarker = null;
+                        stopSpin();
+                        if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                          try{ closePanel(filterPanel); }catch(err){}
+                        }
+                        fn(pid, false, true);
+                      }catch(err){ console.error(err); }
+                    });
+                  });
+                };
+                markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
+                ['pointerdown','mousedown','touchstart'].forEach(type => {
+                  markerContainer.addEventListener(type, (ev)=>{
+                    const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+                    const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+                    if(!isTouchLike){
+                      try{ ev.preventDefault(); }catch(err){}
+                    }
+                    try{ ev.stopPropagation(); }catch(err){}
+                  }, { capture: true });
+                });
+                markerContainer.addEventListener('mouseenter', ()=>{
+                  window.__overCard = true;
+                });
+                markerContainer.addEventListener('mouseleave', ()=>{
+                  window.__overCard = false;
+                  if(listLocked) return;
+                  const currentPopup = hoverPopup;
+                  schedulePopupRemoval(currentPopup, 160);
+                });
+              }
+
               markerContainer.dataset.id = overlayRoot.dataset.id || '';
               markerContainer.dataset.count = String(multiCount);
               markerContainer.dataset.venueKey = resolvedVenueKey;
-              markerContainer.setAttribute('aria-hidden', 'true');
-              markerContainer.style.pointerEvents = 'auto';
-              markerContainer.style.userSelect = 'none';
               markerContainer.dataset.surfaceBg = 'transparent';
               markerContainer.style.background = 'transparent';
 
-              const markerPill = new Image();
-              try{ markerPill.decoding = 'async'; }catch(e){}
-              markerPill.alt = '';
-              markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
-              markerPill.className = 'mapmarker-pill';
-              markerPill.style.opacity = '0.9';
-              markerPill.style.visibility = 'visible';
-              markerPill.draggable = false;
+              const pillImg = markerContainer.querySelector('.mapmarker-pill');
+              if(pillImg){
+                pillImg.style.opacity = '0.9';
+                pillImg.style.visibility = 'visible';
+              }
 
-              const markerIcon = new Image();
-              try{ markerIcon.decoding = 'async'; }catch(e){}
-              markerIcon.alt = '';
-              markerIcon.className = 'mapmarker';
-              markerIcon.draggable = false;
-              markerIcon.referrerPolicy = 'no-referrer';
-              markerIcon.loading = 'lazy';
-              markerIcon.onerror = ()=>{
-                markerIcon.onerror = null;
-                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
-              };
-              markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+              const countLine = markerContainer.querySelector('.multi-post-map-count');
+              if(countLine){
+                countLine.textContent = `${multiCount} posts here`;
+              }
 
-              const markerLabel = document.createElement('div');
-              markerLabel.className = 'mapmarker-label multi-post-map-label';
-              const countLine = document.createElement('div');
-              countLine.className = 'mapmarker-label-line multi-post-map-count';
-              countLine.textContent = `${multiCount} posts here`;
-              markerLabel.appendChild(countLine);
-              const venueLineEl = document.createElement('div');
-              venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
-              const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
-              venueLineEl.textContent = venueText || '';
-              markerLabel.appendChild(venueLineEl);
+              const venueLineEl = markerContainer.querySelector('.multi-post-map-venue');
+              if(venueLineEl){
+                const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
+                venueLineEl.textContent = venueText || '';
+              }
 
-              markerContainer.append(markerPill, markerIcon, markerLabel);
-              overlayRoot.append(markerContainer);
-              overlayRoot.classList.add('is-card-visible');
-              overlayRoot.style.pointerEvents = '';
-
-              const handleMultiCardClick = (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
-                const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
-                if(!pid) return;
-                activePostId = firstPost.id;
-                if(resolvedVenueKey){
-                  selectedVenueKey = resolvedVenueKey;
-                }
-                updateSelectedMarkerRing();
-                callWhenDefined('openPost', (fn)=>{
-                  requestAnimationFrame(() => {
-                    try{
-                      touchMarker = null;
-                      stopSpin();
-                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
-                        try{ closePanel(filterPanel); }catch(err){}
-                      }
-                      fn(pid, false, true);
-                    }catch(err){ console.error(err); }
-                  });
-                });
-              };
-              markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
-              ['pointerdown','mousedown','touchstart'].forEach(type => {
-                markerContainer.addEventListener(type, (ev)=>{
-                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
-                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
-                  if(!isTouchLike){
-                    try{ ev.preventDefault(); }catch(err){}
-                  }
-                  try{ ev.stopPropagation(); }catch(err){}
-                }, { capture: true });
-              });
-              markerContainer.addEventListener('mouseenter', ()=>{
-                window.__overCard = true;
-              });
-              markerContainer.addEventListener('mouseleave', ()=>{
-                window.__overCard = false;
-                if(listLocked) return;
-                const currentPopup = hoverPopup;
-                schedulePopupRemoval(currentPopup, 160);
-              });
               updateMultiPostCardOverlays();
             } else {
               const markerContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- reuse existing multi-post marker cards instead of re-creating duplicates on refresh
- keep multi-post card content updated while preserving hover behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e369913a90833199d0d3f040a03adb