### PR TITLE
Align multi-venue small cards beneath marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,26 +153,60 @@
       position: absolute;
       left: 0;
       top: 0;
-      transform: translate(-50%, -50%);
-      display: none;
+      transform: translate(-20px, -50%);
+      display: flex;
       flex-direction: column;
-      gap: 8px;
-      padding: 10px;
-      border-radius: 20px;
-      background: #000;
-      opacity: 0.7;
-      color: #fff;
-      pointer-events: none;
+      align-items: center;
+      gap: 10px;
+      padding: 0;
+      border-radius: 0;
+      background: transparent;
+      opacity: 1;
+      color: inherit;
+      pointer-events: auto;
       box-sizing: border-box;
       z-index: 20010;
+      width: max-content;
+      min-width: 150px;
+      max-width: 260px;
+    }
+    .multi-post-map-container:not(.is-open) .multi-post-map-list{
+      display: none;
+    }
+    .multi-post-map-container.is-open .multi-post-map-list{
+      display: flex;
+    }
+    .multi-post-map-container .multi-post-map-card{
+      position: relative;
+      left: auto;
+      top: auto;
+      transform: none;
+      gap: 0;
+      pointer-events: auto;
     }
     .multi-post-map-container.is-open{
-      display: flex;
       pointer-events: auto;
     }
-    .multi-post-map-card{
+    .multi-post-map-list{
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      width: 100%;
+      max-width: 260px;
+      max-height: calc(40px * 5 + 10px * 4);
+      overflow-y: auto;
       pointer-events: auto;
-      gap: 0;
+      scrollbar-width: thin;
+    }
+    .multi-post-map-list::-webkit-scrollbar{
+      width: 6px;
+    }
+    .multi-post-map-list::-webkit-scrollbar-thumb{
+      background: rgba(255, 255, 255, 0.5);
+      border-radius: 999px;
+    }
+    .multi-post-map-list::-webkit-scrollbar-track{
+      background: transparent;
     }
     .multi-post-map-card .mapmarker-pill{
       z-index: 0;
@@ -9663,6 +9697,184 @@ function makePosts(){
       return matches[0] || null;
     }
 
+    function getVenuePostsInSortOrder(venueKey, postsAtVenue){
+      const list = Array.isArray(postsAtVenue) ? postsAtVenue.slice() : getVenuePosts(venueKey);
+      if(!list.length){
+        return list;
+      }
+      if(!Array.isArray(sortedPostList) || !sortedPostList.length){
+        return list;
+      }
+      const indexMap = new Map();
+      sortedPostList.forEach((post, idx) => {
+        if(!post) return;
+        const id = post.id;
+        if(id === undefined || id === null) return;
+        const key = String(id);
+        if(!indexMap.has(key)){
+          indexMap.set(key, idx);
+        }
+      });
+      return list
+        .map(post => {
+          const id = post && post.id !== undefined && post.id !== null ? String(post.id) : '';
+          const index = id && indexMap.has(id) ? indexMap.get(id) : Number.MAX_SAFE_INTEGER;
+          return { post, index, id };
+        })
+        .sort((a, b) => {
+          if(a.index !== b.index){
+            return a.index - b.index;
+          }
+          return a.id.localeCompare(b.id);
+        })
+        .map(item => item.post);
+    }
+
+    function createSmallMapCardElement(post, options = {}){
+      if(!post) return null;
+      const opts = (options && typeof options === 'object') ? options : {};
+      const pointerEvents = typeof opts.pointerEvents === 'string' ? opts.pointerEvents : 'none';
+      const markerContainer = document.createElement('div');
+      markerContainer.className = 'small-map-card';
+      const markerId = post && post.id !== undefined && post.id !== null ? String(post.id) : '';
+      if(markerId){
+        markerContainer.dataset.id = markerId;
+      }
+      markerContainer.setAttribute('aria-hidden', 'true');
+      markerContainer.style.pointerEvents = pointerEvents;
+      markerContainer.style.userSelect = 'none';
+
+      const markerIcon = new Image();
+      try{ markerIcon.decoding = 'async'; }catch(e){}
+      markerIcon.alt = '';
+      markerIcon.className = 'mapmarker';
+      markerIcon.draggable = false;
+      const markerSources = window.subcategoryMarkers || {};
+      const markerIds = window.subcategoryMarkerIds || {};
+      const slugifyFn = typeof slugify === 'function' ? slugify : (window.slugify || (str => (str || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')));
+      const markerIdCandidates = [];
+      if(post && post.subcategory){
+        const mappedId = markerIds[post.subcategory];
+        if(mappedId) markerIdCandidates.push(mappedId);
+        markerIdCandidates.push(slugifyFn(post.subcategory));
+      }
+      const markerIconUrl = markerIdCandidates.map(id => (id && markerSources[id]) || null).find(Boolean) || '';
+      const markerFallback = 'assets/icons-30/whats-on-category-icon-30.webp';
+      markerIcon.referrerPolicy = 'no-referrer';
+      markerIcon.loading = 'lazy';
+      markerIcon.onerror = ()=>{
+        markerIcon.onerror = null;
+        markerIcon.src = markerFallback;
+      };
+      markerIcon.src = markerIconUrl || markerFallback;
+
+      const markerPill = new Image();
+      try{ markerPill.decoding = 'async'; }catch(e){}
+      markerPill.alt = '';
+      markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+      markerPill.className = 'mapmarker-pill';
+      markerPill.style.opacity = '0.9';
+      markerPill.style.visibility = 'visible';
+      markerPill.draggable = false;
+
+      const labelLines = getMarkerLabelLines(post);
+      const markerLabel = document.createElement('div');
+      markerLabel.className = 'mapmarker-label';
+      const markerLine1 = document.createElement('div');
+      markerLine1.className = 'mapmarker-label-line';
+      markerLine1.textContent = labelLines.line1;
+      markerLabel.appendChild(markerLine1);
+      if(labelLines.line2){
+        const markerLine2 = document.createElement('div');
+        markerLine2.className = 'mapmarker-label-line';
+        markerLine2.textContent = labelLines.line2;
+        markerLabel.appendChild(markerLine2);
+      }
+
+      markerContainer.append(markerPill, markerIcon, markerLabel);
+      return markerContainer;
+    }
+
+    function attachMarkerCardInteractions(element, targetPost, venueKey){
+      if(!element || element.__markerCardHandlersAttached) return;
+      const post = targetPost || null;
+      const pid = post && post.id !== undefined && post.id !== null ? String(post.id) : '';
+      if(!pid) return;
+      const openPostForCard = ()=>{
+        activePostId = post.id;
+        if(venueKey){
+          selectedVenueKey = venueKey;
+        }
+        updateSelectedMarkerRing();
+        callWhenDefined('openPost', (fn)=>{
+          requestAnimationFrame(() => {
+            try{
+              touchMarker = null;
+              stopSpin();
+              if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                try{ closePanel(filterPanel); }catch(err){}
+              }
+              fn(pid, false, true);
+            }catch(err){ console.error(err); }
+          });
+        });
+      };
+      const handleClick = (ev)=>{
+        try{ ev.preventDefault(); }catch(err){}
+        try{ ev.stopPropagation(); }catch(err){}
+        openPostForCard();
+      };
+      element.addEventListener('click', handleClick, { capture: true });
+      ['pointerdown','mousedown','touchstart'].forEach(type => {
+        element.addEventListener(type, (ev)=>{
+          const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+          const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+          if(!isTouchLike){
+            try{ ev.preventDefault(); }catch(err){}
+          }
+          try{ ev.stopPropagation(); }catch(err){}
+        }, { capture: true });
+      });
+      element.addEventListener('mouseenter', ()=>{
+        window.__overCard = true;
+      });
+      element.addEventListener('mouseleave', ()=>{
+        window.__overCard = false;
+        if(listLocked) return;
+        const currentPopup = hoverPopup;
+        schedulePopupRemoval(currentPopup, 160);
+      });
+      element.__markerCardHandlersAttached = true;
+    }
+
+    function populateMultiPostList(listEl, postsOrdered, venueKey){
+      if(!listEl) return;
+      const postsList = Array.isArray(postsOrdered) ? postsOrdered : [];
+      const prevScrollTop = listEl.scrollTop || 0;
+      listEl.textContent = '';
+      postsList.forEach(post => {
+        if(!post) return;
+        const card = createSmallMapCardElement(post, { pointerEvents: 'auto' });
+        if(!card) return;
+        card.setAttribute('aria-hidden', 'false');
+        attachMarkerCardInteractions(card, post, venueKey);
+        listEl.appendChild(card);
+      });
+      if(listEl.dataset){
+        if(listEl.childElementCount){
+          listEl.dataset.count = String(listEl.childElementCount);
+        } else if(listEl.dataset.count){
+          delete listEl.dataset.count;
+        }
+      }
+      const maxScrollTop = Math.max(0, listEl.scrollHeight - listEl.clientHeight);
+      if(maxScrollTop > 0){
+        listEl.scrollTop = Math.min(prevScrollTop, maxScrollTop);
+      } else {
+        listEl.scrollTop = 0;
+      }
+    }
+
     function parseMultiPostIds(attr){
       if(!attr) return [];
       return attr.split(',').map(id => id.trim()).filter(Boolean);
@@ -9676,7 +9888,8 @@ function makePosts(){
           return;
         }
         const postsAtVenue = getVenuePosts(venueKey);
-        const ids = postsAtVenue.map(post => String(post.id));
+        const orderedPosts = getVenuePostsInSortOrder(venueKey, postsAtVenue);
+        const ids = orderedPosts.map(post => String(post.id));
         overlay.dataset.multiPostIds = ids.join(',');
         overlay.dataset.multiCount = String(ids.length);
         const primary = getFirstPostForVenue(venueKey);
@@ -9698,6 +9911,19 @@ function makePosts(){
           if(venueLine){
             const venueName = primary ? getVenueNameForKey(primary, venueKey) : '';
             venueLine.textContent = venueName;
+          }
+        }
+        const container = overlay.querySelector('.multi-post-map-container');
+        if(container){
+          if(container.dataset){
+            container.dataset.count = String(ids.length);
+            if(venueKey){
+              container.dataset.venueKey = venueKey;
+            }
+          }
+          const listEl = container.querySelector('.multi-post-map-list');
+          if(listEl){
+            populateMultiPostList(listEl, orderedPosts, venueKey);
           }
         }
         if(hoverPopup && typeof getPopupElement === 'function'){
@@ -12522,54 +12748,28 @@ if (!map.__pillHooksInstalled) {
               markerLabel.appendChild(venueLineEl);
 
               markerContainer.append(markerPill, markerIcon, markerLabel);
-              overlayRoot.append(markerContainer);
+
+              const orderedVenuePosts = getVenuePostsInSortOrder(resolvedVenueKey, venuePosts);
+              const multiPostContainer = document.createElement('div');
+              multiPostContainer.className = 'multi-post-map-container';
+              if(resolvedVenueKey){
+                multiPostContainer.dataset.venueKey = resolvedVenueKey;
+              }
+              multiPostContainer.dataset.count = String(orderedVenuePosts.length);
+              multiPostContainer.appendChild(markerContainer);
+
+              const smallCardsList = document.createElement('div');
+              smallCardsList.className = 'multi-post-map-list';
+              populateMultiPostList(smallCardsList, orderedVenuePosts, resolvedVenueKey);
+              multiPostContainer.appendChild(smallCardsList);
+
+              const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
+              attachMarkerCardInteractions(markerContainer, firstPost, resolvedVenueKey);
+
+              overlayRoot.append(multiPostContainer);
               overlayRoot.classList.add('is-card-visible');
               overlayRoot.style.pointerEvents = '';
 
-              const handleMultiCardClick = (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
-                const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
-                if(!pid) return;
-                activePostId = firstPost.id;
-                if(resolvedVenueKey){
-                  selectedVenueKey = resolvedVenueKey;
-                }
-                updateSelectedMarkerRing();
-                callWhenDefined('openPost', (fn)=>{
-                  requestAnimationFrame(() => {
-                    try{
-                      touchMarker = null;
-                      stopSpin();
-                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
-                        try{ closePanel(filterPanel); }catch(err){}
-                      }
-                      fn(pid, false, true);
-                    }catch(err){ console.error(err); }
-                  });
-                });
-              };
-              markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
-              ['pointerdown','mousedown','touchstart'].forEach(type => {
-                markerContainer.addEventListener(type, (ev)=>{
-                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
-                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
-                  if(!isTouchLike){
-                    try{ ev.preventDefault(); }catch(err){}
-                  }
-                  try{ ev.stopPropagation(); }catch(err){}
-                }, { capture: true });
-              });
-              markerContainer.addEventListener('mouseenter', ()=>{
-                window.__overCard = true;
-              });
-              markerContainer.addEventListener('mouseleave', ()=>{
-                window.__overCard = false;
-                if(listLocked) return;
-                const currentPopup = hoverPopup;
-                schedulePopupRemoval(currentPopup, 160);
-              });
               updateMultiPostCardOverlays();
             } else {
               const markerContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- reposition multi-post venue small cards directly beneath their marker with 10px spacing and scroll support when needed
- add helpers to build ordered small-map cards and reuse marker interaction wiring for multi-venue lists
- keep multi-venue overlays in sync with filter order by rebuilding the scrollable list from the sorted dataset

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e39e60e2148331a52095668d4683e0