### PR TITLE
Fix multi-post map card layout and interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,8 @@
       transition: background-color 0.2s ease;
     }
     .multi-post-map-card{
-      /* Keep the card anchored relative to the marker regardless of hover state */
-      transform: translate(-20px, -50%);
+      /* Keep the card centered on the marker */
+      transform: translate(-50%, -50%);
     }
     .mapmarker{
       position: relative;
@@ -153,10 +153,10 @@
       position: absolute;
       left: 0;
       top: 0;
-      transform: translate(-20px, -50%);
+      transform: translate(-50%, -50%);
       display: flex;
       flex-direction: column;
-      align-items: center;
+      align-items: stretch;
       gap: 10px;
       padding: 0;
       border-radius: 0;
@@ -183,6 +183,7 @@
       transform: none;
       gap: 0;
       pointer-events: auto;
+      width: 100%;
     }
     .multi-post-map-container.is-open{
       pointer-events: auto;
@@ -237,6 +238,8 @@
       top: auto;
       width: 100%;
       max-width: 260px;
+      background: transparent;
+      box-shadow: none;
     }
     .big-map-card--popup{
       background-color: rgba(0, 0, 0, 0.88);
@@ -7460,6 +7463,7 @@ if (typeof slugify !== 'function') {
           container.dataset.locked = 'true';
         }
         multiPostContainerSet.add(container);
+        ensureMultiPostActivePost(container);
       } else {
         if(container.dataset.locked === 'true' && !options.force){
           return;
@@ -7469,6 +7473,17 @@ if (typeof slugify !== 'function') {
           delete container.dataset.locked;
         }
         multiPostContainerSet.delete(container);
+        const overlay = container.closest('.mapmarker-overlay');
+        const bigCard = overlay ? overlay.querySelector('.big-map-card--popup') : null;
+        if(bigCard){
+          bigCard.style.display = 'none';
+        }
+        if(overlay && overlay.dataset){
+          const fallbackId = overlay.dataset.primaryPostId || '';
+          if(fallbackId){
+            overlay.dataset.id = fallbackId;
+          }
+        }
       }
     }
 
@@ -9730,6 +9745,104 @@ function makePosts(){
         .map(item => item.post);
     }
 
+    function getPostById(id){
+      if(id === undefined || id === null) return null;
+      const key = String(id);
+      return posts.find(p => p && String(p.id) === key) || null;
+    }
+
+    function createBigMapPopupCard(post){
+      const cardRoot = document.createElement('div');
+      cardRoot.className = 'big-map-card big-map-card--popup';
+      cardRoot.setAttribute('aria-hidden', 'true');
+      cardRoot.style.pointerEvents = 'auto';
+      cardRoot.style.userSelect = 'none';
+
+      const pillImg = new Image();
+      try{ pillImg.decoding = 'async'; }catch(e){}
+      pillImg.alt = '';
+      pillImg.src = 'assets/icons-30/225x60-pill-99.webp';
+      pillImg.className = 'big-map-card-pill';
+      pillImg.style.opacity = '0.9';
+      pillImg.draggable = false;
+
+      const thumbImg = new Image();
+      try{ thumbImg.decoding = 'async'; }catch(e){}
+      thumbImg.alt = '';
+      const thumbFallback = 'assets/funmap-logo-small.png';
+      thumbImg.loading = 'lazy';
+      thumbImg.onerror = ()=>{
+        thumbImg.onerror = null;
+        thumbImg.src = thumbFallback;
+      };
+      thumbImg.className = 'big-map-card-thumb';
+      thumbImg.referrerPolicy = 'no-referrer';
+      thumbImg.draggable = false;
+
+      const labelEl = document.createElement('div');
+      labelEl.className = 'big-map-card-label';
+      const titleWrap = document.createElement('div');
+      titleWrap.className = 'big-map-card-title';
+      labelEl.appendChild(titleWrap);
+      const venueEl = document.createElement('div');
+      venueEl.className = 'big-map-card-venue';
+      labelEl.appendChild(venueEl);
+
+      cardRoot.append(pillImg, thumbImg, labelEl);
+      cardRoot.__bigCardRefs = { thumbImg, titleWrap, venueEl, thumbFallback };
+      updateBigMapPopupCard(cardRoot, post);
+      return cardRoot;
+    }
+
+    function updateBigMapPopupCard(cardRoot, post){
+      if(!cardRoot) return;
+      const refs = cardRoot.__bigCardRefs || {};
+      const thumbImg = refs.thumbImg;
+      const titleWrap = refs.titleWrap;
+      const venueEl = refs.venueEl;
+      const fallback = refs.thumbFallback || 'assets/funmap-logo-small.png';
+      const postId = post && post.id !== undefined && post.id !== null ? String(post.id) : '';
+      if(cardRoot.dataset){
+        if(postId){
+          cardRoot.dataset.id = postId;
+        } else if(cardRoot.dataset.id){
+          delete cardRoot.dataset.id;
+        }
+      }
+      if(thumbImg){
+        const source = post ? imgThumb(post) : '';
+        thumbImg.onerror = ()=>{
+          thumbImg.onerror = null;
+          thumbImg.src = fallback;
+        };
+        thumbImg.src = source || fallback;
+      }
+      if(titleWrap){
+        while(titleWrap.firstChild){
+          titleWrap.removeChild(titleWrap.firstChild);
+        }
+        const labelLines = post ? getMarkerLabelLines(post) : { line1:'', line2:'', cardTitleLines:[] };
+        const cardTitleLines = Array.isArray(labelLines.cardTitleLines) && labelLines.cardTitleLines.length
+          ? labelLines.cardTitleLines.slice(0, 2)
+          : [labelLines.line1, labelLines.line2].filter(Boolean).slice(0, 2);
+        const lines = cardTitleLines.length ? cardTitleLines : [''];
+        lines.forEach(line => {
+          const lineEl = document.createElement('div');
+          lineEl.className = 'big-map-card-title-line';
+          lineEl.textContent = line || '';
+          titleWrap.appendChild(lineEl);
+        });
+        if(venueEl){
+          const venueLine = post
+            ? (labelLines.venueLine || shortenMarkerLabelText(getPrimaryVenueName(post), mapCardTitleWidthPx))
+            : '';
+          venueEl.textContent = venueLine || '';
+          venueEl.style.display = venueLine ? '' : 'none';
+        }
+      }
+      cardRoot.__activePostId = postId || '';
+    }
+
     function createSmallMapCardElement(post, options = {}){
       if(!post) return null;
       const opts = (options && typeof options === 'object') ? options : {};
@@ -9875,6 +9988,146 @@ function makePosts(){
       }
     }
 
+    function attachMultiPostListInteractions(listEl, container){
+      if(!listEl || listEl.__multiListHandlersAttached) return;
+      const stopEvent = (ev)=>{
+        try{ ev.stopPropagation(); }catch(err){}
+      };
+      const handleWheel = (ev)=>{
+        const { deltaY = 0 } = ev;
+        const before = listEl.scrollTop;
+        if(listEl.scrollHeight > listEl.clientHeight){
+          listEl.scrollTop += deltaY;
+        }
+        const moved = listEl.scrollTop !== before;
+        if(moved){
+          try{ ev.preventDefault(); }catch(err){}
+        }
+        try{ ev.stopPropagation(); }catch(err){}
+      };
+      listEl.addEventListener('wheel', handleWheel, { passive: false });
+      listEl.addEventListener('pointerdown', stopEvent, { capture: true });
+      listEl.addEventListener('touchstart', stopEvent, { capture: true });
+      listEl.__multiListHandlersAttached = true;
+      if(container){
+        listEl.__multiListContainer = container;
+      }
+    }
+
+    function setMultiPostActivePost(container, post){
+      if(!container) return;
+      const overlay = container.closest('.mapmarker-overlay');
+      const bigCard = overlay ? overlay.querySelector('.big-map-card--popup') : null;
+      if(!bigCard){
+        return;
+      }
+      if(post){
+        updateBigMapPopupCard(bigCard, post);
+        bigCard.style.display = '';
+        if(container.dataset){
+          container.dataset.activePostId = String(post.id);
+        }
+        if(overlay && overlay.dataset){
+          overlay.dataset.id = String(post.id);
+        }
+      } else {
+        bigCard.style.display = 'none';
+        if(container.dataset && container.dataset.activePostId){
+          delete container.dataset.activePostId;
+        }
+        if(overlay && overlay.dataset){
+          const fallbackId = overlay.dataset.primaryPostId || '';
+          if(fallbackId){
+            overlay.dataset.id = fallbackId;
+          }
+        }
+      }
+    }
+
+    function ensureMultiPostActivePost(container){
+      if(!container) return;
+      const ids = Array.isArray(container.__orderedPostIds) ? container.__orderedPostIds : [];
+      const activeId = container.dataset && container.dataset.activePostId ? container.dataset.activePostId : '';
+      const primaryId = container.dataset && container.dataset.primaryPostId ? container.dataset.primaryPostId : '';
+      const targetId = activeId && ids.includes(activeId)
+        ? activeId
+        : (primaryId && ids.includes(primaryId) ? primaryId : (ids[0] || ''));
+      const post = targetId ? getPostById(targetId) : null;
+      if(post){
+        setMultiPostActivePost(container, post);
+      } else {
+        setMultiPostActivePost(container, null);
+      }
+    }
+
+    function attachMultiPostHoverHandlers(container){
+      if(!container || container.__multiHoverHandlersAttached) return;
+      const handlePointerOver = (ev)=>{
+        const target = ev.target;
+        if(!target) return;
+        const smallCard = target.closest ? target.closest('.small-map-card') : null;
+        if(smallCard && container.contains(smallCard)){
+          const cid = smallCard.dataset ? smallCard.dataset.id : '';
+          if(cid){
+            const post = getPostById(cid);
+            if(post){
+              setMultiPostActivePost(container, post);
+            }
+          }
+          return;
+        }
+        const multiCard = target.closest ? target.closest('.multi-post-map-card') : null;
+        if(multiCard && container.contains(multiCard)){
+          ensureMultiPostActivePost(container);
+        }
+      };
+      container.addEventListener('pointerover', handlePointerOver);
+      container.__multiHoverHandlersAttached = true;
+    }
+
+    function attachBigMapCardOverlayInteractions(cardRoot, overlayRoot){
+      if(!cardRoot || cardRoot.__bigCardHandlersAttached) return;
+      const handleOverlayClick = (ev)=>{
+        try{ ev.preventDefault(); }catch(err){}
+        try{ ev.stopPropagation(); }catch(err){}
+        const pid = overlayRoot && overlayRoot.dataset ? overlayRoot.dataset.id : '';
+        if(!pid) return;
+        callWhenDefined('openPost', (fn)=>{
+          requestAnimationFrame(() => {
+            try{
+              touchMarker = null;
+              stopSpin();
+              if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                try{ closePanel(filterPanel); }catch(err){}
+              }
+              fn(pid, false, true);
+            }catch(err){ console.error(err); }
+          });
+        });
+      };
+      cardRoot.addEventListener('click', handleOverlayClick, { capture: true });
+      ['pointerdown','mousedown','touchstart'].forEach(type => {
+        cardRoot.addEventListener(type, (ev)=>{
+          const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+          const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+          if(!isTouchLike){
+            try{ ev.preventDefault(); }catch(err){}
+          }
+          try{ ev.stopPropagation(); }catch(err){}
+        }, { capture: true });
+      });
+      cardRoot.addEventListener('mouseenter', ()=>{
+        window.__overCard = true;
+      });
+      cardRoot.addEventListener('mouseleave', ()=>{
+        window.__overCard = false;
+        if(listLocked) return;
+        const currentPopup = hoverPopup;
+        schedulePopupRemoval(currentPopup, 160);
+      });
+      cardRoot.__bigCardHandlersAttached = true;
+    }
+
     function parseMultiPostIds(attr){
       if(!attr) return [];
       return attr.split(',').map(id => id.trim()).filter(Boolean);
@@ -9920,10 +10173,24 @@ function makePosts(){
             if(venueKey){
               container.dataset.venueKey = venueKey;
             }
+            if(primaryId){
+              container.dataset.primaryPostId = primaryId;
+            }
           }
+          container.__orderedPostIds = ids.slice();
           const listEl = container.querySelector('.multi-post-map-list');
           if(listEl){
             populateMultiPostList(listEl, orderedPosts, venueKey);
+            attachMultiPostListInteractions(listEl, container);
+          }
+          attachMultiPostHoverHandlers(container);
+          if(container.classList.contains('is-open')){
+            if(container.dataset && container.dataset.activePostId && !ids.includes(container.dataset.activePostId)){
+              container.dataset.activePostId = ids[0] || primaryId || '';
+            }
+            ensureMultiPostActivePost(container);
+          } else if(container.dataset && container.dataset.activePostId && !ids.includes(container.dataset.activePostId)){
+            delete container.dataset.activePostId;
           }
         }
         if(hoverPopup && typeof getPopupElement === 'function'){
@@ -12758,18 +13025,36 @@ if (!map.__pillHooksInstalled) {
               multiPostContainer.dataset.count = String(orderedVenuePosts.length);
               multiPostContainer.appendChild(markerContainer);
 
+              if(primaryId){
+                multiPostContainer.dataset.primaryPostId = primaryId;
+              }
+
               const smallCardsList = document.createElement('div');
               smallCardsList.className = 'multi-post-map-list';
               populateMultiPostList(smallCardsList, orderedVenuePosts, resolvedVenueKey);
               multiPostContainer.appendChild(smallCardsList);
+              attachMultiPostListInteractions(smallCardsList, multiPostContainer);
 
               const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
               attachMarkerCardInteractions(markerContainer, firstPost, resolvedVenueKey);
 
-              overlayRoot.append(multiPostContainer);
+              const bigCard = createBigMapPopupCard(firstPost);
+              bigCard.style.display = 'none';
+
+              multiPostContainer.__orderedPostIds = orderedVenuePosts
+                .map(p => (p && p.id !== undefined && p.id !== null) ? String(p.id) : '')
+                .filter(Boolean);
+              if(firstPost && firstPost.id !== undefined && firstPost.id !== null){
+                multiPostContainer.dataset.activePostId = String(firstPost.id);
+              }
+
+              attachMultiPostHoverHandlers(multiPostContainer);
+
+              overlayRoot.append(multiPostContainer, bigCard);
               overlayRoot.classList.add('is-card-visible');
               overlayRoot.style.pointerEvents = '';
 
+              attachBigMapCardOverlayInteractions(bigCard, overlayRoot);
               updateMultiPostCardOverlays();
             } else {
               const markerContainer = document.createElement('div');
@@ -12828,107 +13113,12 @@ if (!map.__pillHooksInstalled) {
 
               markerContainer.append(markerPill, markerIcon, markerLabel);
 
-              const cardRoot = document.createElement('div');
-              cardRoot.className = 'big-map-card big-map-card--popup';
-              cardRoot.dataset.id = overlayRoot.dataset.id;
-              cardRoot.setAttribute('aria-hidden', 'true');
-              cardRoot.style.pointerEvents = 'auto';
-              cardRoot.style.userSelect = 'none';
-
-              const pillImg = new Image();
-              try{ pillImg.decoding = 'async'; }catch(e){}
-              pillImg.alt = '';
-              pillImg.src = 'assets/icons-30/225x60-pill-99.webp';
-              pillImg.className = 'big-map-card-pill';
-              pillImg.style.opacity = '0.9';
-              pillImg.draggable = false;
-
-              const thumbImg = new Image();
-              try{ thumbImg.decoding = 'async'; }catch(e){}
-              thumbImg.alt = '';
-              const thumbFallback = 'assets/funmap-logo-small.png';
-              thumbImg.loading = 'lazy';
-              thumbImg.onerror = ()=>{
-                thumbImg.onerror = null;
-                thumbImg.src = thumbFallback;
-              };
-              thumbImg.src = imgThumb(post) || thumbFallback;
-              thumbImg.className = 'big-map-card-thumb';
-              thumbImg.referrerPolicy = 'no-referrer';
-              thumbImg.draggable = false;
-
-              const labelEl = document.createElement('div');
-              labelEl.className = 'big-map-card-label';
-              const titleWrap = document.createElement('div');
-              titleWrap.className = 'big-map-card-title';
-              const cardTitleLines = Array.isArray(labelLines.cardTitleLines) && labelLines.cardTitleLines.length
-                ? labelLines.cardTitleLines.slice(0, 2)
-                : [labelLines.line1, labelLines.line2].filter(Boolean).slice(0, 2);
-              cardTitleLines.forEach(line => {
-                if(!line) return;
-                const lineEl = document.createElement('div');
-                lineEl.className = 'big-map-card-title-line';
-                lineEl.textContent = line;
-                titleWrap.appendChild(lineEl);
-              });
-              if(!titleWrap.childElementCount){
-                const lineEl = document.createElement('div');
-                lineEl.className = 'big-map-card-title-line';
-                lineEl.textContent = '';
-                titleWrap.appendChild(lineEl);
-              }
-              labelEl.appendChild(titleWrap);
-              const venueLine = labelLines.venueLine || shortenMarkerLabelText(getPrimaryVenueName(post), mapCardTitleWidthPx);
-              if(venueLine){
-                const venueEl = document.createElement('div');
-                venueEl.className = 'big-map-card-venue';
-                venueEl.textContent = venueLine;
-                labelEl.appendChild(venueEl);
-              }
-
-              cardRoot.append(pillImg, thumbImg, labelEl);
+              const cardRoot = createBigMapPopupCard(post);
               overlayRoot.append(markerContainer, cardRoot);
               overlayRoot.classList.add('is-card-visible');
               overlayRoot.style.pointerEvents = '';
 
-              const handleOverlayClick = (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                const pid = overlayRoot.dataset.id;
-                if(!pid) return;
-                callWhenDefined('openPost', (fn)=>{
-                  requestAnimationFrame(() => {
-                    try{
-                      touchMarker = null;
-                      stopSpin();
-                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
-                        try{ closePanel(filterPanel); }catch(err){}
-                      }
-                      fn(pid, false, true);
-                    }catch(err){ console.error(err); }
-                  });
-                });
-              };
-              cardRoot.addEventListener('click', handleOverlayClick, { capture: true });
-              ['pointerdown','mousedown','touchstart'].forEach(type => {
-                cardRoot.addEventListener(type, (ev)=>{
-                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
-                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
-                  if(!isTouchLike){
-                    try{ ev.preventDefault(); }catch(err){}
-                  }
-                  try{ ev.stopPropagation(); }catch(err){}
-                }, { capture: true });
-              });
-              cardRoot.addEventListener('mouseenter', ()=>{
-                window.__overCard = true;
-              });
-              cardRoot.addEventListener('mouseleave', ()=>{
-                window.__overCard = false;
-                if(listLocked) return;
-                const currentPopup = hoverPopup;
-                schedulePopupRemoval(currentPopup, 160);
-              });
+              attachBigMapCardOverlayInteractions(cardRoot, overlayRoot);
             }
 
             const marker = new mapboxgl.Marker({ element: overlayRoot, anchor: 'center' });


### PR DESCRIPTION
## Summary
- Recenter the multi-post map card stack and ensure small cards render without obscured pills
- Add shared helpers for big map cards and apply them to multi-post overlays so hover/lock behaviour shows the correct details
- Stop wheel events from bubbling to the map and keep overlay data in sync when multi-post cards update

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3b47c8b34833195c8de46a2296e50