### PR TITLE
Fix multi-post map card duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,8 @@
       transition: background-color 0.2s ease;
     }
     .multi-post-map-card{
-      /* Keep the card anchored relative to the marker regardless of hover state */
-      transform: translate(-20px, -50%);
+      /* Keep the card centered on the marker */
+      transform: translate(-50%, -50%);
     }
     .mapmarker{
       position: relative;
@@ -12478,100 +12478,130 @@ if (!map.__pillHooksInstalled) {
             }
 
             if(isMultiVenue){
-              const markerContainer = document.createElement('div');
-              markerContainer.className = 'multi-post-map-card';
+              if(resolvedVenueKey){
+                const selectorKey = typeof CSS !== 'undefined' && CSS && typeof CSS.escape === 'function'
+                  ? CSS.escape(resolvedVenueKey)
+                  : resolvedVenueKey.replace(/"/g, '\\"');
+                document.querySelectorAll(`.mapmarker-overlay[data-venue-key="${selectorKey}"]`).forEach(existing => {
+                  if(existing !== overlayRoot){
+                    try{ existing.remove(); }catch(err){}
+                  }
+                });
+              }
+
+              let markerContainer = overlayRoot.querySelector('.multi-post-map-card');
+              if(!markerContainer){
+                markerContainer = document.createElement('div');
+                markerContainer.className = 'multi-post-map-card';
+                markerContainer.setAttribute('aria-hidden', 'true');
+                markerContainer.style.pointerEvents = 'auto';
+                markerContainer.style.userSelect = 'none';
+
+                const markerPill = new Image();
+                try{ markerPill.decoding = 'async'; }catch(e){}
+                markerPill.alt = '';
+                markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+                markerPill.className = 'mapmarker-pill';
+                markerPill.draggable = false;
+
+                const markerIcon = new Image();
+                try{ markerIcon.decoding = 'async'; }catch(e){}
+                markerIcon.alt = '';
+                markerIcon.className = 'mapmarker';
+                markerIcon.draggable = false;
+                markerIcon.referrerPolicy = 'no-referrer';
+                markerIcon.loading = 'lazy';
+                markerIcon.onerror = ()=>{
+                  markerIcon.onerror = null;
+                  markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+                };
+                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+
+                const markerLabel = document.createElement('div');
+                markerLabel.className = 'mapmarker-label multi-post-map-label';
+                const countLine = document.createElement('div');
+                countLine.className = 'mapmarker-label-line multi-post-map-count';
+                markerLabel.appendChild(countLine);
+                const venueLineEl = document.createElement('div');
+                venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
+                markerLabel.appendChild(venueLineEl);
+
+                markerContainer.append(markerPill, markerIcon, markerLabel);
+                overlayRoot.append(markerContainer);
+                overlayRoot.classList.add('is-card-visible');
+                overlayRoot.style.pointerEvents = '';
+
+                const handleMultiCardClick = (ev)=>{
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
+                  const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
+                  if(!pid) return;
+                  activePostId = firstPost.id;
+                  if(resolvedVenueKey){
+                    selectedVenueKey = resolvedVenueKey;
+                  }
+                  updateSelectedMarkerRing();
+                  callWhenDefined('openPost', (fn)=>{
+                    requestAnimationFrame(() => {
+                      try{
+                        touchMarker = null;
+                        stopSpin();
+                        if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                          try{ closePanel(filterPanel); }catch(err){}
+                        }
+                        fn(pid, false, true);
+                      }catch(err){ console.error(err); }
+                    });
+                  });
+                };
+                markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
+                ['pointerdown','mousedown','touchstart'].forEach(type => {
+                  markerContainer.addEventListener(type, (ev)=>{
+                    const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+                    const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+                    if(!isTouchLike){
+                      try{ ev.preventDefault(); }catch(err){}
+                    }
+                    try{ ev.stopPropagation(); }catch(err){}
+                  }, { capture: true });
+                });
+                markerContainer.addEventListener('mouseenter', ()=>{
+                  window.__overCard = true;
+                });
+                markerContainer.addEventListener('mouseleave', ()=>{
+                  window.__overCard = false;
+                  if(listLocked) return;
+                  const currentPopup = hoverPopup;
+                  schedulePopupRemoval(currentPopup, 160);
+                });
+              }
+
               markerContainer.dataset.id = overlayRoot.dataset.id || '';
               markerContainer.dataset.count = String(multiCount);
               markerContainer.dataset.venueKey = resolvedVenueKey;
-              markerContainer.setAttribute('aria-hidden', 'true');
-              markerContainer.style.pointerEvents = 'auto';
-              markerContainer.style.userSelect = 'none';
 
-              const markerPill = new Image();
-              try{ markerPill.decoding = 'async'; }catch(e){}
-              markerPill.alt = '';
-              markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
-              markerPill.className = 'mapmarker-pill';
-              markerPill.style.opacity = '0.9';
-              markerPill.style.visibility = 'visible';
-              markerPill.draggable = false;
+              const pillImg = markerContainer.querySelector('.mapmarker-pill');
+              if(pillImg){
+                pillImg.style.opacity = '';
+                pillImg.style.visibility = '';
+              }
 
-              const markerIcon = new Image();
-              try{ markerIcon.decoding = 'async'; }catch(e){}
-              markerIcon.alt = '';
-              markerIcon.className = 'mapmarker';
-              markerIcon.draggable = false;
-              markerIcon.referrerPolicy = 'no-referrer';
-              markerIcon.loading = 'lazy';
-              markerIcon.onerror = ()=>{
-                markerIcon.onerror = null;
-                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
-              };
-              markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+              const countLine = markerContainer.querySelector('.multi-post-map-count');
+              if(countLine){
+                countLine.textContent = `${multiCount} posts here`;
+              }
+              const venueLine = markerContainer.querySelector('.multi-post-map-venue');
+              if(venueLine){
+                const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
+                venueLine.textContent = venueText || '';
+              }
 
-              const markerLabel = document.createElement('div');
-              markerLabel.className = 'mapmarker-label multi-post-map-label';
-              const countLine = document.createElement('div');
-              countLine.className = 'mapmarker-label-line multi-post-map-count';
-              countLine.textContent = `${multiCount} posts here`;
-              markerLabel.appendChild(countLine);
-              const venueLineEl = document.createElement('div');
-              venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
-              const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
-              venueLineEl.textContent = venueText || '';
-              markerLabel.appendChild(venueLineEl);
-
-              markerContainer.append(markerPill, markerIcon, markerLabel);
-              overlayRoot.append(markerContainer);
-              overlayRoot.classList.add('is-card-visible');
-              overlayRoot.style.pointerEvents = '';
-
-              const handleMultiCardClick = (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
-                const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
-                if(!pid) return;
-                activePostId = firstPost.id;
-                if(resolvedVenueKey){
-                  selectedVenueKey = resolvedVenueKey;
-                }
-                updateSelectedMarkerRing();
-                callWhenDefined('openPost', (fn)=>{
-                  requestAnimationFrame(() => {
-                    try{
-                      touchMarker = null;
-                      stopSpin();
-                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
-                        try{ closePanel(filterPanel); }catch(err){}
-                      }
-                      fn(pid, false, true);
-                    }catch(err){ console.error(err); }
-                  });
-                });
-              };
-              markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
-              ['pointerdown','mousedown','touchstart'].forEach(type => {
-                markerContainer.addEventListener(type, (ev)=>{
-                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
-                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
-                  if(!isTouchLike){
-                    try{ ev.preventDefault(); }catch(err){}
-                  }
-                  try{ ev.stopPropagation(); }catch(err){}
-                }, { capture: true });
-              });
-              markerContainer.addEventListener('mouseenter', ()=>{
-                window.__overCard = true;
-              });
-              markerContainer.addEventListener('mouseleave', ()=>{
-                window.__overCard = false;
-                if(listLocked) return;
-                const currentPopup = hoverPopup;
-                schedulePopupRemoval(currentPopup, 160);
-              });
               updateMultiPostCardOverlays();
             } else {
+              overlayRoot.querySelectorAll('.multi-post-map-card').forEach(card => {
+                try{ card.remove(); }catch(err){}
+              });
               const markerContainer = document.createElement('div');
               markerContainer.className = 'small-map-card';
               markerContainer.dataset.id = overlayRoot.dataset.id;


### PR DESCRIPTION
## Summary
- prevent duplicate multi-post overlays by reusing the existing venue card and removing lingering small cards
- center the multi-post card over its marker and clear pill opacity overrides for consistent styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e42a2402788331b49a9eccee86c598