### PR TITLE
Tighten multi-post map overlay handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,8 @@
       transition: background-color 0.2s ease;
     }
     .multi-post-map-card{
-      /* Keep the card anchored relative to the marker regardless of hover state */
-      transform: translate(-20px, -50%);
+      /* Keep the card centered on the marker */
+      transform: translate(-50%, -50%);
     }
     .mapmarker{
       position: relative;
@@ -9700,6 +9700,25 @@ function makePosts(){
             venueLine.textContent = venueName;
           }
         }
+
+        const relatedIds = new Set(ids);
+        document.querySelectorAll('.mapmarker-overlay').forEach(otherOverlay => {
+          if(!otherOverlay || otherOverlay === overlay || !otherOverlay.dataset){
+            return;
+          }
+          const otherVenueKey = otherOverlay.dataset.venueKey || '';
+          const otherId = otherOverlay.dataset.id || '';
+          if(otherVenueKey !== venueKey && (!otherId || !relatedIds.has(otherId))){
+            return;
+          }
+          const markerInstance = otherOverlay.__markerInstance;
+          if(markerInstance && typeof markerInstance.remove === 'function'){
+            try{ markerInstance.remove(); }catch(err){}
+          } else {
+            try{ otherOverlay.remove(); }catch(err){}
+          }
+        });
+
         if(hoverPopup && typeof getPopupElement === 'function'){
           const popupEl = getPopupElement(hoverPopup);
           if(popupEl === overlay && primaryId){
@@ -12478,100 +12497,140 @@ if (!map.__pillHooksInstalled) {
             }
 
             if(isMultiVenue){
-              const markerContainer = document.createElement('div');
-              markerContainer.className = 'multi-post-map-card';
+              if(resolvedVenueKey){
+                const selectorKey = typeof CSS !== 'undefined' && CSS && typeof CSS.escape === 'function'
+                  ? CSS.escape(resolvedVenueKey)
+                  : resolvedVenueKey.replace(/"/g, '\\"');
+                document.querySelectorAll(`.mapmarker-overlay[data-venue-key="${selectorKey}"]`).forEach(existing => {
+                  if(!existing || existing === overlayRoot){
+                    return;
+                  }
+                  const markerInstance = existing.__markerInstance;
+                  if(markerInstance && typeof markerInstance.remove === 'function'){
+                    try{ markerInstance.remove(); }catch(err){}
+                  } else {
+                    try{ existing.remove(); }catch(err){}
+                  }
+                });
+              }
+
+              let markerContainer = overlayRoot.querySelector('.multi-post-map-card');
+              if(!markerContainer){
+                markerContainer = document.createElement('div');
+                markerContainer.className = 'multi-post-map-card';
+                markerContainer.setAttribute('aria-hidden', 'true');
+                markerContainer.style.pointerEvents = 'auto';
+                markerContainer.style.userSelect = 'none';
+
+                const markerPill = new Image();
+                try{ markerPill.decoding = 'async'; }catch(e){}
+                markerPill.alt = '';
+                markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+                markerPill.className = 'mapmarker-pill';
+                markerPill.draggable = false;
+
+                const markerIcon = new Image();
+                try{ markerIcon.decoding = 'async'; }catch(e){}
+                markerIcon.alt = '';
+                markerIcon.className = 'mapmarker';
+                markerIcon.draggable = false;
+                markerIcon.referrerPolicy = 'no-referrer';
+                markerIcon.loading = 'lazy';
+                markerIcon.onerror = ()=>{
+                  markerIcon.onerror = null;
+                  markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+                };
+                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+
+                const markerLabel = document.createElement('div');
+                markerLabel.className = 'mapmarker-label multi-post-map-label';
+                const countLine = document.createElement('div');
+                countLine.className = 'mapmarker-label-line multi-post-map-count';
+                markerLabel.appendChild(countLine);
+                const venueLineEl = document.createElement('div');
+                venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
+                markerLabel.appendChild(venueLineEl);
+
+                markerContainer.append(markerPill, markerIcon, markerLabel);
+                overlayRoot.append(markerContainer);
+                overlayRoot.classList.add('is-card-visible');
+                overlayRoot.style.pointerEvents = '';
+
+                const handleMultiCardClick = (ev)=>{
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
+                  const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
+                  if(!pid) return;
+                  activePostId = firstPost.id;
+                  if(resolvedVenueKey){
+                    selectedVenueKey = resolvedVenueKey;
+                  }
+                  updateSelectedMarkerRing();
+                  callWhenDefined('openPost', (fn)=>{
+                    requestAnimationFrame(() => {
+                      try{
+                        touchMarker = null;
+                        stopSpin();
+                        if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
+                          try{ closePanel(filterPanel); }catch(err){}
+                        }
+                        fn(pid, false, true);
+                      }catch(err){ console.error(err); }
+                    });
+                  });
+                };
+                markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
+                ['pointerdown','mousedown','touchstart'].forEach(type => {
+                  markerContainer.addEventListener(type, (ev)=>{
+                    const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
+                    const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
+                    if(!isTouchLike){
+                      try{ ev.preventDefault(); }catch(err){}
+                    }
+                    try{ ev.stopPropagation(); }catch(err){}
+                  }, { capture: true });
+                });
+                markerContainer.addEventListener('mouseenter', ()=>{
+                  window.__overCard = true;
+                });
+                markerContainer.addEventListener('mouseleave', ()=>{
+                  window.__overCard = false;
+                  if(listLocked) return;
+                  const currentPopup = hoverPopup;
+                  schedulePopupRemoval(currentPopup, 160);
+                });
+              }
+
               markerContainer.dataset.id = overlayRoot.dataset.id || '';
               markerContainer.dataset.count = String(multiCount);
               markerContainer.dataset.venueKey = resolvedVenueKey;
-              markerContainer.setAttribute('aria-hidden', 'true');
-              markerContainer.style.pointerEvents = 'auto';
-              markerContainer.style.userSelect = 'none';
 
-              const markerPill = new Image();
-              try{ markerPill.decoding = 'async'; }catch(e){}
-              markerPill.alt = '';
-              markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
-              markerPill.className = 'mapmarker-pill';
-              markerPill.style.opacity = '0.9';
-              markerPill.style.visibility = 'visible';
-              markerPill.draggable = false;
+              markerContainer.style.left = '50%';
+              markerContainer.style.top = '50%';
+              markerContainer.style.transform = 'translate(-50%, -50%)';
 
-              const markerIcon = new Image();
-              try{ markerIcon.decoding = 'async'; }catch(e){}
-              markerIcon.alt = '';
-              markerIcon.className = 'mapmarker';
-              markerIcon.draggable = false;
-              markerIcon.referrerPolicy = 'no-referrer';
-              markerIcon.loading = 'lazy';
-              markerIcon.onerror = ()=>{
-                markerIcon.onerror = null;
-                markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
-              };
-              markerIcon.src = 'assets/icons-30/multi-post-icon-30.webp';
+              const pillImg = markerContainer.querySelector('.mapmarker-pill');
+              if(pillImg){
+                pillImg.style.opacity = '';
+                pillImg.style.visibility = '';
+              }
 
-              const markerLabel = document.createElement('div');
-              markerLabel.className = 'mapmarker-label multi-post-map-label';
-              const countLine = document.createElement('div');
-              countLine.className = 'mapmarker-label-line multi-post-map-count';
-              countLine.textContent = `${multiCount} posts here`;
-              markerLabel.appendChild(countLine);
-              const venueLineEl = document.createElement('div');
-              venueLineEl.className = 'mapmarker-label-line multi-post-map-venue';
-              const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
-              venueLineEl.textContent = venueText || '';
-              markerLabel.appendChild(venueLineEl);
+              const countLine = markerContainer.querySelector('.multi-post-map-count');
+              if(countLine){
+                countLine.textContent = `${multiCount} posts here`;
+              }
+              const venueLine = markerContainer.querySelector('.multi-post-map-venue');
+              if(venueLine){
+                const venueText = primaryPost ? getVenueNameForKey(primaryPost, resolvedVenueKey) : '';
+                venueLine.textContent = venueText || '';
+              }
 
-              markerContainer.append(markerPill, markerIcon, markerLabel);
-              overlayRoot.append(markerContainer);
-              overlayRoot.classList.add('is-card-visible');
-              overlayRoot.style.pointerEvents = '';
-
-              const handleMultiCardClick = (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                const firstPost = getFirstPostForVenue(resolvedVenueKey) || primaryPost || post;
-                const pid = firstPost && firstPost.id !== undefined && firstPost.id !== null ? String(firstPost.id) : '';
-                if(!pid) return;
-                activePostId = firstPost.id;
-                if(resolvedVenueKey){
-                  selectedVenueKey = resolvedVenueKey;
-                }
-                updateSelectedMarkerRing();
-                callWhenDefined('openPost', (fn)=>{
-                  requestAnimationFrame(() => {
-                    try{
-                      touchMarker = null;
-                      stopSpin();
-                      if(typeof closePanel === 'function' && typeof filterPanel !== 'undefined' && filterPanel){
-                        try{ closePanel(filterPanel); }catch(err){}
-                      }
-                      fn(pid, false, true);
-                    }catch(err){ console.error(err); }
-                  });
-                });
-              };
-              markerContainer.addEventListener('click', handleMultiCardClick, { capture: true });
-              ['pointerdown','mousedown','touchstart'].forEach(type => {
-                markerContainer.addEventListener(type, (ev)=>{
-                  const pointerType = typeof ev.pointerType === 'string' ? ev.pointerType.toLowerCase() : '';
-                  const isTouchLike = pointerType === 'touch' || ev.type === 'touchstart';
-                  if(!isTouchLike){
-                    try{ ev.preventDefault(); }catch(err){}
-                  }
-                  try{ ev.stopPropagation(); }catch(err){}
-                }, { capture: true });
-              });
-              markerContainer.addEventListener('mouseenter', ()=>{
-                window.__overCard = true;
-              });
-              markerContainer.addEventListener('mouseleave', ()=>{
-                window.__overCard = false;
-                if(listLocked) return;
-                const currentPopup = hoverPopup;
-                schedulePopupRemoval(currentPopup, 160);
-              });
               updateMultiPostCardOverlays();
             } else {
+              overlayRoot.querySelectorAll('.multi-post-map-card').forEach(card => {
+                try{ card.remove(); }catch(err){}
+              });
               const markerContainer = document.createElement('div');
               markerContainer.className = 'small-map-card';
               markerContainer.dataset.id = overlayRoot.dataset.id;
@@ -12747,6 +12806,7 @@ if (!map.__pillHooksInstalled) {
             marker.__postId = overlayRoot.dataset.id || (primaryPost && primaryPost.id !== undefined && primaryPost.id !== null
               ? String(primaryPost.id)
               : (post && String(post.id)));
+            overlayRoot.__markerInstance = marker;
             window.__overCard = false;
             registerPopup(marker);
             return marker;


### PR DESCRIPTION
## Summary
- remove any prior markers tied to the same venue before rendering a multi-post card and store the marker instance for cleanup
- ensure the multi-post overlay replaces other cards at the venue and stays centered on the marker

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e42a2402788331b49a9eccee86c598