### PR TITLE
Keep recents panel accessible when posts view is disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -10628,13 +10628,18 @@ function makePosts(){
           postsButton.classList.toggle('is-disabled', !postsEnabled);
         }
         document.body.classList.toggle('hide-posts-ui', !postsEnabled);
+        const historyActive = document.body.classList.contains('show-history');
         if(!postsEnabled){
-          if(typeof setMode === 'function' && document.body.classList.contains('mode-posts')){
+          if(typeof setMode === 'function' && document.body.classList.contains('mode-posts') && !historyActive){
             setMode('map', true);
+          } else if(typeof adjustBoards === 'function'){
+            adjustBoards();
           }
-          document.body.classList.remove('show-history');
-          if(typeof adjustBoards === 'function'){ adjustBoards(); }
+          if(!historyActive){
+            document.body.classList.remove('show-history');
+          }
           if(typeof updateModeToggle === 'function'){ updateModeToggle(); }
+          return;
         }
       };
 


### PR DESCRIPTION
## Summary
- prevent the map zoom safeguard from closing the recents history panel
- allow the layout/update routines to refresh without forcing map mode when recents are visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e42f1868448331977ac8ed77cd1fec