### PR TITLE
Ensure recents board posts ignore filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -10937,7 +10937,14 @@ function makePosts(){
         spinEnabled = false;
         localStorage.setItem('spinGlobe', 'false');
         stopSpin();
-        const p = posts.find(x=>x.id===id); if(!p) return;
+        let p = posts.find(x=>x.id===id);
+        if(!p){
+          const allPosts = getAllPostsCache();
+          if(Array.isArray(allPosts)){
+            p = allPosts.find(x=>x && x.id === id);
+          }
+        }
+        if(!p) return;
         activePostId = id;
         selectedVenueKey = null;
         updateSelectedMarkerRing();


### PR DESCRIPTION
## Summary
- fall back to the full posts cache when opening a post so recents are not limited by the active map bounds or filters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5143e64e48331ab0f5aac1ed240df