### PR TITLE
Fix multi-post map card hover duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,9 @@
       box-shadow: 0 0 0 3px #000;
       box-sizing: border-box;
     }
+    .map--midzoom-markers .multi-post-map-card .mapmarker{
+      box-shadow: none;
+    }
     .mapmarker-pill{
       position: absolute;
       left: 0;
@@ -12818,6 +12821,15 @@ if (!map.__pillHooksInstalled) {
       
         const handleMarkerMouseEnter = (e)=>{
           map.getCanvas().style.cursor = 'pointer';
+          if(window.__overCard){
+            const originalTarget = e && e.originalEvent ? e.originalEvent.target : null;
+            const overlayTarget = originalTarget && typeof originalTarget.closest === 'function'
+              ? originalTarget.closest('.mapmarker-overlay')
+              : null;
+            if(overlayTarget && overlayTarget.dataset && overlayTarget.dataset.multi === 'true'){
+              return;
+            }
+          }
           const f = e.features && e.features[0]; if(!f) return;
           const props = f.properties || {};
           const id = props.id;


### PR DESCRIPTION
## Summary
- remove the box shadow ring from multi-post map card icons
- avoid recreating hover overlays while the pointer is already over a multi-post card to stop duplicate cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e531d3bae48331bfa7dc029e4a5c56