### PR TITLE
Fix map cluster zoom behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -6748,32 +6748,42 @@ if (typeof slugify !== 'function') {
           if(!bucket || !Array.isArray(bucket.posts) || bucket.posts.length <= 1){
             return null;
           }
-          const nextZoom = Math.min(currentZoom + 1, maxAllowedZoom);
-          if(!(nextZoom > currentZoom)){
+          const safeCurrent = Number.isFinite(currentZoom) ? currentZoom : 0;
+          const safeMax = Number.isFinite(maxAllowedZoom) ? maxAllowedZoom : safeCurrent;
+          if(!(safeMax > safeCurrent)){
             return null;
           }
-          const { groups } = groupPostsForBalloonZoom(bucket.posts, nextZoom);
-          const childBuckets = Array.from(groups.values()).filter(child => child && child.count > 0);
-          if(childBuckets.length === 0){
-            return null;
+          const step = 0.25;
+          const maxIterations = Math.max(1, Math.ceil((safeMax - safeCurrent) / step) + 1);
+          for(let i=0;i<maxIterations;i++){
+            const candidateZoom = Math.min(safeMax, safeCurrent + (i + 1) * step);
+            if(!(candidateZoom > safeCurrent)){
+              continue;
+            }
+            const { groups } = groupPostsForBalloonZoom(bucket.posts, candidateZoom);
+            const childBuckets = Array.from(groups.values()).filter(child => child && child.count > 0);
+            if(childBuckets.length <= 1){
+              continue;
+            }
+            let totalCount = 0;
+            let sumLng = 0;
+            let sumLat = 0;
+            childBuckets.forEach(child => {
+              const childCenterLng = child.sumLng / child.count;
+              const childCenterLat = child.sumLat / child.count;
+              totalCount += child.count;
+              sumLng += childCenterLng * child.count;
+              sumLat += childCenterLat * child.count;
+            });
+            if(totalCount <= 0){
+              continue;
+            }
+            return {
+              center: [sumLng / totalCount, sumLat / totalCount],
+              zoom: candidateZoom
+            };
           }
-          let totalCount = 0;
-          let sumLng = 0;
-          let sumLat = 0;
-          childBuckets.forEach(child => {
-            const childCenterLng = child.sumLng / child.count;
-            const childCenterLat = child.sumLat / child.count;
-            totalCount += child.count;
-            sumLng += childCenterLng * child.count;
-            sumLat += childCenterLat * child.count;
-          });
-          if(totalCount <= 0){
-            return null;
-          }
-          return {
-            center: [sumLng / totalCount, sumLat / totalCount],
-            zoom: nextZoom
-          };
+          return null;
         }
 
         let lastBalloonBucketKey = null;
@@ -6906,16 +6916,19 @@ if (typeof slugify !== 'function') {
                 ? lastBalloonGroupingDetails.groups
                 : null;
               const bucketData = grouping && bucketKey ? grouping.get(bucketKey) : null;
-              const childTarget = computeChildBalloonTarget(bucketData, safeCurrentZoom, maxAllowedZoom);
+              const childZoomLimit = Number.isFinite(maxZoom)
+                ? Math.min(maxZoom, Math.max(maxAllowedZoom, 9))
+                : 9;
+              const childTarget = computeChildBalloonTarget(bucketData, safeCurrentZoom, childZoomLimit);
               const hasChildTarget = childTarget && Array.isArray(childTarget.center) && childTarget.center.length >= 2;
               const targetCenter = hasChildTarget
                 ? [childTarget.center[0], childTarget.center[1]]
                 : [coords[0], coords[1]];
-              const desiredLeafZoom = Math.min(9, maxAllowedZoom);
+              const desiredLeafZoom = Number.isFinite(maxZoom) ? Math.min(9, maxZoom) : 9;
               let finalZoom;
               if(hasChildTarget){
                 const childZoom = childTarget && Number.isFinite(childTarget.zoom)
-                  ? Math.min(childTarget.zoom, maxAllowedZoom)
+                  ? Math.min(childTarget.zoom, childZoomLimit)
                   : NaN;
                 finalZoom = Number.isFinite(childZoom) ? childZoom : safeCurrentZoom;
                 if(finalZoom < safeCurrentZoom){


### PR DESCRIPTION
## Summary
- refine balloon cluster drilldown to continue zooming until child clusters become visible
- ensure clusters without children zoom the map to level 9 while respecting the map's maximum zoom

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e55da973e88331876ae1e16c68d091