### PR TITLE
Rename map card components and align overlay markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   </style>
 
   <style>
-    .map-card{
+    .big-map-card{
       position: relative;
       width: 225px;
       height: 60px;
@@ -66,7 +66,7 @@
       z-index: 5;
       will-change: transform;
     }
-    .mapmarker-overlay > .map-card{
+    .mapmarker-overlay > .big-map-card{
       position: absolute;
       left: 0;
       top: 0;
@@ -74,7 +74,7 @@
       pointer-events: auto;
       z-index: 30;
     }
-    .mapmarker-overlay.is-card-visible > .mapmarker-container{
+    .mapmarker-overlay.is-card-visible > .small-map-card{
       opacity: 0;
       visibility: hidden;
     }
@@ -82,8 +82,8 @@
       pointer-events: auto;
       z-index: 20000;
     }
-    .map-card img,
-    .mapmarker-container img{ display:block; }
+    .big-map-card img,
+    .small-map-card img{ display:block; }
     .map-card-pill{
       position: absolute;
       inset: auto;
@@ -98,13 +98,13 @@
       mix-blend-mode: normal;
       z-index: 0;
     }
-    .mapmarker-container{
+    .small-map-card{
       position: absolute;
       left: 0;
       top: 0;
       width: 150px;
       height: 40px;
-      transform: translate(-50%, -50%);
+      transform: translate(-20px, -20px);
       pointer-events: none;
       border-radius: 999px;
       background: rgba(0, 0, 0, 0.9);
@@ -143,21 +143,21 @@
       mix-blend-mode: normal;
       z-index: 0;
     }
-    .map-card--popup{
+    .big-map-card--popup{
       background-color: rgba(0, 0, 0, 0.88);
       transition: background-color 0.2s ease;
     }
-    .map-card--popup.is-map-highlight,
-    .mapmarker-overlay:hover .map-card--popup{
+    .big-map-card--popup.is-map-highlight,
+    .mapmarker-overlay:hover .big-map-card--popup{
       background-color: #2e3a72;
     }
     .open-post .post-header.is-map-highlight{
       background-color: #2e3a72;
     }
-    .mapmarker-container.is-pill-highlight{
+    .small-map-card.is-pill-highlight{
       background-color: #2e3a72;
     }
-    .mapmarker-overlay:hover .mapmarker-container{
+    .mapmarker-overlay:hover .small-map-card{
       background-color: #2e3a72;
     }
     .map-card-thumb{
@@ -280,7 +280,7 @@
       margin-top: 0;
       color: #d0d0d0;
     }
-    .map-card--list{
+    .big-map-card--list{
       position: relative;
       width: 100%;
       height: auto;
@@ -292,7 +292,7 @@
       border-radius: 0;
       box-shadow: none;
     }
-    .map-card--list .map-card-thumb{
+    .big-map-card--list .map-card-thumb{
       position: static;
       width: 64px;
       height: 64px;
@@ -300,7 +300,7 @@
       box-shadow: none;
       flex: 0 0 64px;
     }
-    .map-card--list .map-card-label{
+    .big-map-card--list .map-card-label{
       position: static;
       width: auto;
       height: auto;
@@ -308,13 +308,13 @@
       gap: 4px;
       text-shadow: none;
     }
-    .map-card--list .map-card-title{
+    .big-map-card--list .map-card-title{
       white-space: normal;
     }
-    .map-card--list .map-card-title-line{
+    .big-map-card--list .map-card-title-line{
       white-space: normal;
     }
-    .map-card--list .map-card-venue{
+    .big-map-card--list .map-card-venue{
       white-space: nowrap;
     }
   </style>
@@ -4715,12 +4715,12 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   z-index:-1;
 }
 
-.map-card--popup,
-.map-card--list{
+.big-map-card--popup,
+.big-map-card--list{
   pointer-events: auto;
   cursor: pointer;
 }
-.map-card--popup{
+.big-map-card--popup{
   display: block;
 }
 
@@ -4755,7 +4755,7 @@ body.open-post-sticky-images .open-post.desc-expanded .post-images{
   overflow:hidden;
 }
 
-.mapboxgl-popup.map-card .mapboxgl-popup-content{
+.mapboxgl-popup.big-map-card .mapboxgl-popup-content{
   overflow: visible;
 }
 
@@ -7329,12 +7329,12 @@ if (typeof slugify !== 'function') {
           delete el.dataset.prevAriaSelected;
         }
       };
-      document.querySelectorAll(`.post-card.${highlightClass}, .open-post .post-header.${highlightClass}, .map-card.${highlightClass}`).forEach(el => {
+      document.querySelectorAll(`.post-card.${highlightClass}, .open-post .post-header.${highlightClass}, .big-map-card.${highlightClass}`).forEach(el => {
         el.classList.remove(highlightClass);
         restoreAttr(el);
         restoreHighlightBackground(el);
       });
-      document.querySelectorAll(`.mapmarker-container.${markerHighlightClass}`).forEach(el => {
+      document.querySelectorAll(`.small-map-card.${markerHighlightClass}`).forEach(el => {
         el.classList.remove(markerHighlightClass);
       });
 
@@ -7387,10 +7387,10 @@ if (typeof slugify !== 'function') {
           if(normalizedVenue && overlayKey && overlayKey !== normalizedVenue){
             return;
           }
-          overlay.querySelectorAll('.mapmarker-container').forEach(el => {
+          overlay.querySelectorAll('.small-map-card').forEach(el => {
             el.classList.add(markerHighlightClass);
           });
-          overlay.querySelectorAll('.map-card').forEach(el => {
+          overlay.querySelectorAll('.big-map-card').forEach(el => {
             el.classList.add(highlightClass);
           });
         });
@@ -9540,11 +9540,11 @@ function makePosts(){
           labelClasses.push('map-card-label--single-line');
         }
         const labelHtml = `<div class="${labelClasses.join(' ')}"><div class="map-card-title">${titleHtml}</div>${venueHtml}</div>`;
-        const classes = ['map-card'];
+        const classes = ['big-map-card'];
         const extraClasses = Array.isArray(opts.extraClasses) ? opts.extraClasses : (opts.extraClass ? [opts.extraClass] : []);
         const variant = opts.variant || 'popup';
-        if(variant === 'popup') classes.push('map-card--popup');
-        if(variant === 'list') classes.push('map-card--list');
+        if(variant === 'popup') classes.push('big-map-card--popup');
+        if(variant === 'list') classes.push('big-map-card--list');
         extraClasses.filter(Boolean).forEach(cls => classes.push(cls));
         if(variant === 'list'){
           return `<div class="${classes.join(' ')}" data-id="${p.id}"><img class="map-card-thumb" src="${imgThumb(p)}" alt="" referrerpolicy="no-referrer" />${labelHtml}</div>`;
@@ -10776,7 +10776,7 @@ function makePosts(){
           }
         }
         $$('.recents-card[aria-selected="true"], .post-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
-        $$('.mapboxgl-popup.map-card .map-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
+        $$('.mapboxgl-popup.big-map-card .big-map-card[aria-selected="true"]').forEach(el=>el.removeAttribute('aria-selected'));
 
         const container = fromHistory ? document.getElementById('recentsBoard') : postsWideEl;
         if(!container) return;
@@ -10888,7 +10888,7 @@ function makePosts(){
             }
           }
         }
-        const mapCard = document.querySelector('.mapboxgl-popup.map-card .map-card');
+        const mapCard = document.querySelector('.mapboxgl-popup.big-map-card .big-map-card');
         if(mapCard) mapCard.setAttribute('aria-selected','true');
 
         const detail = buildDetail(p);
@@ -12134,7 +12134,7 @@ if (!map.__pillHooksInstalled) {
             overlayRoot.style.userSelect = 'none';
 
             const markerContainer = document.createElement('div');
-            markerContainer.className = 'mapmarker-container';
+            markerContainer.className = 'small-map-card';
             markerContainer.dataset.id = overlayRoot.dataset.id;
             markerContainer.setAttribute('aria-hidden', 'true');
             markerContainer.style.pointerEvents = 'none';
@@ -12190,7 +12190,7 @@ if (!map.__pillHooksInstalled) {
             markerContainer.append(markerPill, markerIcon, markerLabel);
 
             const cardRoot = document.createElement('div');
-            cardRoot.className = 'map-card map-card--popup';
+            cardRoot.className = 'big-map-card big-map-card--popup';
             cardRoot.dataset.id = overlayRoot.dataset.id;
             cardRoot.setAttribute('aria-hidden', 'true');
             cardRoot.style.pointerEvents = 'auto';
@@ -12888,7 +12888,7 @@ function openPostModal(id){
     });
 
     document.addEventListener('click', (ev)=>{
-      const card = ev.target.closest('.mapboxgl-popup.map-card .map-card');
+      const card = ev.target.closest('.mapboxgl-popup.big-map-card .big-map-card');
       if(card){
         ev.preventDefault();
         const pid = card.getAttribute('data-id') || (card.closest('.map-card-list-item') && card.closest('.map-card-list-item').getAttribute('data-id'));
@@ -14639,7 +14639,7 @@ document.addEventListener('pointerdown', (e) => {
     {key:'list', label:'List', selectors:{bg:['.quick-list-board'], text:['.quick-list-board'], title:['.quick-list-board .recents-card .t','.quick-list-board .recents-card .title'], btn:['.quick-list-board button','.quick-list-board .sq','.quick-list-board .tiny','.quick-list-board .btn'], btnText:['.quick-list-board button','.quick-list-board .sq','.quick-list-board .tiny','.quick-list-board .btn'], card:['.quick-list-board .recents-card']}},
     {key:'post-board', label:'Closed Posts', selectors:{bg:['.post-board'], text:['.post-board','.post-board .posts'], title:['.post-board .post-card .t','.post-board .post-card .title','.post-board .open-post .t','.post-board .open-post .title'], btn:['.post-board button'], btnText:['.post-board button'], card:['.post-board .post-card','.post-board .open-post']}},
     {key:'open-post', label:'Open Posts', selectors:{text:['.open-post','.open-post .venue-info','.open-post .session-info'], title:['.open-post .t','.open-post .title'], btn:['.open-post button'], btnText:['.open-post button'], card:['.open-post'], header:['.open-post .post-header'], image:['.open-post .image-box'], menu:['.open-post .venue-menu button','.open-post .session-menu button']}},
-    {key:'map', label:'Map', selectors:{popupBg:['.mapboxgl-popup.map-card .mapboxgl-popup-content','.mapboxgl-popup.map-card .map-card','.mapboxgl-popup.map-card .chip','.mapboxgl-popup.map-card .chip-small','.mapboxgl-popup.map-card .map-card-list-item'], popupText:['.mapboxgl-popup.map-card .map-card','.mapboxgl-popup.map-card .map-card-title','.mapboxgl-popup.map-card .map-card-venue','.mapboxgl-popup.map-card .chip','.mapboxgl-popup.map-card .chip-small','.mapboxgl-popup.map-card .map-card-list-item'], title:['.mapboxgl-popup.map-card .map-card-title','.mapboxgl-popup.map-card .chip .t','.mapboxgl-popup.map-card .chip .title','.mapboxgl-popup.map-card .chip-small .t','.mapboxgl-popup.map-card .chip-small .title']}},
+    {key:'map', label:'Map', selectors:{popupBg:['.mapboxgl-popup.big-map-card .mapboxgl-popup-content','.mapboxgl-popup.big-map-card .big-map-card','.mapboxgl-popup.big-map-card .chip','.mapboxgl-popup.big-map-card .chip-small','.mapboxgl-popup.big-map-card .map-card-list-item'], popupText:['.mapboxgl-popup.big-map-card .big-map-card','.mapboxgl-popup.big-map-card .map-card-title','.mapboxgl-popup.big-map-card .map-card-venue','.mapboxgl-popup.big-map-card .chip','.mapboxgl-popup.big-map-card .chip-small','.mapboxgl-popup.big-map-card .map-card-list-item'], title:['.mapboxgl-popup.big-map-card .map-card-title','.mapboxgl-popup.big-map-card .chip .t','.mapboxgl-popup.big-map-card .chip .title','.mapboxgl-popup.big-map-card .chip-small .t','.mapboxgl-popup.big-map-card .chip-small .title']}},
     {key:'filter', label:'Filter Panel', selectors:{bg:['#filterPanel .panel-content'], text:['#filterPanel .panel-content'], title:['#filterPanel .panel-content .t','#filterPanel .panel-content .title'], btn:['#filterPanel button:not([class*="mapboxgl-"])','#filterPanel .sq','#filterPanel .tiny'], btnText:['#filterPanel button:not([class*="mapboxgl-"])','#filterPanel .sq','#filterPanel .tiny']}},
     {key:'calendar', label:'Calendar', selectors:{bg:['.calendar'], text:['.calendar .day'], weekday:['.calendar .weekday'], title:['.calendar .calendar-header'], header:['.calendar .calendar-header']}},
   {key:'adminPanel', label:'Admin Panel', selectors:{bg:['#adminPanel .panel-content'], text:['#adminPanel .panel-content'], title:['#adminPanel .panel-content .t','#adminPanel .panel-content .title'], btn:['#adminPanel button','#adminPanel #spinType span'], btnText:['#adminPanel button','#adminPanel #spinType span']}},


### PR DESCRIPTION
## Summary
- rename the map card UI classes to the new big-map-card and small-map-card names across styles and scripts
- align the marker overlay transforms so the big card thumbnail and small card marker centers coincide and keep highlight logic up to date

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e55fa644748331a4904381539cade9