### PR TITLE
Adjust map control width responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -3131,7 +3131,7 @@ body.filters-active #filterBtn{
   flex:1 1 240px;
   min-width:0;
   width:100%;
-  max-width:360px;
+  max-width:100%;
   display:flex;
 }
 #filterPanel .map-control-row .geocoder,
@@ -3311,7 +3311,7 @@ body.filters-active #filterBtn{
   left:50%;
   top:calc(var(--header-h) + 10px);
   transform:translateX(-50%);
-  width:auto;
+  width:100%;
   max-width:600px;
   min-width:0;
   z-index:1;


### PR DESCRIPTION
## Summary
- allow the map control row geocoder to grow with its container by removing the 360px cap
- let the map control row expand fluidly while remaining centred with a 600px maximum width

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5883f8ab88331b9a0e3c2940734f8