### PR TITLE
Prevent overscrolling at gallery edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -13199,7 +13199,7 @@ function openPostModal(id){
           const width = imageBox.clientWidth || 1;
           let adjustedDelta = deltaX;
           if((currentIdx === 0 && adjustedDelta > 0) || (currentIdx === imgs.length-1 && adjustedDelta < 0)){
-            adjustedDelta *= 0.3;
+            adjustedDelta = 0;
           }
           const deltaPercent = (adjustedDelta / width) * 100;
           const basePercent = -currentIdx * 100;


### PR DESCRIPTION
## Summary
- stop the touch drag handler from moving past the first or last image to avoid blank areas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e594d1035c8331966f6f5831f16c6a