### PR TITLE
Fix small marker overlay lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5877,7 +5877,14 @@ if (typeof slugify !== 'function') {
       if(postId === undefined || postId === null){
         return;
       }
-      const post = posts.find(item => item && String(item.id) === String(postId));
+      let post = posts.find(item => item && String(item.id) === String(postId));
+      if(!post){
+        try{
+          post = getPostByIdAnywhere(postId);
+        }catch(err){
+          post = null;
+        }
+      }
       if(!post){
         return;
       }


### PR DESCRIPTION
## Summary
- fall back to the cached post lookup when rebuilding small marker overlays so markers still render even if the local post list misses an id

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5ad571c548331bec961800c746379