### PR TITLE
Ensure small map card pills update on hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -7321,6 +7321,28 @@ if (typeof slugify !== 'function') {
       }, delay);
     }
 
+    const SMALL_MAP_CARD_PILL_DEFAULT_SRC = 'assets/icons-30/150x40-pill-70.webp';
+    const SMALL_MAP_CARD_PILL_HOVER_SRC = 'assets/icons-30/150x40-pill-#2f3b73.webp';
+
+    function setSmallMapCardPillImage(cardEl, highlighted){
+      if(!cardEl) return;
+      const pillImg = cardEl.querySelector('.mapmarker-pill');
+      if(!pillImg) return;
+      if(!pillImg.dataset.defaultSrc){
+        const currentSrc = pillImg.getAttribute('src') || '';
+        pillImg.dataset.defaultSrc = currentSrc || SMALL_MAP_CARD_PILL_DEFAULT_SRC;
+      }
+      if(!pillImg.dataset.highlightSrc){
+        pillImg.dataset.highlightSrc = SMALL_MAP_CARD_PILL_HOVER_SRC;
+      }
+      const targetSrc = highlighted
+        ? (pillImg.dataset.highlightSrc || SMALL_MAP_CARD_PILL_HOVER_SRC)
+        : (pillImg.dataset.defaultSrc || SMALL_MAP_CARD_PILL_DEFAULT_SRC);
+      if((pillImg.getAttribute('src') || '') !== targetSrc){
+        pillImg.setAttribute('src', targetSrc);
+      }
+    }
+
     function updateSelectedMarkerRing(){
       const highlightClass = 'is-map-highlight';
       const markerHighlightClass = 'is-pill-highlight';
@@ -7366,6 +7388,7 @@ if (typeof slugify !== 'function') {
         restoreHighlightBackground(el);
       });
       document.querySelectorAll(`.small-map-card.${markerHighlightClass}`).forEach(el => {
+        setSmallMapCardPillImage(el, false);
         el.classList.remove(markerHighlightClass);
       });
 
@@ -7425,6 +7448,7 @@ if (typeof slugify !== 'function') {
             return;
           }
           overlay.querySelectorAll('.small-map-card').forEach(el => {
+            setSmallMapCardPillImage(el, true);
             el.classList.add(markerHighlightClass);
           });
           overlay.querySelectorAll('.big-map-card').forEach(el => {
@@ -12210,6 +12234,8 @@ if (!map.__pillHooksInstalled) {
             try{ markerPill.decoding = 'async'; }catch(e){}
             markerPill.alt = '';
             markerPill.src = 'assets/icons-30/150x40-pill-70.webp';
+            markerPill.dataset.defaultSrc = 'assets/icons-30/150x40-pill-70.webp';
+            markerPill.dataset.highlightSrc = 'assets/icons-30/150x40-pill-#2f3b73.webp';
             markerPill.className = 'mapmarker-pill';
             markerPill.loading = 'eager';
             markerPill.style.opacity = '0.9';
@@ -12715,11 +12741,15 @@ if (!map.__pillHooksInstalled) {
                 cardEl.dataset.hoverPrevHighlight = cardEl.classList.contains(mapHighlightClass) ? '1' : '0';
               }
               cardEl.classList.add(mapHighlightClass);
+              setSmallMapCardPillImage(cardEl, true);
             } else if(Object.prototype.hasOwnProperty.call(cardEl.dataset, 'hoverPrevHighlight')){
               const prev = cardEl.dataset.hoverPrevHighlight === '1';
               delete cardEl.dataset.hoverPrevHighlight;
               if(!prev){
                 cardEl.classList.remove(mapHighlightClass);
+                setSmallMapCardPillImage(cardEl, false);
+              } else {
+                setSmallMapCardPillImage(cardEl, true);
               }
             }
           });


### PR DESCRIPTION
## Summary
- add reusable helper to manage small map card pill image swaps
- update marker overlay creation and hover logic to use the new highlight pill artwork

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5be38ba28833185cd4751debef41e