### PR TITLE
Ensure multi-venue markers use dedicated icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -7516,6 +7516,7 @@ if (typeof slugify !== 'function') {
 
     const SMALL_MAP_CARD_PILL_DEFAULT_SRC = 'assets/icons-30/150x40-pill-70.webp';
     const SMALL_MAP_CARD_PILL_HOVER_SRC = 'assets/icons-30/150x40-pill-2f3b73.webp';
+    const MULTI_POST_MARKER_ICON_ID = 'multi-post-icon';
     const SMALL_MULTI_MAP_CARD_ICON_SRC = 'assets/icons-30/multi-post-icon-30.webp';
 
     function registerOverlayCleanup(overlayEl, fn){
@@ -7843,6 +7844,7 @@ function mulberry32(a){ return function(){var t=a+=0x6D2B79F5; t=Math.imul(t^t>>
     const COLOR_NAMES = window.COLOR_NAMES = ['blue','dark-yellow','green','indigo','orange','red','violet'];
     const subcategoryIcons = window.subcategoryIcons = {};
     const subcategoryMarkers = window.subcategoryMarkers = {};
+    subcategoryMarkers[MULTI_POST_MARKER_ICON_ID] = SMALL_MULTI_MAP_CARD_ICON_SRC;
     const subcategoryMarkerIds = window.subcategoryMarkerIds = {};
     const categoryShapes = window.categoryShapes = {};
 
@@ -12276,6 +12278,7 @@ if (!map.__pillHooksInstalled) {
         if(!primary || !primary.post || !primary.entry) return null;
         const { post, entry } = primary;
         const baseSub = subcategoryMarkerIds[post.subcategory] || slugify(post.subcategory);
+        const multiIconId = MULTI_POST_MARKER_ICON_ID;
         const venueName = (() => {
           for(const item of group.entries){
             const candidate = item && item.entry && item.entry.loc && item.entry.loc.venue;
@@ -12288,7 +12291,7 @@ if (!map.__pillHooksInstalled) {
         const multiCountLabel = `${multiCount} posts here`;
         const multiVenueText = shortenMarkerLabelText(venueName, markerLabelTextAreaWidthPx);
         const combinedLabel = multiVenueText ? `${multiCountLabel}\n${multiVenueText}` : multiCountLabel;
-        const spriteSource = ['multi', baseSub || '', multiCountLabel, multiVenueText || ''].join('|');
+        const spriteSource = ['multi', multiIconId || '', baseSub || '', multiCountLabel, multiVenueText || ''].join('|');
         const labelSpriteId = hashString(spriteSource);
         const featureId = `venue:${group.key}::${post.id}`;
         const coordinates = [entry.lng, entry.lat];
@@ -12307,7 +12310,7 @@ if (!map.__pillHooksInstalled) {
             venueName,
             city: post.city,
             cat: post.category,
-            sub: baseSub,
+            sub: multiIconId,
             baseSub,
             venueKey: group.key,
             locationIndex: entry.index,


### PR DESCRIPTION
## Summary
- define a dedicated multi-post marker icon id and register its asset for map usage
- update grouped venue feature metadata to always reference the multi-post icon instead of inheriting a child post icon

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5f6efba148331a96c9728f7765e94